### PR TITLE
fix: bug in debug logging

### DIFF
--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -398,7 +398,7 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
    * Configures the Momento client to timeout if a request exceeds this limit.
    * Momento client default is 5 seconds.
    */
-  requestTimeoutMs: 5 * 1000,
+  requestTimeoutMs: 15 * 1000,
   /**
    * Controls the size of the payload that will be used for the cache items in
    * the load test.  Smaller payloads will generally provide lower latencies than
@@ -412,7 +412,7 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
    * is more contention between the concurrent function calls, client-side latencies
    * may increase.
    */
-  numberOfConcurrentRequests: 50,
+  numberOfConcurrentRequests: 10,
   /**
    * Controls how long the load test will run.  We will execute this many operations
    * (1 cache 'set' followed immediately by 1 'get') across all of our concurrent

--- a/src/momento-cache.ts
+++ b/src/momento-cache.ts
@@ -77,7 +77,7 @@ export class MomentoCache {
   }
 
   private validateRequestTimeout(timeout?: number) {
-    this.logger.debug(`Request timeout: ${this.endpoint}`);
+    this.logger.debug(`Request timeout ms: ${String(timeout)}`);
     if (timeout && timeout <= 0) {
       throw new InvalidArgumentError(
         'request timeout must be greater than zero.'


### PR DESCRIPTION
Fixes seeing debug logs like this every time.
```bash
{"level":20,"time":1668709906140,"pid":78770,"name":"MomentoCache","msg":"Creating cache client using endpoint: 'cache.cell-ap-northeast-1-1.prod.a.momentohq.com'"}
{"level":20,"time":1668709906154,"pid":78770,"name":"MomentoCache","msg":"Request timeout: undefined"}
```

Also lowers concurrency since we made limits more aggressive for GA launch and ups timeout to be more inline for what we are defaulting in SDK.