### PR TITLE
fix: copy down package.json into dist during publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,5 +52,6 @@ jobs:
           echo "Publishing package with version $VERSION"
           mv package.json package.json.ORIG
           cat package.json.ORIG|jq ". += {\"version\": \"$VERSION\"}" > package.json
+          cp package.json dist/package.json
           npm publish
         shell: bash


### PR DESCRIPTION
We currently read our package.json file in programmatically to obtain sdk version. This commit copies down package.json into dist folder during publish so code can access it in a consistent way.

Loosely following advice off [this](https://stackoverflow.com/questions/38858718/npm-script-copy-package-json-to-dist-when-bundling) SO post. Feels like there should be cleaner way to do this like we do in python for example with `pkg_resources.get_distribution("momento").version` but javascript ecosystem does not seem to have a very consistent strategy for doing this.