### PR TITLE
feat: re-introduce logging options

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,8 +1,11 @@
 import {TransportStrategy} from './transport/transport-strategy';
+import {LoggerOptions} from '../utils/logging';
 
 export interface Configuration {
   // TODO: add RetryStrategy
   // TODO: add Middlewares
+  getLoggerOptions(): LoggerOptions;
+  withLoggerOptions(loggerOptions: LoggerOptions): Configuration;
   getTransportStrategy(): TransportStrategy;
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration;
   getMaxIdleMillis(): number;
@@ -11,12 +14,22 @@ export interface Configuration {
 }
 
 export class SimpleCacheConfiguration implements Configuration {
+  private readonly loggerOptions: LoggerOptions;
   private readonly transportStrategy: TransportStrategy;
   private readonly maxIdleMillis: number;
 
-  constructor(transportStrategy: TransportStrategy, maxIdleMillis: number) {
+  constructor(
+    loggerOptions: LoggerOptions,
+    transportStrategy: TransportStrategy,
+    maxIdleMillis: number
+  ) {
+    this.loggerOptions = loggerOptions;
     this.transportStrategy = transportStrategy;
     this.maxIdleMillis = maxIdleMillis;
+  }
+
+  getLoggerOptions(): LoggerOptions {
+    return this.loggerOptions;
   }
 
   getTransportStrategy(): TransportStrategy {
@@ -27,16 +40,33 @@ export class SimpleCacheConfiguration implements Configuration {
     return this.maxIdleMillis;
   }
 
+  withLoggerOptions(loggerOptions: LoggerOptions): Configuration {
+    return new SimpleCacheConfiguration(
+      loggerOptions,
+      this.transportStrategy,
+      this.maxIdleMillis
+    );
+  }
+
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration {
-    return new SimpleCacheConfiguration(transportStrategy, this.maxIdleMillis);
+    return new SimpleCacheConfiguration(
+      this.loggerOptions,
+      transportStrategy,
+      this.maxIdleMillis
+    );
   }
 
   withMaxIdleMillis(maxIdleMillis: number) {
-    return new SimpleCacheConfiguration(this.transportStrategy, maxIdleMillis);
+    return new SimpleCacheConfiguration(
+      this.loggerOptions,
+      this.transportStrategy,
+      maxIdleMillis
+    );
   }
 
   withClientTimeout(clientTimeout: number): Configuration {
     return new SimpleCacheConfiguration(
+      this.loggerOptions,
       this.transportStrategy.withClientTimeout(clientTimeout),
       this.maxIdleMillis
     );

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -5,13 +5,19 @@ import {
   StaticTransportStrategy,
 } from './transport/transport-strategy';
 import {GrpcConfiguration} from './transport/grpc-configuration';
+import {LogFormat, LoggerOptions, LogLevel} from '../utils/logging';
 
 // 4 minutes.  We want to remain comfortably underneath the idle timeout for AWS NLB, which is 350s.
 const defaultMaxIdleMillis = 4 * 60 * 1_000;
 const defaultMaxSessionMemoryMb = 256;
+const defaultLoggerOptions: LoggerOptions = {
+  level: LogLevel.WARN,
+  format: LogFormat.CONSOLE,
+};
 
 export class Laptop extends SimpleCacheConfiguration {
-  static latest() {
+  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
+    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 5000;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -22,12 +28,13 @@ export class Laptop extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new Laptop(transportStrategy, maxIdleMillis);
+    return new Laptop(finalLoggerOptions, transportStrategy, maxIdleMillis);
   }
 }
 
 class InRegionDefault extends SimpleCacheConfiguration {
-  static latest() {
+  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
+    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 1100;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -38,12 +45,17 @@ class InRegionDefault extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new InRegionDefault(transportStrategy, maxIdleMillis);
+    return new InRegionDefault(
+      finalLoggerOptions,
+      transportStrategy,
+      maxIdleMillis
+    );
   }
 }
 
 class InRegionLowLatency extends SimpleCacheConfiguration {
-  static latest() {
+  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
+    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 500;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -54,7 +66,11 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new InRegionDefault(transportStrategy, maxIdleMillis);
+    return new InRegionDefault(
+      finalLoggerOptions,
+      transportStrategy,
+      maxIdleMillis
+    );
   }
 }
 

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -16,8 +16,7 @@ const defaultLoggerOptions: LoggerOptions = {
 };
 
 export class Laptop extends SimpleCacheConfiguration {
-  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
-    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
+  static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 5000;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -28,13 +27,12 @@ export class Laptop extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new Laptop(finalLoggerOptions, transportStrategy, maxIdleMillis);
+    return new Laptop(loggerOptions, transportStrategy, maxIdleMillis);
   }
 }
 
 class InRegionDefault extends SimpleCacheConfiguration {
-  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
-    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
+  static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 1100;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -45,17 +43,12 @@ class InRegionDefault extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new InRegionDefault(
-      finalLoggerOptions,
-      transportStrategy,
-      maxIdleMillis
-    );
+    return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
   }
 }
 
 class InRegionLowLatency extends SimpleCacheConfiguration {
-  static latest(loggerOptions: LoggerOptions | undefined = undefined) {
-    const finalLoggerOptions = loggerOptions ?? defaultLoggerOptions;
+  static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 500;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
@@ -66,11 +59,7 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
       null,
       grpcConfig
     );
-    return new InRegionDefault(
-      finalLoggerOptions,
-      transportStrategy,
-      maxIdleMillis
-    );
+    return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
   }
 }
 

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -11,7 +11,6 @@ import * as CacheDelete from './messages/responses/cache-delete';
 import * as CacheSet from './messages/responses/cache-set';
 import {getLogger, initializeMomentoLogging, Logger} from './utils/logging';
 import * as CacheSetFetch from './messages/responses/cache-set-fetch';
-import {getLogger, Logger} from './utils/logging';
 import {range} from './utils/collections';
 import {Configuration} from './config/configuration';
 import {CredentialProvider} from './auth/credential-provider';

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -9,6 +9,7 @@ import * as RevokeSigningKey from './messages/responses/revoke-signing-key';
 import * as CacheGet from './messages/responses/cache-get';
 import * as CacheDelete from './messages/responses/cache-delete';
 import * as CacheSet from './messages/responses/cache-set';
+import {getLogger, initializeMomentoLogging, Logger} from './utils/logging';
 import * as CacheSetFetch from './messages/responses/cache-set-fetch';
 import {getLogger, Logger} from './utils/logging';
 import {range} from './utils/collections';
@@ -38,6 +39,7 @@ export class SimpleCacheClient {
    * Creates an instance of SimpleCacheClient.
    */
   constructor(props: SimpleCacheClientProps) {
+    initializeMomentoLogging(props.configuration.getLoggerOptions());
     this.logger = getLogger(this);
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;


### PR DESCRIPTION
When we initially introduced the new Configuration objects, we temporarily removed the plumbing that would allow users to configure logging.  This commit adds the logging configuration back to the Configuration interface and ensures that logging is initialized during client construction.