### PR TITLE
chore: modify github action to do releases from 'release' branch

### DIFF
--- a/.github/workflows/push-to-release-branch.yml
+++ b/.github/workflows/push-to-release-branch.yml
@@ -1,8 +1,8 @@
-name: CD
+name: Push to Release Branch
 
 on:
   push:
-    branches: [main]
+    branches: [release]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This commit changes the behavior so that we won't do a release to
npmjs on every commit to `main`.  We will be releasing from the
`release` branch from now on.  In a future commit we'll add
a manually-dispatched action to trigger a release, which will
involve doing a merge from `main` to `release` and then pushing
to `release` to trigger this action.

For more info see: https://www.notion.so/momentohq/Dev-Eco-Releases-Best-Practices-d3e94013e9d94d9baf255a1173cd1f36
