### PR TITLE
fix: Introduce idle wrapper around gRPC clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gomomento/generated-types": "0.13.0",
         "@grpc/grpc-js": "1.5.10",
-        "jose": "^4.10.2",
+        "jose": "4.10.2",
         "jwt-decode": "3.1.2",
         "pino": "8.1.0",
         "pino-pretty": "8.1.0"

--- a/src/grpc/grpc-client-wrapper.ts
+++ b/src/grpc/grpc-client-wrapper.ts
@@ -1,0 +1,7 @@
+export interface CloseableGrpcClient {
+  close(): void;
+}
+
+export interface GrpcClientWrapper<T extends CloseableGrpcClient> {
+  getClient(): T;
+}

--- a/src/grpc/idle-grpc-client-wrapper.ts
+++ b/src/grpc/idle-grpc-client-wrapper.ts
@@ -1,0 +1,61 @@
+import {getLogger, Logger} from '../utils/logging';
+import {CloseableGrpcClient, GrpcClientWrapper} from './grpc-client-wrapper';
+
+// TODO: This should not be defined here, it should be part of the Configuration object when we
+// introduce that.
+const MAX_IDLE_MILLIS = 4 * 60 * 1_000; // 4 minutes.  We want to remain comfortably underneath the idle timeout for AWS NLB, which is 350s.
+
+export interface IdleGrpcClientWrapperProps<T extends CloseableGrpcClient> {
+  clientFactoryFn: () => T;
+}
+
+/**
+ * This wrapper allows us to ensure that a grpc client is not re-used if it has been idle
+ * for longer than a specified period of time.  This is important in some environments,
+ * such as AWS Lambda, where the runtime may be paused indefinitely between invocations.
+ * In such cases we have observed that while the runtime is suspended, the connection
+ * may have been closed by the server. (e.g., AWS NLB has an idle timeout of 350s:
+ * https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout )
+ * When the runtime resumes, it does not recognize that the connection has been closed,
+ * and it may continue to attempt to send bytes to it, resulting in client-side timeouts
+ * (DEADLINE_EXCEEDED).  Forcefully refreshing the client if it has been idle for too
+ * long will prevent this.
+ *
+ * NOTE: We can't rely on keepalive pings in this scenario, because the lambda runtime
+ * may be suspended in such a way that background tasks such as the keepalive pings
+ * will not be able to execute.
+ */
+export class IdleGrpcClientWrapper<T extends CloseableGrpcClient>
+  implements GrpcClientWrapper<T>
+{
+  private readonly logger: Logger;
+
+  private client: T;
+  private readonly clientFactoryFn: () => T;
+
+  private readonly maxIdleMillis: number;
+  private lastAccessTime: number;
+
+  constructor(props: IdleGrpcClientWrapperProps<T>) {
+    this.logger = getLogger(this);
+    this.clientFactoryFn = props.clientFactoryFn;
+    this.client = this.clientFactoryFn();
+    this.maxIdleMillis = MAX_IDLE_MILLIS;
+    this.lastAccessTime = Date.now();
+  }
+
+  getClient(): T {
+    this.logger.trace(
+      `Checking to see if client has been idle for more than ${this.maxIdleMillis} ms`
+    );
+    if (Date.now() - this.lastAccessTime > this.maxIdleMillis) {
+      this.logger.info(
+        `Client has been idle for more than ${this.maxIdleMillis} ms; reconnecting.`
+      );
+      this.client.close();
+      this.client = this.clientFactoryFn();
+    }
+    this.lastAccessTime = Date.now();
+    return this.client;
+  }
+}

--- a/src/momento-cache.ts
+++ b/src/momento-cache.ts
@@ -13,6 +13,8 @@ import {SetResponse} from './messages/SetResponse';
 import {version} from '../package.json';
 import {DeleteResponse} from './messages/DeleteResponse';
 import {getLogger, Logger} from './utils/logging';
+import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
+import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
 
 /**
  * @property {string} authToken - momento jwt token
@@ -28,7 +30,7 @@ type MomentoCacheProps = {
 };
 
 export class MomentoCache {
-  private readonly client: cache.cache_client.ScsClient;
+  private readonly clientWrapper: GrpcClientWrapper<cache.cache_client.ScsClient>;
   private readonly textEncoder: TextEncoder;
   private readonly defaultTtlSeconds: number;
   private readonly requestTimeoutMs: number;
@@ -47,21 +49,25 @@ export class MomentoCache {
     this.logger.debug(
       `Creating cache client using endpoint: '${props.endpoint}'`
     );
-    this.client = new cache.cache_client.ScsClient(
-      props.endpoint,
-      ChannelCredentials.createSsl(),
-      {
-        // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
-        // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
-        // This needs to be tunable: https://github.com/momentohq/dev-eco-issue-tracker/issues/85
-        'grpc-node.max_session_memory': 256,
-        // This flag controls whether channels use a shared global pool of subchannels, or whether
-        // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
-        // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
-        // than one grpc client.
-        'grpc.use_local_subchannel_pool': 1,
-      }
-    );
+    this.clientWrapper = new IdleGrpcClientWrapper({
+      clientFactoryFn: () =>
+        new cache.cache_client.ScsClient(
+          props.endpoint,
+          ChannelCredentials.createSsl(),
+          {
+            // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
+            // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
+            // This needs to be tunable: https://github.com/momentohq/dev-eco-issue-tracker/issues/85
+            'grpc-node.max_session_memory': 256,
+            // This flag controls whether channels use a shared global pool of subchannels, or whether
+            // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
+            // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
+            // than one grpc client.
+            'grpc.use_local_subchannel_pool': 1,
+          }
+        ),
+    });
+
     this.textEncoder = new TextEncoder();
     this.defaultTtlSeconds = props.defaultTtlSeconds;
     this.requestTimeoutMs =
@@ -121,7 +127,7 @@ export class MomentoCache {
     });
     const metadata = this.createMetadata(cacheName);
     return await new Promise((resolve, reject) => {
-      this.client.Set(
+      this.clientWrapper.getClient().Set(
         request,
         metadata,
         {
@@ -156,7 +162,7 @@ export class MomentoCache {
     });
     const metadata = this.createMetadata(cacheName);
     return await new Promise((resolve, reject) => {
-      this.client.Delete(
+      this.clientWrapper.getClient().Delete(
         request,
         metadata,
         {
@@ -194,7 +200,7 @@ export class MomentoCache {
     const metadata = this.createMetadata(cacheName);
 
     return await new Promise((resolve, reject) => {
-      this.client.Get(
+      this.clientWrapper.getClient().Get(
         request,
         metadata,
         {


### PR DESCRIPTION
In some environments such as AWS Lambda, it is possible for
a cache client to be instantiated and stored in a long-lived
(global) variable, which then may not be accessed for long
periods of time (e.g. between lambda invocations).

The lambda environment may suspend the runtime in such a way
that no code will be executing between invocations (i.e., no
keepalive pings).  If there are more than 5 minutes between
lambda invocations, then the server side of the cache client
(AWS NLB) will detect the connection as idle and close it.

On the next lambda invocation, the grpc-js library does not
recognize that the connection has been closed so it will
continue to try to send data to it, resulting in a client-side
timeout (DEADLINE_EXCEEDED).

In this commit we add a wrapper around the client that ensures
that if it has been idle for too long, we will explicitly
refresh it to make sure that the connection is usable before
we issue requests against it.
