### PR TITLE
chore: Add an editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# These are encrypted files. Don't mess with them.
+[*.enc]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/examples/load-gen.ts
+++ b/examples/load-gen.ts
@@ -181,7 +181,7 @@ resource exhausted: ${
           loadGenContext.globalRstStreamCount
         )}%)
 
-cumulative set latencies:      
+cumulative set latencies:
 ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.setLatencies)}
 
 cumulative get latencies:
@@ -329,7 +329,7 @@ ${BasicJavaScriptLoadGen.outputHistogramSummary(loadGenContext.getLatencies)}
 
   private static outputHistogramSummary(histogram: hdr.Histogram): string {
     return `
-  count: ${histogram.totalCount} 
+  count: ${histogram.totalCount}
     min: ${histogram.minNonZeroValue}
     p50: ${histogram.getValueAtPercentile(50)}
     p90: ${histogram.getValueAtPercentile(90)}


### PR DESCRIPTION
Makes whitespace handling consistent. Honored by many editors, others have a plugin. See https://editorconfig.org/