### PR TITLE
chore: add warning about preview APIs for collections

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,5 +1,14 @@
 {{ ossHeader }}
 
+## Preview Features
+
+This SDK contains APIs for interacting with collection data structures: Lists, Sets, and Dictionaries.  These APIs
+are currently in preview.  If you would like to request early access to the data structure APIs, please contact us
+at `support@momentohq.com`.
+
+**Note that if you call the List, Set, or Dictionary APIs without first signing up for our early access preview, you
+the calls will result in an `Unsupported operation` error.**
+
 ## Getting Started :running:
 
 ### Requirements


### PR DESCRIPTION
We need to make it clear on the README that there are now APIs in here that you can't use without signing up for the preview features.