### PR TITLE
feat: introduce InRegion pre-built Configurations

### DIFF
--- a/src/config/transport/grpc-configuration.ts
+++ b/src/config/transport/grpc-configuration.ts
@@ -1,6 +1,6 @@
-export interface IGrpcConfiguration {
+export interface GrpcConfiguration {
   getDeadlineMilliseconds(): number;
-  withDeadlineMilliseconds(deadlineMilliseconds: number): IGrpcConfiguration;
+  withDeadlineMilliseconds(deadlineMilliseconds: number): GrpcConfiguration;
   getMaxSessionMemory(): number;
-  withMaxSessionMemory(maxSessionMemory: number): IGrpcConfiguration;
+  withMaxSessionMemory(maxSessionMemory: number): GrpcConfiguration;
 }

--- a/src/config/transport/transport-strategy.ts
+++ b/src/config/transport/transport-strategy.ts
@@ -1,19 +1,19 @@
-import {IGrpcConfiguration} from './grpc-configuration';
+import {GrpcConfiguration} from './grpc-configuration';
 
 export interface TransportStrategy {
   getMaxConcurrentRequests(): number | null;
 
-  getGrpcConfig(): IGrpcConfiguration;
+  getGrpcConfig(): GrpcConfiguration;
 
   // TODO: for use in middleware
   withMaxConcurrentRequests(maxConcurrentRequests: number): TransportStrategy;
 
-  withGrpcConfig(grpcConfig: IGrpcConfiguration): TransportStrategy;
+  withGrpcConfig(grpcConfig: GrpcConfiguration): TransportStrategy;
 
   withClientTimeout(clientTimeout: number): TransportStrategy;
 }
 
-export class StaticGrpcConfiguration implements IGrpcConfiguration {
+export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly deadlineMilliseconds: number;
   private readonly maxSessionMemory: number;
   constructor(deadlineMilliseconds: number, maxSessionMemory: number) {
@@ -48,11 +48,11 @@ export class StaticGrpcConfiguration implements IGrpcConfiguration {
 
 export class StaticTransportStrategy implements TransportStrategy {
   private readonly maxConcurrentRequests: number | null;
-  private readonly grpcConfig: IGrpcConfiguration;
+  private readonly grpcConfig: GrpcConfiguration;
 
   constructor(
     maxConcurrentRequests: number | null,
-    grpcConfiguration: IGrpcConfiguration
+    grpcConfiguration: GrpcConfiguration
   ) {
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.grpcConfig = grpcConfiguration;
@@ -62,7 +62,7 @@ export class StaticTransportStrategy implements TransportStrategy {
     return this.maxConcurrentRequests;
   }
 
-  getGrpcConfig(): IGrpcConfiguration {
+  getGrpcConfig(): GrpcConfiguration {
     return this.grpcConfig;
   }
 
@@ -72,7 +72,7 @@ export class StaticTransportStrategy implements TransportStrategy {
     return new StaticTransportStrategy(maxConcurrentRequests, this.grpcConfig);
   }
 
-  withGrpcConfig(grpcConfig: IGrpcConfiguration): StaticTransportStrategy {
+  withGrpcConfig(grpcConfig: GrpcConfiguration): StaticTransportStrategy {
     return new StaticTransportStrategy(this.maxConcurrentRequests, grpcConfig);
   }
 


### PR DESCRIPTION
This commit introduces a first attempt at a pattern for providing the InRegion pre-built Configurations.  We needed a slightly different pattern here since these configurations are nested one level more deeply inside of the Configurations namespace.