### PR TITLE
chore: add a workflow for triggering manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,20 @@
+name: Manual Release
+# Triggers a merge from main->release, which will then trigger a release
+# from the release branch.
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Merge main -> release
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: main
+          target_branch: release
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a manual workflow to start the release process.
The workflow does a merge from the `main` branch to the `release`
branch, which will then trigger the release via the push to the
`release` branch.
