### PR TITLE
fix: remove wait for ready hack when getting a cache

### DIFF
--- a/integration/Momento.test.ts
+++ b/integration/Momento.test.ts
@@ -12,21 +12,19 @@ describe('Momento.ts Integration Tests', () => {
     const cacheName = v4();
     const momento = new Momento(AUTH_TOKEN);
     await momento.createCache(cacheName);
-    const cache = momento.getCache(cacheName, {defaultTtlSeconds: 10});
+    const cache = await momento.getCache(cacheName, {defaultTtlSeconds: 10});
     await cache.set('key', 'value');
     const res = await cache.get('key');
     expect(res.text()).toEqual('value');
-    // FIXME https://github.com/momentohq/cacheadmin-v2/issues/107
-    // await momento.deleteCache(cacheName);
+    await momento.deleteCache(cacheName);
   });
-  // FIXME https://github.com/momentohq/cacheadmin-v2/issues/107
-  // it('should throw CacheNotFoundError if deleting a non-existent cache', async () => {
-  //   const cacheName = v4();
-  //   const momento = new Momento(AUTH_TOKEN);
-  //   // await expect(momento.deleteCache(cacheName)).rejects.toThrow(
-  //   //   CacheNotFoundError
-  //   // );
-  // });
+  it('should throw CacheNotFoundError if deleting a non-existent cache', async () => {
+    const cacheName = v4();
+    const momento = new Momento(AUTH_TOKEN);
+    await expect(momento.deleteCache(cacheName)).rejects.toThrow(
+      CacheNotFoundError
+    );
+  });
   it('should throw CacheAlreadyExistsError if trying to create a cache that already exists', async () => {
     const cacheName = v4();
     const momento = new Momento(AUTH_TOKEN);
@@ -34,7 +32,6 @@ describe('Momento.ts Integration Tests', () => {
     await expect(momento.createCache(cacheName)).rejects.toThrow(
       CacheAlreadyExistsError
     );
-    // FIXME https://github.com/momentohq/cacheadmin-v2/issues/107
-    // await momento.deleteCache(cacheName);
+    await momento.deleteCache(cacheName);
   });
 });

--- a/src/Momento.ts
+++ b/src/Momento.ts
@@ -58,14 +58,19 @@ export class Momento {
    * @param {CacheProps} props
    * @returns MomentoCache
    */
-  public getCache(name: string, props: CacheProps): MomentoCache {
+  public async getCache(
+    name: string,
+    props: CacheProps
+  ): Promise<MomentoCache> {
     this.validateCacheName(name);
-    return new MomentoCache({
+    const cache = new MomentoCache({
       authToken: this.authToken,
       cacheName: name,
       endpoint: this.cacheEndpoint,
       defaultTtlSeconds: props.defaultTtlSeconds,
     });
+    await cache.connect();
+    return cache;
   }
 
   /**

--- a/src/MomentoCache.ts
+++ b/src/MomentoCache.ts
@@ -9,12 +9,6 @@ import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
 import {GetResponse} from './messages/GetResponse';
 import {SetResponse} from './messages/SetResponse';
 
-const delay = (millis: number): Promise<void> => {
-  return new Promise<void>(resolve => {
-    setTimeout(() => resolve(), millis);
-  });
-};
-
 /**
  * @property {string} authToken - momento jwt token
  * @property {string} cacheName - name of the cache to perform gets and sets against
@@ -57,6 +51,15 @@ export class MomentoCache {
       },
     ];
     this.interceptors = [addHeadersInterceptor(headers)];
+  }
+
+  /**
+   * connects the cache to the backend
+   */
+  public async connect() {
+    // don't care what the response is, just want to make sure we can
+    // connect successfully
+    await this.get('000000');
   }
 
   /**

--- a/test/Momento.test.ts
+++ b/test/Momento.test.ts
@@ -17,9 +17,9 @@ describe('Momento.ts', () => {
       await expect(momento.createCache(name)).rejects.toThrow(
         InvalidArgumentError
       );
-      expect(() => momento.getCache(name, {defaultTtlSeconds: 10})).toThrow(
-        InvalidArgumentError
-      );
+      await expect(
+        momento.getCache(name, {defaultTtlSeconds: 10})
+      ).rejects.toThrow(InvalidArgumentError);
     }
   });
 });


### PR DESCRIPTION
This commit removes the temporary `waitForCacheReady` function, to make sure mr2 loads the cache before the user tries to perform a get or set. Since v2 has been deployed, this is no longer needed