### PR TITLE
feat: More load-gen example options.

### DIFF
--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -104,10 +104,13 @@ class BasicJavaScriptLoadGen {
 
     const delayMillisBetweenRequests =
       (1000.0 * this.numberOfConcurrentRequests) / this.maxRequestsPerSecond;
-    this.logger.info(`Limiting to ${this.maxRequestsPerSecond} tps`);
     this.logger.trace(
       `delayMillisBetweenRequests: ${delayMillisBetweenRequests}`
     );
+
+    this.logger.info(`Limiting to ${this.maxRequestsPerSecond} tps`);
+    this.logger.info(`Running ${this.numberOfConcurrentRequests} concurrent requests`)
+    this.logger.info(`Running for ${this.totalSecondsToRun} seconds`);
 
     const loadGenContext: BasicJavasScriptLoadGenContext = {
       startTime: process.hrtime(),

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -20,7 +20,7 @@ interface BasicJavaScriptLoadGenOptions {
   requestTimeoutMs: number;
   cacheItemPayloadBytes: number;
   numberOfConcurrentRequests: number;
-  printStatsEveryNMs: number;
+  showStatsIntervalSeconds: number;
   maxRequestsPerSecond: number;
   totalMsToRun: number;
 }
@@ -55,7 +55,7 @@ class BasicJavaScriptLoadGen {
   private readonly loggerOptions: LoggerOptions;
   private readonly requestTimeoutMs: number;
   private readonly numberOfConcurrentRequests: number;
-  private readonly printStatsEveryNMs: number;
+  private readonly showStatsIntervalSeconds: number;
   private readonly maxRequestsPerSecond: number;
   private readonly totalMsToRun: number;
   private readonly cacheValue: string;
@@ -75,7 +75,7 @@ class BasicJavaScriptLoadGen {
     this.authToken = authToken;
     this.requestTimeoutMs = options.requestTimeoutMs;
     this.numberOfConcurrentRequests = options.numberOfConcurrentRequests;
-    this.printStatsEveryNMs = options.printStatsEveryNMs;
+    this.showStatsIntervalSeconds = options.showStatsIntervalSeconds;
     this.maxRequestsPerSecond = options.maxRequestsPerSecond;
     this.totalMsToRun = options.totalMsToRun;
 
@@ -150,7 +150,7 @@ class BasicJavaScriptLoadGen {
     setTimeout(finish, totalMsToRun);
     const intervalId = setInterval(() => {
       this.logStats(loadGenContext);
-    }, this.printStatsEveryNMs);
+    }, this.showStatsIntervalSeconds * 1000);
 
     let i = 1;
     for (;;) {
@@ -425,9 +425,9 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
     format: LogFormat.CONSOLE,
   },
   /** Print some statistics about throughput and latency every time this many
-   *  milliseconds have passed. Default is 5 seconds.
+   *  seconds have passed. Default is 5 seconds.
    */
-  printStatsEveryNMs: 5 * 1000,
+  showStatsIntervalSeconds: 5,
   /**
    * Configures the Momento client to timeout if a request exceeds this limit.
    * Momento client default is 5 seconds.

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -107,9 +107,11 @@ class BasicJavaScriptLoadGen {
     const numOperationsPerWorker =
       this.totalNumberOfOperationsToExecute / this.numberOfConcurrentRequests;
     const delayMillisBetweenRequests =
-      1000.0 * this.numberOfConcurrentRequests / this.maxRequestsPerSecond;
+      (1000.0 * this.numberOfConcurrentRequests) / this.maxRequestsPerSecond;
     this.logger.info(`Limiting to ${this.maxRequestsPerSecond} tps`);
-    this.logger.debug(`delayMillisBetweenRequests: ${delayMillisBetweenRequests}`);
+    this.logger.debug(
+      `delayMillisBetweenRequests: ${delayMillisBetweenRequests}`
+    );
 
     const loadGenContext: BasicJavasScriptLoadGenContext = {
       startTime: process.hrtime(),
@@ -148,9 +150,18 @@ class BasicJavaScriptLoadGen {
     delayMillisBetweenRequests: number
   ): Promise<void> {
     for (let i = 1; i <= numOperations; i++) {
-      await this.issueAsyncSetGet(client, loadGenContext, workerId, i, delayMillisBetweenRequests);
+      await this.issueAsyncSetGet(
+        client,
+        loadGenContext,
+        workerId,
+        i,
+        delayMillisBetweenRequests
+      );
 
-      if (loadGenContext.globalRequestCount % this.printStatsEveryNRequests === 0) {
+      if (
+        loadGenContext.globalRequestCount % this.printStatsEveryNRequests ===
+        0
+      ) {
         this.logger.info(`
 cumulative stats:
    total requests: ${
@@ -158,7 +169,7 @@ cumulative stats:
    } (${BasicJavaScriptLoadGen.tps(
           loadGenContext,
           loadGenContext.globalRequestCount
-      )} tps, limited to ${this.maxRequestsPerSecond} tps)
+        )} tps, limited to ${this.maxRequestsPerSecond} tps)
            success: ${
              loadGenContext.globalSuccessCount
            } (${BasicJavaScriptLoadGen.percentRequests(
@@ -220,11 +231,10 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
     if (result !== undefined) {
       const setDuration = BasicJavaScriptLoadGen.getElapsedMillis(setStartTime);
       loadGenContext.setLatencies.recordValue(setDuration);
-      if (setDuration < delayMillisBetweenRequests)
-      {
-          const delayMs = delayMillisBetweenRequests - setDuration;
-          this.logger.debug(`delaying: ${delayMs}`);
-          await delay(delayMs);
+      if (setDuration < delayMillisBetweenRequests) {
+        const delayMs = delayMillisBetweenRequests - setDuration;
+        this.logger.debug(`delaying: ${delayMs}`);
+        await delay(delayMs);
       }
     }
 
@@ -245,16 +255,18 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
       } else {
         valueString = 'n/a';
       }
-      if (loadGenContext.globalRequestCount % this.printStatsEveryNRequests === 0) {
+      if (
+        loadGenContext.globalRequestCount % this.printStatsEveryNRequests ===
+        0
+      ) {
         this.logger.info(
           `worker: ${workerId}, worker request: ${operationId}, global request: ${loadGenContext.globalRequestCount}, status: ${getResult.status}, val: ${valueString}`
         );
       }
-      if (getDuration < delayMillisBetweenRequests)
-      {
-          const delayMs = delayMillisBetweenRequests - getDuration;
-          this.logger.debug(`delaying: ${delayMs}`);
-          await delay(delayMs);
+      if (getDuration < delayMillisBetweenRequests) {
+        const delayMs = delayMillisBetweenRequests - getDuration;
+        this.logger.debug(`delaying: ${delayMs}`);
+        await delay(delayMs);
       }
     }
   }

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -386,10 +386,10 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
    */
   loggerOptions: {
     /**
-     * Available log levels are TRACE, DEBUG, INFO, WARN, and ERROR.  DEBUG
+     * Available log levels are TRACE, DEBUG, INFO, WARN, and ERROR.  INFO
      * is a reasonable choice for this load generator program.
      */
-    level: LogLevel.DEBUG,
+    level: LogLevel.INFO,
     /**
      * Allows you to choose between formatting your log output as JSON (a good
      * choice for production environments) or CONSOLE (a better choice for

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -147,14 +147,13 @@ class BasicJavaScriptLoadGen {
     delayMillisBetweenRequests: number
   ): Promise<void> {
     let finished = false;
-    let finish = () => finished = true;
+    const finish = () => (finished = true);
     setTimeout(finish, totalMsToRun);
-    const intervalId = setInterval(
-      () => { this.logStats(loadGenContext) },
-      this.printStatsEveryNMs
-    );
+    const intervalId = setInterval(() => {
+      this.logStats(loadGenContext);
+    }, this.printStatsEveryNMs);
 
-    for(let i = 1; true; i++) {
+    for (let i = 1; true; i++) {
       await this.issueAsyncSetGet(
         client,
         loadGenContext,
@@ -163,22 +162,20 @@ class BasicJavaScriptLoadGen {
         delayMillisBetweenRequests
       );
 
-      if(finished) {
+      if (finished) {
         clearInterval(intervalId);
-        this.logStats(loadGenContext)
-        return
+        this.logStats(loadGenContext);
+        return;
       }
     }
   }
 
-  private logStats(
-    loadGenContext: BasicJavasScriptLoadGenContext
-  ): void {
+  private logStats(loadGenContext: BasicJavasScriptLoadGenContext): void {
     this.logger.info(`
 cumulative stats:
 total requests: ${
- loadGenContext.globalRequestCount
-} (${BasicJavaScriptLoadGen.tps(
+      loadGenContext.globalRequestCount
+    } (${BasicJavaScriptLoadGen.tps(
       loadGenContext,
       loadGenContext.globalRequestCount
     )} tps, limited to ${this.maxRequestsPerSecond} tps)
@@ -198,8 +195,8 @@ total requests: ${
       loadGenContext.globalUnavailableCount
     )}%)
 deadline exceeded: ${
-loadGenContext.globalDeadlineExceededCount
-} (${BasicJavaScriptLoadGen.percentRequests(
+      loadGenContext.globalDeadlineExceededCount
+    } (${BasicJavaScriptLoadGen.percentRequests(
       loadGenContext,
       loadGenContext.globalDeadlineExceededCount
     )}%)

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -22,6 +22,7 @@ interface BasicJavaScriptLoadGenOptions {
   cacheItemPayloadBytes: number;
   numberOfConcurrentRequests: number;
   totalNumberOfOperationsToExecute: number;
+  printStatsEveryNRequests: number;
 }
 
 enum AsyncSetGetResult {
@@ -54,6 +55,7 @@ class BasicJavaScriptLoadGen {
   private readonly loggerOptions: LoggerOptions;
   private readonly requestTimeoutMs: number;
   private readonly numberOfConcurrentRequests: number;
+  private readonly printStatsEveryNRequests: number;
   private readonly totalNumberOfOperationsToExecute: number;
   private readonly cacheValue: string;
 
@@ -72,6 +74,7 @@ class BasicJavaScriptLoadGen {
     this.authToken = authToken;
     this.requestTimeoutMs = options.requestTimeoutMs;
     this.numberOfConcurrentRequests = options.numberOfConcurrentRequests;
+    this.printStatsEveryNRequests = options.printStatsEveryNRequests;
     this.totalNumberOfOperationsToExecute =
       options.totalNumberOfOperationsToExecute;
 
@@ -138,7 +141,7 @@ class BasicJavaScriptLoadGen {
     for (let i = 1; i <= numOperations; i++) {
       await this.issueAsyncSetGet(client, loadGenContext, workerId, i);
 
-      if (loadGenContext.globalRequestCount % 1000 === 0) {
+      if (loadGenContext.globalRequestCount % this.printStatsEveryNRequests === 0) {
         this.logger.info(`
 cumulative stats:
    total requests: ${
@@ -226,7 +229,7 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
       } else {
         valueString = 'n/a';
       }
-      if (loadGenContext.globalRequestCount % 1000 === 0) {
+      if (loadGenContext.globalRequestCount % this.printStatsEveryNRequests === 0) {
         this.logger.info(
           `worker: ${workerId}, worker request: ${operationId}, global request: ${loadGenContext.globalRequestCount}, status: ${getResult.status}, val: ${valueString}`
         );
@@ -394,6 +397,10 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
      */
     format: LogFormat.CONSOLE,
   },
+  /** Each time the load generator has executed this many requests, it will
+   *  print out some statistics about throughput and latency.
+   */
+  printStatsEveryNRequests: 1000,
   /**
    * Configures the Momento client to timeout if a request exceeds this limit.
    * Momento client default is 5 seconds.

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -152,7 +152,8 @@ class BasicJavaScriptLoadGen {
       this.logStats(loadGenContext);
     }, this.printStatsEveryNMs);
 
-    for (let i = 1; true; i++) {
+    let i = 1;
+    for (;;) {
       await this.issueAsyncSetGet(
         client,
         loadGenContext,
@@ -166,6 +167,8 @@ class BasicJavaScriptLoadGen {
         this.logStats(loadGenContext);
         return;
       }
+
+      i++;
     }
   }
 

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -1,6 +1,5 @@
 import {
   AlreadyExistsError,
-  CacheGetStatus,
   getLogger,
   InternalServerError,
   LimitExceededError,

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -22,7 +22,7 @@ interface BasicJavaScriptLoadGenOptions {
   numberOfConcurrentRequests: number;
   showStatsIntervalSeconds: number;
   maxRequestsPerSecond: number;
-  totalMsToRun: number;
+  totalSecondsToRun: number;
 }
 
 enum AsyncSetGetResult {
@@ -57,7 +57,7 @@ class BasicJavaScriptLoadGen {
   private readonly numberOfConcurrentRequests: number;
   private readonly showStatsIntervalSeconds: number;
   private readonly maxRequestsPerSecond: number;
-  private readonly totalMsToRun: number;
+  private readonly totalSecondsToRun: number;
   private readonly cacheValue: string;
 
   private readonly cacheName: string = 'js-loadgen';
@@ -77,7 +77,7 @@ class BasicJavaScriptLoadGen {
     this.numberOfConcurrentRequests = options.numberOfConcurrentRequests;
     this.showStatsIntervalSeconds = options.showStatsIntervalSeconds;
     this.maxRequestsPerSecond = options.maxRequestsPerSecond;
-    this.totalMsToRun = options.totalMsToRun;
+    this.totalSecondsToRun = options.totalSecondsToRun;
 
     this.cacheValue = 'x'.repeat(options.cacheItemPayloadBytes);
   }
@@ -127,7 +127,7 @@ class BasicJavaScriptLoadGen {
           momento,
           loadGenContext,
           workerId + 1,
-          this.totalMsToRun,
+          this.totalSecondsToRun,
           delayMillisBetweenRequests
         )
     );
@@ -142,12 +142,12 @@ class BasicJavaScriptLoadGen {
     client: SimpleCacheClient,
     loadGenContext: BasicJavasScriptLoadGenContext,
     workerId: number,
-    totalMsToRun: number,
+    totalSecondsToRun: number,
     delayMillisBetweenRequests: number
   ): Promise<void> {
     let finished = false;
     const finish = () => (finished = true);
-    setTimeout(finish, totalMsToRun);
+    setTimeout(finish, totalSecondsToRun * 1000);
     const intervalId = setInterval(() => {
       this.logStats(loadGenContext);
     }, this.showStatsIntervalSeconds * 1000);
@@ -458,7 +458,7 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
    * Controls how long the load test will run, in milliseconds. We will execute operations
    * for this long and the exit. The default is 60 seconds.
    */
-  totalMsToRun: 60 * 1000,
+  totalSecondsToRun: 10,
 };
 
 main(loadGeneratorOptions)

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -109,7 +109,9 @@ class BasicJavaScriptLoadGen {
     );
 
     this.logger.info(`Limiting to ${this.maxRequestsPerSecond} tps`);
-    this.logger.info(`Running ${this.numberOfConcurrentRequests} concurrent requests`)
+    this.logger.info(
+      `Running ${this.numberOfConcurrentRequests} concurrent requests`
+    );
     this.logger.info(`Running for ${this.totalSecondsToRun} seconds`);
 
     const loadGenContext: BasicJavasScriptLoadGenContext = {

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -105,7 +105,7 @@ class BasicJavaScriptLoadGen {
     const delayMillisBetweenRequests =
       (1000.0 * this.numberOfConcurrentRequests) / this.maxRequestsPerSecond;
     this.logger.info(`Limiting to ${this.maxRequestsPerSecond} tps`);
-    this.logger.debug(
+    this.logger.trace(
       `delayMillisBetweenRequests: ${delayMillisBetweenRequests}`
     );
 
@@ -242,7 +242,7 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
       loadGenContext.setLatencies.recordValue(setDuration);
       if (setDuration < delayMillisBetweenRequests) {
         const delayMs = delayMillisBetweenRequests - setDuration;
-        this.logger.debug(`delaying: ${delayMs}`);
+        this.logger.trace(`delaying: ${delayMs}`);
         await delay(delayMs);
       }
     }
@@ -258,7 +258,7 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
       loadGenContext.getLatencies.recordValue(getDuration);
       if (getDuration < delayMillisBetweenRequests) {
         const delayMs = delayMillisBetweenRequests - getDuration;
-        this.logger.debug(`delaying: ${delayMs}`);
+        this.logger.trace(`delaying: ${delayMs}`);
         await delay(delayMs);
       }
     }
@@ -416,7 +416,7 @@ const loadGeneratorOptions: BasicJavaScriptLoadGenOptions = {
      * Available log levels are TRACE, DEBUG, INFO, WARN, and ERROR.  INFO
      * is a reasonable choice for this load generator program.
      */
-    level: LogLevel.INFO,
+    level: LogLevel.DEBUG,
     /**
      * Allows you to choose between formatting your log output as JSON (a good
      * choice for production environments) or CONSOLE (a better choice for


### PR DESCRIPTION
* maxRequestsPerSecond
  * prevents throttling
  * log the limit so the user realizes it's the script, not the service
* Change to time based instead of request based limits (see momentohq/client-sdk-dotnet#229)
  * <strike>totalNumberOfOperationsToExecute</strike> totalMsToRun
  * printStatsEveryNMs
* Always print stats at the end.

This probably diverges from the other SDK's load generators.

Closes #123 