### PR TITLE
fix: memory issues for retries; improvements to logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2427,9 +2427,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.181",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.181.tgz",
-      "integrity": "sha512-T6JzLj+9J6CdPgI7jXLcq5Ao2qyFhEBfWFUExxRRVFdVYAU86SfcLX3Zw6p1HzvngR+M8C4q6eDkQ5flEr1RnA==",
+      "version": "1.4.183",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.183.tgz",
+      "integrity": "sha512-PnJvlREshGPh3M5tgReLgqbOQ61yd4Knwo39Cxy9SMfqwX9q5iRy+JioQC1LyKx1IBAH2zoctAWblhgM2kbEKQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8776,9 +8776,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.181",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.181.tgz",
-      "integrity": "sha512-T6JzLj+9J6CdPgI7jXLcq5Ao2qyFhEBfWFUExxRRVFdVYAU86SfcLX3Zw6p1HzvngR+M8C4q6eDkQ5flEr1RnA==",
+      "version": "1.4.183",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.183.tgz",
+      "integrity": "sha512-PnJvlREshGPh3M5tgReLgqbOQ61yd4Knwo39Cxy9SMfqwX9q5iRy+JioQC1LyKx1IBAH2zoctAWblhgM2kbEKQ==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/momentohq/client-sdk-javascript"
   },
   "scripts": {
+    "prebuild": "eslint . --ext .ts",
     "test": "jest",
     "integration": "jest --config jest-integration.config.js",
     "lint": "eslint . --ext .ts",

--- a/src/Momento.ts
+++ b/src/Momento.ts
@@ -16,7 +16,10 @@ import {version} from '../package.json';
 import {CreateSigningKeyResponse} from './messages/CreateSigningKeyResponse';
 import {RevokeSigningKeyResponse} from './messages/RevokeSigningKeyResponse';
 import {ListSigningKeysResponse} from './messages/ListSigningKeysResponse';
-import {createRetryInterceptorIfEnabled, RetryInterceptor} from './grpc/RetryInterceptor';
+import {
+  createRetryInterceptorIfEnabled,
+  RetryInterceptor,
+} from './grpc/RetryInterceptor';
 import {getLogger, Logger, LoggerOptions} from './utils/logging';
 
 export interface MomentoProps {
@@ -45,7 +48,7 @@ export class Momento {
       ClientTimeoutInterceptor(Momento.REQUEST_TIMEOUT_MS),
       ...createRetryInterceptorIfEnabled({
         loggerOptions: props.loggerOptions,
-      })
+      }),
     ];
     this.logger.debug(
       `Creating control client using endpoint: '${props.endpoint}`

--- a/src/MomentoCache.ts
+++ b/src/MomentoCache.ts
@@ -73,9 +73,8 @@ export class MomentoCache {
       ClientTimeoutInterceptor(this.requestTimeoutMs),
       ...createRetryInterceptorIfEnabled({
         loggerOptions: this.loggerOptions,
-      })
+      }),
     ];
