### PR TITLE
feat: DRY up constructor args, improve consistency of variable names

### DIFF
--- a/integration/simple-cache-client.test.ts
+++ b/integration/simple-cache-client.test.ts
@@ -15,9 +15,15 @@ import {
   SimpleCacheClient,
 } from '../src';
 import {TextEncoder} from 'util';
+import {SimpleCacheClientProps} from '../src/simple-cache-client-props';
 
-const authProvider = new EnvMomentoTokenProvider('TEST_AUTH_TOKEN');
+const credentialProvider = new EnvMomentoTokenProvider('TEST_AUTH_TOKEN');
 const configuration = Configurations.Laptop.latest();
+const cacheClientProps: SimpleCacheClientProps = {
+  configuration: configuration,
+  credentialProvider: credentialProvider,
+  defaultTtlSeconds: 1111,
+};
 const INTEGRATION_TEST_CACHE_NAME =
   process.env.TEST_CACHE_NAME || 'js-integration-test-default';
 
@@ -34,7 +40,7 @@ const deleteCacheIfExists = async (
 };
 
 beforeAll(async () => {
-  const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+  const momento = new SimpleCacheClient(cacheClientProps);
   await deleteCacheIfExists(momento, INTEGRATION_TEST_CACHE_NAME);
   const createResponse = await momento.createCache(INTEGRATION_TEST_CACHE_NAME);
   if (createResponse instanceof CreateCache.Error) {
@@ -43,7 +49,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+  const momento = new SimpleCacheClient(cacheClientProps);
   const deleteResponse = await momento.deleteCache(INTEGRATION_TEST_CACHE_NAME);
   if (deleteResponse instanceof DeleteCache.Error) {
     throw deleteResponse.innerException();
@@ -67,7 +73,7 @@ async function withCache(
 describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should create and delete a cache, set and get a value', async () => {
     const cacheName = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     await withCache(momento, cacheName, async () => {
       const setResponse = await momento.set(cacheName, 'key', 'value');
       expect(setResponse).toBeInstanceOf(CacheSet.Success);
@@ -80,7 +86,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   });
   it('should return NotFoundError if deleting a non-existent cache', async () => {
     const cacheName = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const deleteResponse = await momento.deleteCache(cacheName);
     expect(deleteResponse).toBeInstanceOf(DeleteCache.Response);
     expect(deleteResponse).toBeInstanceOf(DeleteCache.Error);
@@ -92,7 +98,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   });
   it('should return AlreadyExists response if trying to create a cache that already exists', async () => {
     const cacheName = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     await withCache(momento, cacheName, async () => {
       const createResponse = await momento.createCache(cacheName);
       expect(createResponse).toBeInstanceOf(CreateCache.AlreadyExists);
@@ -100,7 +106,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   });
   it('should create 1 cache and list the created cache', async () => {
     const cacheName = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     await withCache(momento, cacheName, async () => {
       const listResponse = await momento.listCaches();
       expect(listResponse).toBeInstanceOf(ListCaches.Success);
@@ -114,7 +120,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set and get string from cache', async () => {
     const cacheKey = v4();
     const cacheValue = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -133,7 +139,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set and get bytes from cache', async () => {
     const cacheKey = new TextEncoder().encode(v4());
     const cacheValue = new TextEncoder().encode(v4());
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -152,7 +158,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set string key with bytes value', async () => {
     const cacheKey = v4();
     const cacheValue = new TextEncoder().encode(v4());
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -171,7 +177,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set byte key with string value', async () => {
     const cacheValue = v4();
     const cacheKey = new TextEncoder().encode(v4());
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -190,7 +196,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set and get string from cache and returned set value matches string cacheValue', async () => {
     const cacheKey = v4();
     const cacheValue = v4();
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -204,7 +210,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set string key with bytes value and returned set value matches byte cacheValue', async () => {
     const cacheKey = v4();
     const cacheValue = new TextEncoder().encode(v4());
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       cacheKey,
@@ -217,22 +223,18 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   });
   it('should timeout on a request that exceeds specified timeout', async () => {
     const cacheName = v4();
-    const defaultTimeoutClient = new SimpleCacheClient(
-      configuration,
-      authProvider,
-      1111
-    );
+    const defaultTimeoutClient = new SimpleCacheClient(cacheClientProps);
     const shortTimeoutTransportStrategy = configuration
       .getTransportStrategy()
       .withClientTimeout(1);
     const shortTimeoutConfiguration = configuration.withTransportStrategy(
       shortTimeoutTransportStrategy
     );
-    const shortTimeoutClient = new SimpleCacheClient(
-      shortTimeoutConfiguration,
-      authProvider,
-      1111
-    );
+    const shortTimeoutClient = new SimpleCacheClient({
+      configuration: shortTimeoutConfiguration,
+      credentialProvider: credentialProvider,
+      defaultTtlSeconds: 1111,
+    });
     await withCache(defaultTimeoutClient, cacheName, async () => {
       const cacheKey = v4();
       // Create a longer cache value that should take longer than 1ms to send
@@ -251,7 +253,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
   it('should set and then delete a value in cache', async () => {
     const cacheKey = v4();
     const cacheValue = new TextEncoder().encode(v4());
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     await momento.set(INTEGRATION_TEST_CACHE_NAME, cacheKey, cacheValue);
     const getResponse = await momento.get(
       INTEGRATION_TEST_CACHE_NAME,
@@ -271,7 +273,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     expect(getMiss).toBeInstanceOf(CacheGet.Miss);
   });
   it('should return InvalidArgument response for set, get, and delete with empty key', async () => {
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       '',
@@ -296,7 +298,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     );
   });
   it('should return InvalidArgument response for set, get, and delete with invalid cache name', async () => {
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const setResponse = await momento.set('', 'bar', 'foo');
     expect(setResponse).toBeInstanceOf(CacheSet.Error);
     expect((setResponse as CacheSet.Error).errorCode()).toEqual(
@@ -314,7 +316,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     );
   });
   it('should return InvalidArgument response for set request with empty key or value', async () => {
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const noKeySetResponse = await momento.set(
       INTEGRATION_TEST_CACHE_NAME,
       '',
@@ -335,7 +337,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     );
   });
   it('should return InvalidArgument response for get request with empty key', async () => {
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const noKeyGetResponse = await momento.get(INTEGRATION_TEST_CACHE_NAME, '');
     expect(noKeyGetResponse).toBeInstanceOf(CacheGet.Error);
     expect((noKeyGetResponse as CacheGet.Error).errorCode()).toEqual(
@@ -343,7 +345,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     );
   });
   it('should create, list, and revoke a signing key', async () => {
-    const momento = new SimpleCacheClient(configuration, authProvider, 1111);
+    const momento = new SimpleCacheClient(cacheClientProps);
     const createSigningKeyResponse = await momento.createSigningKey(30);
     expect(createSigningKeyResponse).toBeInstanceOf(CreateSigningKey.Success);
     let listSigningKeysResponse = await momento.listSigningKeys();

--- a/integration/simple-cache-client.test.ts
+++ b/integration/simple-cache-client.test.ts
@@ -39,8 +39,8 @@ const deleteCacheIfExists = async (
   }
 };
 
-let momento:SimpleCacheClient;
-beforeAll(function() {
+let momento: SimpleCacheClient;
+beforeAll(() => {
   momento = new SimpleCacheClient(cacheClientProps);
 });
 

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,6 +1,6 @@
 import {decodeJwt} from '../utils/jwt';
 
-export interface ICredentialProvider {
+export interface CredentialProvider {
   getAuthToken(): string;
 
   getControlEndpoint(): string;
@@ -12,7 +12,7 @@ export interface ICredentialProvider {
   getTrustedCacheEndpointCertificateName(): string | null;
 }
 
-export class EnvMomentoTokenProvider implements ICredentialProvider {
+export class EnvMomentoTokenProvider implements CredentialProvider {
   private readonly authToken: string;
   private readonly controlEndpoint: string;
   private readonly cacheEndpoint: string;

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,25 +1,27 @@
-import {ITransportStrategy} from './transport/transport-strategy';
+import {TransportStrategy} from './transport/transport-strategy';
 
-export interface IConfiguration {
+export interface SimpleCacheConfiguration {
   // TODO: add RetryStrategy
   // TODO: add Middlewares
-  getTransportStrategy(): ITransportStrategy;
-  withTransportStrategy(transportStrategy: ITransportStrategy): IConfiguration;
+  getTransportStrategy(): TransportStrategy;
+  withTransportStrategy(
+    transportStrategy: TransportStrategy
+  ): SimpleCacheConfiguration;
   getMaxIdleMillis(): number;
-  withMaxIdleMillis(maxIdleMillis: number): IConfiguration;
-  withClientTimeout(clientTimeout: number): IConfiguration;
+  withMaxIdleMillis(maxIdleMillis: number): SimpleCacheConfiguration;
+  withClientTimeout(clientTimeout: number): SimpleCacheConfiguration;
 }
 
-export class Configuration implements IConfiguration {
-  private readonly transportStrategy: ITransportStrategy;
+export class Configuration implements SimpleCacheConfiguration {
+  private readonly transportStrategy: TransportStrategy;
   private readonly maxIdleMillis: number;
 
-  constructor(transportStrategy: ITransportStrategy, maxIdleMillis: number) {
+  constructor(transportStrategy: TransportStrategy, maxIdleMillis: number) {
     this.transportStrategy = transportStrategy;
     this.maxIdleMillis = maxIdleMillis;
   }
 
-  getTransportStrategy(): ITransportStrategy {
+  getTransportStrategy(): TransportStrategy {
     return this.transportStrategy;
   }
 
@@ -27,7 +29,9 @@ export class Configuration implements IConfiguration {
     return this.maxIdleMillis;
   }
 
-  withTransportStrategy(transportStrategy: ITransportStrategy): IConfiguration {
+  withTransportStrategy(
+    transportStrategy: TransportStrategy
+  ): SimpleCacheConfiguration {
     return new Configuration(transportStrategy, this.maxIdleMillis);
   }
 
@@ -35,7 +39,7 @@ export class Configuration implements IConfiguration {
     return new Configuration(this.transportStrategy, maxIdleMillis);
   }
 
-  withClientTimeout(clientTimeout: number): IConfiguration {
+  withClientTimeout(clientTimeout: number): SimpleCacheConfiguration {
     return new Configuration(
       this.transportStrategy.withClientTimeout(clientTimeout),
       this.maxIdleMillis

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -1,13 +1,13 @@
 import {Configuration} from './configuration';
 import {
-  ITransportStrategy,
+  TransportStrategy,
   StaticGrpcConfiguration,
   StaticTransportStrategy,
 } from './transport/transport-strategy';
 import {IGrpcConfiguration} from './transport/grpc-configuration';
 
 export class Laptop extends Configuration {
-  constructor(transportStrategy: ITransportStrategy, maxIdleMillis: number) {
+  constructor(transportStrategy: TransportStrategy, maxIdleMillis: number) {
     super(transportStrategy, maxIdleMillis);
   }
 
@@ -20,7 +20,7 @@ export class Laptop extends Configuration {
       deadlineMilliseconds,
       maxSessionMemory
     );
-    const transportStrategy: ITransportStrategy = new StaticTransportStrategy(
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy(
       null,
       grpcConfig
     );

--- a/src/config/transport/transport-strategy.ts
+++ b/src/config/transport/transport-strategy.ts
@@ -1,16 +1,16 @@
 import {IGrpcConfiguration} from './grpc-configuration';
 
-export interface ITransportStrategy {
+export interface TransportStrategy {
   getMaxConcurrentRequests(): number | null;
 
   getGrpcConfig(): IGrpcConfiguration;
 
   // TODO: for use in middleware
-  withMaxConcurrentRequests(maxConcurrentRequests: number): ITransportStrategy;
+  withMaxConcurrentRequests(maxConcurrentRequests: number): TransportStrategy;
 
-  withGrpcConfig(grpcConfig: IGrpcConfiguration): ITransportStrategy;
+  withGrpcConfig(grpcConfig: IGrpcConfiguration): TransportStrategy;
 
-  withClientTimeout(clientTimeout: number): ITransportStrategy;
+  withClientTimeout(clientTimeout: number): TransportStrategy;
 }
 
 export class StaticGrpcConfiguration implements IGrpcConfiguration {
@@ -46,7 +46,7 @@ export class StaticGrpcConfiguration implements IGrpcConfiguration {
   }
 }
 
-export class StaticTransportStrategy implements ITransportStrategy {
+export class StaticTransportStrategy implements TransportStrategy {
   private readonly maxConcurrentRequests: number | null;
   private readonly grpcConfig: IGrpcConfiguration;
 

--- a/src/grpc/idle-grpc-client-wrapper.ts
+++ b/src/grpc/idle-grpc-client-wrapper.ts
@@ -1,10 +1,10 @@
 import {getLogger, Logger} from '../utils/logging';
 import {CloseableGrpcClient, GrpcClientWrapper} from './grpc-client-wrapper';
-import {IConfiguration} from '../config/configuration';
+import {SimpleCacheConfiguration} from '../config/configuration';
 
 export interface IdleGrpcClientWrapperProps<T extends CloseableGrpcClient> {
   clientFactoryFn: () => T;
-  configuration: IConfiguration;
+  configuration: SimpleCacheConfiguration;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,10 @@ import * as ListSigningKeys from './messages/responses/list-signing-keys';
 import * as RevokeSigningKey from './messages/responses/revoke-signing-key';
 import {CacheInfo} from './messages/cache-info';
 import {
-  ICredentialProvider,
+  CredentialProvider,
   EnvMomentoTokenProvider,
 } from './auth/credential-provider';
-import {IConfiguration} from './config/configuration';
+import {SimpleCacheConfiguration} from './config/configuration';
 
 import {
   MomentoErrorCode,
@@ -45,8 +45,8 @@ export {
 
 export {
   Configurations,
-  IConfiguration,
-  ICredentialProvider,
+  SimpleCacheConfiguration,
+  CredentialProvider,
   EnvMomentoTokenProvider,
   MomentoSigner,
   CacheOperation,

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -20,26 +20,15 @@ import {
   ensureValidSetRequest,
   validateCacheName,
 } from '../utils/validators';
-import {ICredentialProvider} from '../auth/credential-provider';
-import {IConfiguration} from '../config/configuration';
-
-/**
- * @property {string} authToken - momento jwt token
- * @property {string} endpoint - endpoint to reach momento cache
- * @property {number} defaultTtlSeconds - the default time to live of object inside of cache, in seconds
- * @property {number} requestTimeoutMs - the amount of time for a request to complete before timing out, in milliseconds
- */
-type MomentoCacheProps = {
-  authProvider: ICredentialProvider;
-  configuration: IConfiguration;
-  defaultTtlSeconds: number;
-};
+import {CredentialProvider} from '../auth/credential-provider';
+import {SimpleCacheConfiguration} from '../config/configuration';
+import {SimpleCacheClientProps} from '../simple-cache-client-props';
 
 export class CacheClient {
   private readonly clientWrapper: GrpcClientWrapper<cache.cache_client.ScsClient>;
   private readonly textEncoder: TextEncoder;
-  private readonly configuration: IConfiguration;
-  private readonly authProvider: ICredentialProvider;
+  private readonly configuration: SimpleCacheConfiguration;
+  private readonly authProvider: CredentialProvider;
   private readonly defaultTtlSeconds: number;
   private readonly requestTimeoutMs: number;
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
@@ -49,9 +38,9 @@ export class CacheClient {
   /**
    * @param {MomentoCacheProps} props
    */
-  constructor(props: MomentoCacheProps) {
+  constructor(props: SimpleCacheClientProps) {
     this.configuration = props.configuration;
-    this.authProvider = props.authProvider;
+    this.authProvider = props.credentialProvider;
     this.logger = getLogger(this);
     const grpcConfig = this.configuration
       .getTransportStrategy()

--- a/src/internal/control-client.ts
+++ b/src/internal/control-client.ts
@@ -17,12 +17,12 @@ import {IdleGrpcClientWrapper} from '../grpc/idle-grpc-client-wrapper';
 import {GrpcClientWrapper} from '../grpc/grpc-client-wrapper';
 import {normalizeSdkError} from '../errors/error-utils';
 import {validateCacheName, validateTtlMinutes} from '../utils/validators';
-import {ICredentialProvider} from '../auth/credential-provider';
-import {IConfiguration} from '../config/configuration';
+import {CredentialProvider} from '../auth/credential-provider';
+import {SimpleCacheConfiguration} from '../config/configuration';
 
-export interface MomentoProps {
-  authProvider: ICredentialProvider;
-  configuration: IConfiguration;
+export interface ControlClientProps {
+  configuration: SimpleCacheConfiguration;
+  credentialProvider: CredentialProvider;
 }
 
 export class ControlClient {
@@ -32,12 +32,12 @@ export class ControlClient {
   private readonly logger: Logger;
 
   /**
-   * @param {MomentoProps} props
+   * @param {ControlClientProps} props
    */
-  constructor(props: MomentoProps) {
+  constructor(props: ControlClientProps) {
     this.logger = getLogger(this);
     const headers = [
-      new Header('Authorization', props.authProvider.getAuthToken()),
+      new Header('Authorization', props.credentialProvider.getAuthToken()),
       new Header('Agent', `javascript:${version}`),
     ];
     this.interceptors = [
@@ -46,12 +46,12 @@ export class ControlClient {
       ...createRetryInterceptorIfEnabled(),
     ];
     this.logger.debug(
-      `Creating control client using endpoint: '${props.authProvider.getControlEndpoint()}`
+      `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
     );
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
         new control.control_client.ScsControlClient(
-          props.authProvider.getControlEndpoint(),
+          props.credentialProvider.getControlEndpoint(),
           ChannelCredentials.createSsl()
         ),
       configuration: props.configuration,

--- a/src/simple-cache-client-props.ts
+++ b/src/simple-cache-client-props.ts
@@ -1,0 +1,14 @@
+import {CredentialProvider} from './auth/credential-provider';
+import {SimpleCacheConfiguration} from './config/configuration';
+
+/**
+ * @property {string} authToken - momento jwt token
+ * @property {string} endpoint - endpoint to reach momento cache
+ * @property {number} defaultTtlSeconds - the default time to live of object inside of cache, in seconds
+ * @property {number} requestTimeoutMs - the amount of time for a request to complete before timing out, in milliseconds
+ */
+export interface SimpleCacheClientProps {
+  configuration: SimpleCacheConfiguration;
+  credentialProvider: CredentialProvider;
+  defaultTtlSeconds: number;
+}

--- a/test/simple-cache-client.test.ts
+++ b/test/simple-cache-client.test.ts
@@ -5,13 +5,17 @@ import {
   EnvMomentoTokenProvider,
 } from '../src';
 import * as CreateCache from '../src/messages/responses/create-cache';
-const authProvider = new EnvMomentoTokenProvider('TEST_AUTH_TOKEN');
+const credentialProvider = new EnvMomentoTokenProvider('TEST_AUTH_TOKEN');
 const configuration = Configurations.Laptop.latest();
 
 describe('SimpleCacheClient.ts', () => {
   it('cannot create/get cache with invalid name', async () => {
     const invalidCacheNames = ['', '    '];
-    const momento = new SimpleCacheClient(configuration, authProvider, 100);
+    const momento = new SimpleCacheClient({
+      configuration: configuration,
+      credentialProvider: credentialProvider,
+      defaultTtlSeconds: 100,
+    });
     for (const name of invalidCacheNames) {
       const createResponse = await momento.createCache(name);
       expect(createResponse).toBeInstanceOf(CreateCache.Error);
@@ -27,7 +31,11 @@ describe('SimpleCacheClient.ts', () => {
       const invalidTimeoutConfig = configuration.withTransportStrategy(
         configuration.getTransportStrategy().withClientTimeout(-1)
       );
-      new SimpleCacheClient(invalidTimeoutConfig, authProvider, 100);
+      new SimpleCacheClient({
+        configuration: invalidTimeoutConfig,
+        credentialProvider: credentialProvider,
+        defaultTtlSeconds: 100,
+      });
       fail(new Error('Expected InvalidArgumentError to be thrown!'));
     } catch (e) {
       if (!(e instanceof InvalidArgumentError)) {


### PR DESCRIPTION
This just takes a quick pass through the client constructors and standardizes on a re-usable interface for the required constructor args, so that they can be passed in the keyword-arg style.  We also rename some variables such as `authProvider` for consistency with the new interface names.

This is the first PR to work towards the list of outstanding tasks described in https://github.com/momentohq/client-sdk-javascript/issues/146 .