### PR TITLE
chore: linting and validation fixes

### DIFF
--- a/integration/simple-cache-client.test.ts
+++ b/integration/simple-cache-client.test.ts
@@ -27,9 +27,7 @@ const deleteCacheIfExists = async (
 ) => {
   const deleteResponse = await momento.deleteCache(cacheName);
   if (deleteResponse instanceof DeleteCache.Error) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     if (deleteResponse.errorCode() !== MomentoErrorCode.NOT_FOUND_ERROR) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       throw deleteResponse.innerException();
     }
   }
@@ -259,6 +257,78 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
     const getMiss = await momento.get(INTEGRATION_TEST_CACHE_NAME, cacheKey);
     expect(getMiss).toBeInstanceOf(CacheGet.Miss);
+  });
+  it('should return InvalidArgument response for set, get, and delete with empty key', async () => {
+    const momento = new SimpleCacheClient(AUTH_TOKEN, 1111);
+    const setResponse = await momento.set(
+      INTEGRATION_TEST_CACHE_NAME,
+      '',
+      'foo'
+    );
+    expect(setResponse).toBeInstanceOf(CacheSet.Error);
+    expect((setResponse as CacheSet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+    const getResponse = await momento.get(INTEGRATION_TEST_CACHE_NAME, '');
+    expect(getResponse).toBeInstanceOf(CacheGet.Error);
+    expect((getResponse as CacheGet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+    const deleteResponse = await momento.delete(
+      INTEGRATION_TEST_CACHE_NAME,
+      ''
+    );
+    expect(deleteResponse).toBeInstanceOf(CacheDelete.Error);
+    expect((deleteResponse as CacheDelete.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+  });
+  it('should return InvalidArgument response for set, get, and delete with invalid cache name', async () => {
+    const momento = new SimpleCacheClient(AUTH_TOKEN, 1111);
+    const setResponse = await momento.set('', 'bar', 'foo');
+    expect(setResponse).toBeInstanceOf(CacheSet.Error);
+    expect((setResponse as CacheSet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+    const getResponse = await momento.get('', 'bar');
+    expect(getResponse).toBeInstanceOf(CacheGet.Error);
+    expect((getResponse as CacheDelete.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+    const deleteResponse = await momento.delete('', 'bar');
+    expect(deleteResponse).toBeInstanceOf(CacheDelete.Error);
+    expect((deleteResponse as CacheDelete.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+  });
+  it('should return InvalidArgument response for set request with empty key or value', async () => {
+    const momento = new SimpleCacheClient(AUTH_TOKEN, 1111);
+    const noKeySetResponse = await momento.set(
+      INTEGRATION_TEST_CACHE_NAME,
+      '',
+      'value'
+    );
+    expect(noKeySetResponse).toBeInstanceOf(CacheSet.Error);
+    expect((noKeySetResponse as CacheSet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+    const noValueSetResponse = await momento.set(
+      INTEGRATION_TEST_CACHE_NAME,
+      'key',
+      ''
+    );
+    expect(noValueSetResponse).toBeInstanceOf(CacheSet.Error);
+    expect((noValueSetResponse as CacheSet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+  });
+  it('should return InvalidArgument response for get request with empty key', async () => {
+    const momento = new SimpleCacheClient(AUTH_TOKEN, 1111);
+    const noKeyGetResponse = await momento.get(INTEGRATION_TEST_CACHE_NAME, '');
+    expect(noKeyGetResponse).toBeInstanceOf(CacheGet.Error);
+    expect((noKeyGetResponse as CacheGet.Error).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
   });
   it('should create, list, and revoke a signing key', async () => {
     const momento = new SimpleCacheClient(AUTH_TOKEN, 1111);

--- a/src/errors/error-utils.ts
+++ b/src/errors/error-utils.ts
@@ -1,4 +1,11 @@
-import {MomentoErrorCode, SdkError} from './errors';
+import {MomentoErrorCode, SdkError, UnknownError} from './errors';
+
+export function normalizeSdkError(error: Error): SdkError {
+  if (error instanceof SdkError) {
+    return error;
+  }
+  return new UnknownError(error.message);
+}
 
 export abstract class ErrorBody {
   protected _innerException: SdkError;
@@ -19,6 +26,19 @@ export abstract class ErrorBody {
   }
 }
 
+/**
+ * This function is used by the classes in `messages.responses` to copy the
+ * implementation of ErrorBody above into the identical error subtypes
+ * defined in each response type.
+ *
+ * Because those classes *must* subclass a specific response base class, for example
+ * `CacheDelete.Response`, we're using the
+ * [mixin pattern](https://www.typescriptlang.org/docs/handbook/mixins.html)
+ * described in the TypeScript documentation to DRY out their implementations.
+ *
+ * @param derivedCtor The class receiving the mixin implementations
+ * @param constructors A list of classes providing the implementations
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function applyMixins(derivedCtor: any, constructors: any[]) {
   constructors.forEach(baseCtor => {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -15,7 +15,7 @@ export enum MomentoErrorCode {
   AUTHENTICATION_ERROR = 'AUTHENTICATION_ERROR',
   // Request was cancelled by the server
   CANCELLED_ERROR = 'CANCELLED_ERROR',
-  // Request rate exceeded the limits for the account
+  // Request rate, bandwidth, or object size exceeded the limits for the account
   LIMIT_EXCEEDED_ERROR = 'LIMIT_EXCEEDED_ERROR',
   // Request was invalid
   BAD_REQUEST_ERROR = 'BAD_REQUEST_ERROR',
@@ -151,7 +151,7 @@ export class InvalidArgumentError extends SdkError {
 export class LimitExceededError extends SdkError {
   _errorCode = MomentoErrorCode.LIMIT_EXCEEDED_ERROR;
   _messageWrapper =
-    'Request rate exceeded the limits for this account.  To resolve this error, reduce your request rate, or contact us at support@momentohq.com to request a limit increase';
+    'Request rate, bandwidth, or object size exceeded the limits for this account.  To resolve this error, reduce your usage as appropriate or contact us at support@momentohq.com to request a limit increase';
 }
 
 /**

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,35 @@
+import {InvalidArgumentError} from '../errors/errors';
+
+export function validateCacheName(name: string) {
+  if (!name.trim()) {
+    throw new InvalidArgumentError('cache name must not be empty');
+  }
+}
+
+export function validateTtlMinutes(ttlMinutes: number) {
+  if (ttlMinutes < 0) {
+    throw new InvalidArgumentError('ttlMinutes must be positive');
+  }
+}
+
+export function ensureValidSetRequest(
+  key: unknown,
+  value: unknown,
+  ttl: number
+) {
+  ensureValidKey(key);
+
+  if (!value) {
+    throw new InvalidArgumentError('value must not be empty');
+  }
+
+  if (ttl && ttl < 0) {
+    throw new InvalidArgumentError('ttl must be a positive integer');
+  }
+}
+
+export function ensureValidKey(key: unknown) {
+  if (!key) {
+    throw new InvalidArgumentError('key must not be empty');
+  }
+}


### PR DESCRIPTION
This is a followup to https://github.com/momentohq/client-sdk-javascript/pull/131. It removes unneeded linting directives, tightens up control client and data client validation, adds tests for the validators, and adds documentation for the `applyMixins` function.