-
   }
 
   public getEndpoint(): string {
@@ -100,9 +99,9 @@ export class MomentoCache {
   ): Promise<SetResponse> {
     this.ensureValidSetRequest(key, value, ttl || this.defaultTtlSeconds);
     this.logger.trace(
-      `Issuing 'set' request; key: ${key.toString()}, value length: ${value.length}, ttl: ${
-        ttl?.toString() ?? 'null'
-      }`
+      `Issuing 'set' request; key: ${key.toString()}, value length: ${
+        value.length
+      }, ttl: ${ttl?.toString() ?? 'null'}`
     );
     const encodedKey = this.convert(key);
     const encodedValue = this.convert(value);
@@ -248,7 +247,7 @@ export class MomentoCache {
     ];
     return [
       new HeaderInterceptor(headers).addHeadersInterceptor(),
-      ...this.allInterceptorsExceptHeaderInterceptor
+      ...this.allInterceptorsExceptHeaderInterceptor,
     ];
   }
 

--- a/src/SimpleCacheClient.ts
+++ b/src/SimpleCacheClient.ts
@@ -54,7 +54,7 @@ export class SimpleCacheClient {
     defaultTtlSeconds: number,
     options?: SimpleCacheClientOptions
   ) {
-    this.logger = getLogger(this.constructor.name, options?.loggerOptions);
+    this.logger = getLogger(this, options?.loggerOptions);
     const claims = decodeJwt(authToken);
     const controlEndpoint = claims.cp;
     const dataEndpoint = claims.c;

--- a/src/grpc/RetryInterceptor.ts
+++ b/src/grpc/RetryInterceptor.ts
@@ -50,7 +50,9 @@ export interface RetryInterceptorOptions {
 // variable to enable/disable it.
 const RETRIES_ENABLED = true;
 
-export function createRetryInterceptorIfEnabled(options: RetryInterceptorOptions): Array<Interceptor> {
+export function createRetryInterceptorIfEnabled(
+  options: RetryInterceptorOptions
+): Array<Interceptor> {
   if (RETRIES_ENABLED) {
     return [new RetryInterceptor(options).createRetryInterceptor()];
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {SimpleCacheClient} from './SimpleCacheClient';
 import {GetResponse} from './messages/GetResponse';
 import {SetResponse} from './messages/SetResponse';
 import {CacheGetStatus} from './messages/Result';
+import {CacheInfo} from './messages/CacheInfo';
 import {
   AlreadyExistsError,
   AuthenticationError,
@@ -18,13 +19,14 @@ import {
   NotFoundError,
 } from './Errors';
 
-export {LogLevel, LogFormat} from './utils/logging';
+export {Logger, LoggerOptions, LogLevel, LogFormat, getLogger} from './utils/logging';
 
 export {
   SimpleCacheClient,
   GetResponse,
   SetResponse,
   CacheGetStatus,
+  CacheInfo,
   AlreadyExistsError,
   AuthenticationError,
   CancelledError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,13 @@ import {
   NotFoundError,
 } from './Errors';
 
-export {Logger, LoggerOptions, LogLevel, LogFormat, getLogger} from './utils/logging';
+export {
+  Logger,
+  LoggerOptions,
+  LogLevel,
+  LogFormat,
+  getLogger,
+} from './utils/logging';
 
 export {
   SimpleCacheClient,

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -6,13 +6,19 @@ import {
 } from 'pino';
 
 export interface Logger {
+  error(msg: string): void;
+  warn(msg: string): void;
   info(msg: string): void;
   debug(msg: string): void;
+  trace(msg: string): void;
 }
 
 export enum LogLevel {
+  TRACE = 'trace',
   DEBUG = 'debug',
   INFO = 'info',
+  WARN = 'warn',
+  ERROR = 'error'
 }
 
 export enum LogFormat {
@@ -25,9 +31,12 @@ export interface LoggerOptions {
   format?: LogFormat;
 }
 
-export function getLogger(name: string, options?: LoggerOptions): Logger {
+export function getLogger(caller: string | any, options?: LoggerOptions): Logger {
   const loggerOptions = options ?? defaultLoggerOptions();
-  return new PinoLogger(name, loggerOptions);
+  const loggerName = ((typeof caller === 'string') || (caller instanceof String))
+    ? caller
+    : caller.constructor.name;
+  return new PinoLogger(loggerName, loggerOptions);
 }
 
 class PinoLogger implements Logger {
@@ -49,12 +58,24 @@ class PinoLogger implements Logger {
     });
   }
 
+  error(msg: string): void {
+    this._logger.error(msg);
+  }
+
+  warn(msg: string): void {
+    this._logger.warn(msg);
+  }
+
   info(msg: string): void {
     this._logger.info(msg);
   }
 
   debug(msg: string): void {
     this._logger.debug(msg);
+  }
+
+  trace(msg: string): void {
+    this._logger.trace(msg);
   }
 }
 
@@ -66,10 +87,17 @@ function defaultLoggerOptions(): LoggerOptions {
 
 function pinoLogLevelFromLogLevel(level: LogLevel): pino.LevelWithSilent {
   switch (level) {
+    case LogLevel.TRACE:
+      return 'trace';
     case LogLevel.DEBUG:
       return 'debug';
     case LogLevel.INFO:
       return 'info';
+    case LogLevel.WARN:
+      return 'warn';
+    case LogLevel.ERROR:
+      return 'error';
+
     default:
       throw new Error(`Unsupported log level: ${String(level)}`);
   }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -18,7 +18,7 @@ export enum LogLevel {
   DEBUG = 'debug',
   INFO = 'info',
   WARN = 'warn',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
 export enum LogFormat {
@@ -31,11 +31,17 @@ export interface LoggerOptions {
   format?: LogFormat;
 }
 
-export function getLogger(caller: string | any, options?: LoggerOptions): Logger {
+export function getLogger(
+  caller: string | any,
+  options?: LoggerOptions
+): Logger {
   const loggerOptions = options ?? defaultLoggerOptions();
-  const loggerName = ((typeof caller === 'string') || (caller instanceof String))
-    ? caller
-    : caller.constructor.name;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const loggerName: string =
+    typeof caller === 'string' || caller instanceof String
+      ? caller
+      : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        caller.constructor.name;
   return new PinoLogger(loggerName, loggerOptions);
 }
 


### PR DESCRIPTION
This commit fixes a memory issue that surfaced on the retry logic
under higher load.

It also adds a broader array of log levels for users to choose
from, and moves the noisiest log messages to `trace`.  In addition,
there are some places where we had been logging the cache value;
those are removed because for large cache values the log messages
were overwhelming.
