### PR TITLE
fix: try different way including package.json in published bundle

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,6 @@ jobs:
           echo "Publishing package with version $VERSION"
           mv package.json package.json.ORIG
           cat package.json.ORIG|jq ". += {\"version\": \"$VERSION\"}" > package.json
-          cp package.json dist/package.json
           npm publish
         shell: bash
         env:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Client SDK for Momento services",
   "main": "dist/src/index.js",
   "files": [
-    "dist/src"
+    "dist/src",
+    "dist/package.json"
   ],
   "types": "dist/src/index.d.ts",
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     "typeRoots": ["./node_modules/@types"],
     "resolveJsonModule": true
   },
-  "include": ["src/", "test/", "integration/", "package.json"],
+  "include": ["src/", "test/", "integration/"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Still having issues with package json after last fix. Was able to verify this locally w/ 
```
npm run build
npm pack
```

I believe it should work on publish now and copy step added previously might not actually be needed.
```
✗ npm pack
npm notice
npm notice 📦  @gomomento/sdk@0.0.1
npm notice === Tarball Contents ===
npm notice 11.4kB LICENSE
npm notice 1.9kB  README.md
npm notice 1.6kB  dist/package.json   ## <--- Can see now!!!
npm notice 186B   dist/src/CacheServiceErrorMapper.d.ts
npm notice 6.7kB  dist/src/CacheServiceErrorMapper.js
npm notice 3.0kB  dist/src/Errors.d.ts
npm notice 13.1kB dist/src/Errors.js
...
```