### PR TITLE
chore: fill in JSDocs for public APIs, other minor cleanups

### DIFF
--- a/integration/simple-cache-client.test.ts
+++ b/integration/simple-cache-client.test.ts
@@ -224,7 +224,7 @@ describe('SimpleCacheClient.ts Integration Tests', () => {
     const defaultTimeoutClient = momento;
     const shortTimeoutTransportStrategy = configuration
       .getTransportStrategy()
-      .withClientTimeout(1);
+      .withClientTimeoutMillis(1);
     const shortTimeoutConfiguration = configuration.withTransportStrategy(
       shortTimeoutTransportStrategy
     );

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,29 +1,47 @@
 import {decodeJwt} from '../utils/jwt';
 
+/**
+ * Provides information that the SimpleCacheClient needs in order to establish a connection to and authenticate with
+ * the Momento service.
+ * @export
+ * @interface CredentialProvider
+ */
 export interface CredentialProvider {
+  /**
+   * @returns {string} Auth token provided by user, required to authenticate with the service
+   */
   getAuthToken(): string;
 
+  /**
+   * @returns {string} The host which the Momento client will connect to for Momento control plane operations
+   */
   getControlEndpoint(): string;
 
+  /**
+   * @returns {string} The host which the Momento client will connect to for Momento data plane operations
+   */
   getCacheEndpoint(): string;
-
-  getTrustedControlEndpointCertificateName(): string | null;
-
-  getTrustedCacheEndpointCertificateName(): string | null;
 }
 
+/**
+ * Reads and parses a momento auth token stored as an environment variable.
+ * @export
+ * @class EnvMomentoTokenProvider
+ */
 export class EnvMomentoTokenProvider implements CredentialProvider {
   private readonly authToken: string;
   private readonly controlEndpoint: string;
   private readonly cacheEndpoint: string;
-  private readonly trustedControlEndpointCertificateName: string | null;
-  private readonly trustedCacheEndpointCertificateName: string | null;
+
+  /**
+   * @param {string} envVariableName the name of the environment variable from which the auth token will be read
+   * @param {string} [controlEndpoint] optionally overrides the default controlEndpoint
+   * @param {string} [cacheEndpoint] optionally overrides the default cacheEndpoint
+   */
   constructor(
     envVariableName: string,
-    controlEndpoint?: string | null,
-    cacheEndpoint?: string | null,
-    trustedControlEndpointCertificateName?: string | null,
-    trustedCacheEndpointCertificateName?: string | null
+    controlEndpoint?: string,
+    cacheEndpoint?: string
   ) {
     const authToken = process.env[envVariableName];
     if (!authToken) {
@@ -35,10 +53,6 @@ export class EnvMomentoTokenProvider implements CredentialProvider {
     const claims = decodeJwt(authToken);
     this.controlEndpoint = controlEndpoint ?? claims.cp;
     this.cacheEndpoint = cacheEndpoint ?? claims.c;
-    this.trustedCacheEndpointCertificateName =
-      trustedCacheEndpointCertificateName || null;
-    this.trustedControlEndpointCertificateName =
-      trustedControlEndpointCertificateName || null;
   }
 
   getAuthToken(): string {
@@ -51,13 +65,5 @@ export class EnvMomentoTokenProvider implements CredentialProvider {
 
   getControlEndpoint(): string {
     return this.controlEndpoint;
-  }
-
-  getTrustedControlEndpointCertificateName(): string | null {
-    return this.trustedControlEndpointCertificateName;
-  }
-
-  getTrustedCacheEndpointCertificateName(): string | null {
-    return this.trustedCacheEndpointCertificateName;
   }
 }

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,16 +1,49 @@
 import {TransportStrategy} from './transport/transport-strategy';
 import {LoggerOptions} from '../utils/logging';
 
+/**
+ * Configuration options for Momento Simple Cache client.
+ *
+ * @export
+ * @interface Configuration
+ */
 export interface Configuration {
   // TODO: add RetryStrategy
   // TODO: add Middlewares
+  /**
+   * @returns {LoggerOptions} the current configuration options for logging verbosity and format
+   */
   getLoggerOptions(): LoggerOptions;
+
+  /**
+   * Copy constructor for overriding LoggerOptions
+   * @param {LoggerOptions} loggerOptions
+   * @returns {Configuration} a new Configuration object with the specified LoggerOptions
+   */
   withLoggerOptions(loggerOptions: LoggerOptions): Configuration;
+
+  /**
+   * @returns {TransportStrategy} the current configuration options for wire interactions with the Momento service
+   */
   getTransportStrategy(): TransportStrategy;
+
+  /**
+   * Copy constructor for overriding TransportStrategy
+   * @param {TransportStrategy} transportStrategy
+   * @returns {Configuration} a new Configuration object with the specified TransportStrategy
+   */
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration;
+  // TODO: move idle millis into transport strategy
   getMaxIdleMillis(): number;
+  // TODO: move idle millis into transport strategy
   withMaxIdleMillis(maxIdleMillis: number): Configuration;
-  withClientTimeout(clientTimeout: number): Configuration;
+
+  /**
+   * Convenience copy constructor that updates the client-side timeout setting in the TransportStrategy
+   * @param {number} clientTimeoutMillis
+   * @returns {Configuration} a new Configuration object with its TransportStrategy updated to use the specified client timeout
+   */
+  withClientTimeoutMillis(clientTimeoutMillis: number): Configuration;
 }
 
 export class SimpleCacheConfiguration implements Configuration {
@@ -64,10 +97,10 @@ export class SimpleCacheConfiguration implements Configuration {
     );
   }
 
-  withClientTimeout(clientTimeout: number): Configuration {
+  withClientTimeoutMillis(clientTimeout: number): Configuration {
     return new SimpleCacheConfiguration(
       this.loggerOptions,
-      this.transportStrategy.withClientTimeout(clientTimeout),
+      this.transportStrategy.withClientTimeoutMillis(clientTimeout),
       this.maxIdleMillis
     );
   }

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -15,7 +15,18 @@ const defaultLoggerOptions: LoggerOptions = {
   format: LogFormat.CONSOLE,
 };
 
+/**
+ * Laptop config provides defaults suitable for a medium-to-high-latency dev environment.  Permissive timeouts, retries, and
+ * relaxed latency and throughput targets.
+ * @export
+ * @class Laptop
+ */
 export class Laptop extends SimpleCacheConfiguration {
+  /**
+   * Provides the latest recommended configuration for a laptop development environment.
+   * @param {LoggerOptions} [loggerOptions=defaultLoggerOptions]  if no options are provided, a sensible default will be used
+   * @returns {Laptop}
+   */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 5000;
@@ -24,7 +35,6 @@ export class Laptop extends SimpleCacheConfiguration {
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      null,
       grpcConfig
     );
     return new Laptop(loggerOptions, transportStrategy, maxIdleMillis);
@@ -32,6 +42,13 @@ export class Laptop extends SimpleCacheConfiguration {
 }
 
 class InRegionDefault extends SimpleCacheConfiguration {
+  /**
+   * Provides the latest recommended configuration for a low-latency in-region
+   * environment.
+   *
+   * @param {LoggerOptions} [loggerOptions=defaultLoggerOptions]  if no options are provided, a sensible default will be used
+   * @returns {InRegionDefault}
+   */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 1100;
@@ -40,7 +57,6 @@ class InRegionDefault extends SimpleCacheConfiguration {
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      null,
       grpcConfig
     );
     return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
@@ -48,6 +64,11 @@ class InRegionDefault extends SimpleCacheConfiguration {
 }
 
 class InRegionLowLatency extends SimpleCacheConfiguration {
+  /**
+   * Provides the latest recommended configuration for an InRegion environment.
+   * @param {LoggerOptions} [loggerOptions=defaultLoggerOptions]  if no options are provided, a sensible default will be used
+   * @returns {InRegionLowLatency}
+   */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
     const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 500;
@@ -56,14 +77,31 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      null,
       grpcConfig
     );
     return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
   }
 }
 
+/**
+ * InRegion provides defaults suitable for an environment where your client is running in the same region as the Momento
+ * service.  It has more aggressive timeouts and retry behavior than the Laptop config.
+ * @export
+ * @class InRegion
+ */
 export class InRegion {
+  /**
+   * This config prioritizes throughput and client resource utilization.  It has a slightly relaxed client-side timeout
+   * setting to maximize throughput.
+   * @type {InRegionDefault}
+   */
   static Default = InRegionDefault;
+  /**
+   * This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
+   * some throughput to achieve this.  It has a very aggressive client-side timeout.  Use this
+   * configuration if the most important factor is to ensure that cache unavailability doesn't force
+   * unacceptably high latencies for your own application.
+   * @type {InRegionLowLatency}
+   */
   static LowLatency = InRegionLowLatency;
 }

--- a/src/config/transport/grpc-configuration.ts
+++ b/src/config/transport/grpc-configuration.ts
@@ -1,6 +1,32 @@
+/**
+ * Encapsulates gRPC configuration tunables.
+ * @export
+ * @interface GrpcConfiguration
+ */
 export interface GrpcConfiguration {
+  /**
+   * @returns {number} number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
+   *    with a DeadlineExceeded error.
+   */
   getDeadlineMilliseconds(): number;
+
+  /**
+   * Copy constructor for overriding the client-side deadline
+   * @param {number} deadlineMilliseconds
+   * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified client-side deadline
+   */
   withDeadlineMilliseconds(deadlineMilliseconds: number): GrpcConfiguration;
-  getMaxSessionMemory(): number;
-  withMaxSessionMemory(maxSessionMemory: number): GrpcConfiguration;
+
+  /**
+   * @returns {number} the maximum amount of memory, in megabytes, that a session is allowed to consume.  Sessions that consume
+   *    more than this amount will return a ResourceExhausted error.
+   */
+  getMaxSessionMemoryMb(): number;
+
+  /**
+   * Copy constructor for overriding the max session memory
+   * @param {number} maxSessionMemoryMb the desired maximum amount of memory, in megabytes, to allow a client session to consume
+   * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified maximum memory
+   */
+  withMaxSessionMemoryMb(maxSessionMemoryMb: number): GrpcConfiguration;
 }

--- a/src/config/transport/transport-strategy.ts
+++ b/src/config/transport/transport-strategy.ts
@@ -1,16 +1,31 @@
 import {GrpcConfiguration} from './grpc-configuration';
 
+/**
+ * Configures the network options for communicating with the Momento service.
+ * @export
+ * @interface TransportStrategy
+ */
 export interface TransportStrategy {
-  getMaxConcurrentRequests(): number | null;
-
+  /**
+   * Configures the low-level gRPC settings for the Momento client's communication
+   * with the Momento server.
+   * @returns {GrpcConfiguration}
+   */
   getGrpcConfig(): GrpcConfiguration;
 
-  // TODO: for use in middleware
-  withMaxConcurrentRequests(maxConcurrentRequests: number): TransportStrategy;
-
+  /**
+   * Copy constructor for overriding the gRPC configuration
+   * @param {GrpcConfiguration} grpcConfig
+   * @returns {TransportStrategy} a new TransportStrategy with the specified gRPC config.
+   */
   withGrpcConfig(grpcConfig: GrpcConfiguration): TransportStrategy;
 
-  withClientTimeout(clientTimeout: number): TransportStrategy;
+  /**
+   * Copy constructor to update the client-side timeout
+   * @param {number} clientTimeoutMillis
+   * @returns {TransportStrategy} a new TransportStrategy with the specified client timeout
+   */
+  withClientTimeoutMillis(clientTimeoutMillis: number): TransportStrategy;
 }
 
 export class StaticGrpcConfiguration implements GrpcConfiguration {
@@ -25,7 +40,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     return this.deadlineMilliseconds;
   }
 
-  getMaxSessionMemory(): number {
+  getMaxSessionMemoryMb(): number {
     return this.maxSessionMemory;
   }
 
@@ -38,7 +53,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     );
   }
 
-  withMaxSessionMemory(maxSessionMemory: number): StaticGrpcConfiguration {
+  withMaxSessionMemoryMb(maxSessionMemory: number): StaticGrpcConfiguration {
     return new StaticGrpcConfiguration(
       this.deadlineMilliseconds,
       maxSessionMemory
@@ -47,38 +62,22 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
 }
 
 export class StaticTransportStrategy implements TransportStrategy {
-  private readonly maxConcurrentRequests: number | null;
   private readonly grpcConfig: GrpcConfiguration;
 
-  constructor(
-    maxConcurrentRequests: number | null,
-    grpcConfiguration: GrpcConfiguration
-  ) {
-    this.maxConcurrentRequests = maxConcurrentRequests;
+  constructor(grpcConfiguration: GrpcConfiguration) {
     this.grpcConfig = grpcConfiguration;
-  }
-
-  getMaxConcurrentRequests(): number | null {
-    return this.maxConcurrentRequests;
   }
 
   getGrpcConfig(): GrpcConfiguration {
     return this.grpcConfig;
   }
 
-  withMaxConcurrentRequests(
-    maxConcurrentRequests: number
-  ): StaticTransportStrategy {
-    return new StaticTransportStrategy(maxConcurrentRequests, this.grpcConfig);
-  }
-
   withGrpcConfig(grpcConfig: GrpcConfiguration): StaticTransportStrategy {
-    return new StaticTransportStrategy(this.maxConcurrentRequests, grpcConfig);
+    return new StaticTransportStrategy(grpcConfig);
   }
 
-  withClientTimeout(clientTimeout: number): StaticTransportStrategy {
+  withClientTimeoutMillis(clientTimeout: number): StaticTransportStrategy {
     return new StaticTransportStrategy(
-      this.maxConcurrentRequests,
       this.grpcConfig.withDeadlineMilliseconds(clientTimeout)
     );
   }

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -34,8 +34,8 @@ export enum MomentoErrorCode {
 export class MomentoGrpcErrorDetails {
   public readonly code: number;
   public readonly details: string;
-  public readonly metadata: object | null;
-  constructor(code: number, details: string, metadata: object | null) {
+  public readonly metadata?: object;
+  constructor(code: number, details: string, metadata?: object) {
     this.code = code;
     this.details = details;
     this.metadata = metadata;
@@ -59,8 +59,8 @@ export abstract class SdkError extends Error {
   constructor(
     message: string,
     code = 0,
-    metadata: object | null = null,
-    stack: string | null = null
+    metadata: object | undefined = undefined,
+    stack: string | undefined = undefined
   ) {
     super(message);
     const grpcDetails = new MomentoGrpcErrorDetails(code, message, metadata);

--- a/src/messages/responses/list-caches.ts
+++ b/src/messages/responses/list-caches.ts
@@ -7,11 +7,11 @@ import {applyMixins, ErrorBody} from '../../errors/error-utils';
 export abstract class Response extends ResponseBase {}
 
 export class Success extends Response {
-  private readonly nextToken: string | null;
+  private readonly nextToken?: string;
   private readonly caches: CacheInfo[];
   constructor(result?: control.control_client._ListCachesResponse) {
     super();
-    this.nextToken = result?.next_token || null;
+    this.nextToken = result?.next_token;
     if (result) {
       this.caches = result.cache.map(cache => new CacheInfo(cache.cache_name));
     }

--- a/src/messages/responses/list-signing-keys.ts
+++ b/src/messages/responses/list-signing-keys.ts
@@ -7,7 +7,7 @@ import {applyMixins, ErrorBody} from '../../errors/error-utils';
 export abstract class Response extends ResponseBase {}
 
 export class Success extends Response {
-  private readonly nextToken: string | null;
+  private readonly nextToken?: string;
   private readonly signingKeys: SigningKey[];
 
   constructor(
@@ -15,7 +15,7 @@ export class Success extends Response {
     result?: control.control_client._ListSigningKeysResponse
   ) {
     super();
-    this.nextToken = result?.next_token || null;
+    this.nextToken = result?.next_token;
     this.signingKeys =
       result?.signing_key.map(
         signingKey =>

--- a/src/simple-cache-client-props.ts
+++ b/src/simple-cache-client-props.ts
@@ -1,14 +1,17 @@
 import {CredentialProvider} from './auth/credential-provider';
 import {Configuration} from './config/configuration';
 
-/**
- * @property {string} authToken - momento jwt token
- * @property {string} endpoint - endpoint to reach momento cache
- * @property {number} defaultTtlSeconds - the default time to live of object inside of cache, in seconds
- * @property {number} requestTimeoutMs - the amount of time for a request to complete before timing out, in milliseconds
- */
 export interface SimpleCacheClientProps {
+  /**
+   * Configuration settings for the cache client
+   */
   configuration: Configuration;
+  /**
+   * controls how the client will get authentication information for connecting to the Momento service
+   */
   credentialProvider: CredentialProvider;
+  /**
+   * the default time to live of object inside of cache, in seconds
+   */
   defaultTtlSeconds: number;
 }

--- a/test/simple-cache-client.test.ts
+++ b/test/simple-cache-client.test.ts
@@ -29,7 +29,7 @@ describe('SimpleCacheClient.ts', () => {
   it('cannot create a client with an invalid request timeout', () => {
     try {
       const invalidTimeoutConfig = configuration.withTransportStrategy(
-        configuration.getTransportStrategy().withClientTimeout(-1)
+        configuration.getTransportStrategy().withClientTimeoutMillis(-1)
       );
       new SimpleCacheClient({
         configuration: invalidTimeoutConfig,


### PR DESCRIPTION
* First pass at adding missing JSDocs for public APIs
* Removes unused fields (maxConcurrentRequests, certname fields) until we need them
* Renames some duration/size fields to be suffixed with their respective units of measurement
* Migrates places where we were using `| null` to `| undefined` as appropriate