### PR TITLE
fix: [CVE-2022-25878] - Prototype Pollution in protobufjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5385,9 +5385,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -10582,9 +10582,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
Fixes [[CVE-2022-25878]](https://github.com/advisories/GHSA-g954-5hwp-pp24)

`npm audit` output prior to fix

```
$ npm audit
# npm audit report

protobufjs  6.11.0 - 6.11.2
Severity: high
Prototype Pollution in protobufjs - https://github.com/advisories/GHSA-g954-5hwp-pp24
fix available via `npm audit fix`
node_modules/protobufjs

1 high severity vulnerability

To address all issues, run:
  npm audit fix
```

`npm audit` output after fix
```
$ npm audit
found 0 vulnerabilities
```