### PR TITLE
chore: update SDK to consume new versions of protos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "1.3.7",
-        "@momento/wire-types-javascript": "0.7.1",
+        "@momento/wire-types-javascript": "0.8.0",
         "jwt-decode": "3.1.2",
         "toml": "^3.0.0"
       },
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@momento/wire-types-javascript": {
-      "version": "0.7.1",
-      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/wire-types-javascript/-/@momento/wire-types-javascript-0.7.1.tgz",
-      "integrity": "sha512-DjOCWnwkzrA3oBzjztM7fMb395JQUPqdfSlLT/lFa77OrMmnXUObU0mxApSISjP508yOW/g3PKBvVFbcrz+SvQ==",
+      "version": "0.8.0",
+      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/wire-types-javascript/-/@momento/wire-types-javascript-0.8.0.tgz",
+      "integrity": "sha512-TyHacL/FwaHi6fKO7zCi7Qs/cxsz34XiH538cV5QMhwLa2wcaBbF1Mdam6JIt0l2cM5c6FQnrdwN+MxP+BzHyQ==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "1.3.7",
@@ -7126,9 +7126,9 @@
       }
     },
     "@momento/wire-types-javascript": {
-      "version": "0.7.1",
-      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/wire-types-javascript/-/@momento/wire-types-javascript-0.7.1.tgz",
-      "integrity": "sha512-DjOCWnwkzrA3oBzjztM7fMb395JQUPqdfSlLT/lFa77OrMmnXUObU0mxApSISjP508yOW/g3PKBvVFbcrz+SvQ==",
+      "version": "0.8.0",
+      "resolved": "https://momento.jfrog.io/artifactory/api/npm/npm-public/@momento/wire-types-javascript/-/@momento/wire-types-javascript-0.8.0.tgz",
+      "integrity": "sha512-TyHacL/FwaHi6fKO7zCi7Qs/cxsz34XiH538cV5QMhwLa2wcaBbF1Mdam6JIt0l2cM5c6FQnrdwN+MxP+BzHyQ==",
       "requires": {
         "@grpc/grpc-js": "1.3.7",
         "@types/google-protobuf": "3.15.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.3.7",
-    "@momento/wire-types-javascript": "0.7.1",
+    "@momento/wire-types-javascript": "0.8.0",
     "jwt-decode": "3.1.2",
     "toml": "^3.0.0"
   },

--- a/src/Momento.ts
+++ b/src/Momento.ts
@@ -45,7 +45,7 @@ export class Momento {
 
   public async createCache(name: string): Promise<CreateCacheResponse> {
     this.validateCacheName(name);
-    const request = new control.control_client.CreateCacheRequest({
+    const request = new control.control_client._CreateCacheRequest({
       cache_name: name,
     });
     return await new Promise<CreateCacheResponse>((resolve, reject) => {
@@ -73,7 +73,7 @@ export class Momento {
   }
 
   public async deleteCache(name: string): Promise<DeleteCacheResponse> {
-    const request = new control.control_client.DeleteCacheRequest({
+    const request = new control.control_client._DeleteCacheRequest({
       cache_name: name,
     });
     return await new Promise<DeleteCacheResponse>((resolve, reject) => {
@@ -99,7 +99,7 @@ export class Momento {
   }
 
   public async listCaches(nextToken?: string): Promise<ListCachesResponse> {
-    const request = new control.control_client.ListCachesRequest();
+    const request = new control.control_client._ListCachesRequest();
     request.next_token = nextToken ?? '';
     return await new Promise<ListCachesResponse>((resolve, reject) => {
       this.client.ListCaches(

--- a/src/MomentoCache.ts
+++ b/src/MomentoCache.ts
@@ -79,7 +79,7 @@ export class MomentoCache {
     value: Uint8Array,
     ttl: number
   ): Promise<SetResponse> {
-    const request = new cache.cache_client.SetRequest({
+    const request = new cache.cache_client._SetRequest({
       cache_body: value,
       cache_key: key,
       ttl_milliseconds: ttl * 1000,
@@ -113,7 +113,7 @@ export class MomentoCache {
     cacheName: string,
     key: Uint8Array
   ): Promise<GetResponse> {
-    const request = new cache.cache_client.GetRequest({
+    const request = new cache.cache_client._GetRequest({
       cache_key: key,
     });
 
@@ -142,14 +142,14 @@ export class MomentoCache {
   }
 
   private parseGetResponse = (
-    resp: cache.cache_client.GetResponse
+    resp: cache.cache_client._GetResponse
   ): GetResponse => {
     const momentoResult = momentoResultConverter(resp.result);
     return new GetResponse(momentoResult, resp.message, resp.cache_body);
   };
 
   private parseSetResponse = (
-    resp: cache.cache_client.SetResponse,
+    resp: cache.cache_client._SetResponse,
     value: Uint8Array
   ): SetResponse => {
     return new SetResponse(resp.message, value);

--- a/src/messages/ListCachesResponse.ts
+++ b/src/messages/ListCachesResponse.ts
@@ -5,7 +5,7 @@ export class ListCachesResponse {
   private readonly nextToken: string | null;
   private readonly caches: CacheInfo[];
 
-  constructor(result?: control.control_client.ListCachesResponse) {
+  constructor(result?: control.control_client._ListCachesResponse) {
     this.nextToken = result?.next_token || null;
     this.caches = [];
     result?.cache.forEach(cache =>


### PR DESCRIPTION
Resolves https://github.com/momentohq/client-sdk-javascript/issues/35

Some of our protos now have `_` prefixed (e.g. `_ListCachesResponse`). Updates the SDK to consume the new version in `package.json` and update the types as necessary.
