### PR TITLE
fix: simplify interceptors, pass cache name as metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "rm -rf dist && tsc"
   },
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/google-protobuf": "^3.15.5",
     "@types/jest": "^27.0.2",


### PR DESCRIPTION
This commit is modeled after the way the python code is set up.
Instead of passing the cache name as a constructor arg to the
HeaderInterceptor (which forces us to construct a new instance
of that interceptor for each request), we now specify a metadata
object directly on the request that we construct and we set
the cache name there.  This simplifies some of the code because
now we can construct the list of interceptors once at initialization.
