### PR TITLE
refactor: Make it clearer what cache.cache_client is.

### DIFF
--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -1,4 +1,5 @@
 import {cache} from '@gomomento/generated-types';
+import grpcCache = cache.cache_client;
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
 import {TextEncoder} from 'util';
 import {Header, HeaderInterceptor} from '../grpc/headers-interceptor';
@@ -27,7 +28,7 @@ import {Configuration} from '../config/configuration';
 import {SimpleCacheClientProps} from '../simple-cache-client-props';
 
 export class CacheClient {
-  private readonly clientWrapper: GrpcClientWrapper<cache.cache_client.ScsClient>;
+  private readonly clientWrapper: GrpcClientWrapper<grpcCache.ScsClient>;
   private readonly textEncoder: TextEncoder;
   private readonly configuration: Configuration;
   private readonly credentialProvider: CredentialProvider;
@@ -58,7 +59,7 @@ export class CacheClient {
 
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
-        new cache.cache_client.ScsClient(
+        new grpcCache.ScsClient(
           this.credentialProvider.getCacheEndpoint(),
           ChannelCredentials.createSsl(),
           {
@@ -129,7 +130,7 @@ export class CacheClient {
     value: Uint8Array,
     ttl: number
   ): Promise<CacheSet.Response> {
-    const request = new cache.cache_client._SetRequest({
+    const request = new grpcCache._SetRequest({
       cache_body: value,
       cache_key: key,
       ttl_milliseconds: ttl * 1000,
@@ -167,7 +168,7 @@ export class CacheClient {
     cacheName: string,
     setName: Uint8Array
   ): Promise<CacheSetFetch.Response> {
-    const request = new cache.cache_client._SetFetchRequest({
+    const request = new grpcCache._SetFetchRequest({
       set_name: setName,
     });
     const metadata = this.createMetadata(cacheName);
@@ -209,7 +210,7 @@ export class CacheClient {
     cacheName: string,
     key: Uint8Array
   ): Promise<CacheDelete.Response> {
-    const request = new cache.cache_client._DeleteRequest({
+    const request = new grpcCache._DeleteRequest({
       cache_key: key,
     });
     const metadata = this.createMetadata(cacheName);
@@ -251,7 +252,7 @@ export class CacheClient {
     cacheName: string,
     key: Uint8Array
   ): Promise<CacheGet.Response> {
-    const request = new cache.cache_client._GetRequest({
+    const request = new grpcCache._GetRequest({
       cache_key: key,
     });
     const metadata = this.createMetadata(cacheName);
@@ -266,14 +267,14 @@ export class CacheClient {
         (err, resp) => {
           if (resp) {
             switch (resp.result) {
-              case cache.cache_client.ECacheResult.Miss:
+              case grpcCache.ECacheResult.Miss:
                 resolve(new CacheGet.Miss());
                 break;
-              case cache.cache_client.ECacheResult.Hit:
+              case grpcCache.ECacheResult.Hit:
                 resolve(new CacheGet.Hit(resp.cache_body));
                 break;
-              case cache.cache_client.ECacheResult.Invalid:
-              case cache.cache_client.ECacheResult.Ok:
+              case grpcCache.ECacheResult.Invalid:
+              case grpcCache.ECacheResult.Ok:
                 resolve(new CacheGet.Error(new UnknownError(resp.message)));
                 break;
               default:

--- a/src/internal/control-client.ts
+++ b/src/internal/control-client.ts
@@ -1,4 +1,5 @@
 import {control} from '@gomomento/generated-types';
+import grpcControl = control.control_client;
 import {Header, HeaderInterceptor} from '../grpc/headers-interceptor';
 import {ClientTimeoutInterceptor} from '../grpc/client-timeout-interceptor';
 import {createRetryInterceptorIfEnabled} from '../grpc/retry-interceptor';
@@ -26,7 +27,7 @@ export interface ControlClientProps {
 }
 
 export class ControlClient {
-  private readonly clientWrapper: GrpcClientWrapper<control.control_client.ScsControlClient>;
+  private readonly clientWrapper: GrpcClientWrapper<grpcControl.ScsControlClient>;
   private readonly interceptors: Interceptor[];
   private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
   private readonly logger: Logger;
@@ -50,7 +51,7 @@ export class ControlClient {
     );
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
-        new control.control_client.ScsControlClient(
+        new grpcControl.ScsControlClient(
           props.credentialProvider.getControlEndpoint(),
           ChannelCredentials.createSsl()
         ),
@@ -65,7 +66,7 @@ export class ControlClient {
       return new CreateCache.Error(normalizeSdkError(err as Error));
     }
     this.logger.info(`Creating cache: ${name}`);
-    const request = new control.control_client._CreateCacheRequest({
+    const request = new grpcControl._CreateCacheRequest({
       cache_name: name,
     });
     return await new Promise<CreateCache.Response>(resolve => {
@@ -94,7 +95,7 @@ export class ControlClient {
     } catch (err) {
       return new DeleteCache.Error(normalizeSdkError(err as Error));
     }
-    const request = new control.control_client._DeleteCacheRequest({
+    const request = new grpcControl._DeleteCacheRequest({
       cache_name: name,
     });
     this.logger.info(`Deleting cache: ${name}`);
@@ -115,7 +116,7 @@ export class ControlClient {
   }
 
   public async listCaches(nextToken?: string): Promise<ListCaches.Response> {
-    const request = new control.control_client._ListCachesRequest();
+    const request = new grpcControl._ListCachesRequest();
     request.next_token = nextToken ?? '';
     this.logger.debug("Issuing 'listCaches' request");
     return await new Promise<ListCaches.Response>(resolve => {
@@ -141,7 +142,7 @@ export class ControlClient {
       return new CreateSigningKey.Error(normalizeSdkError(err as Error));
     }
     this.logger.debug("Issuing 'createSigningKey' request");
-    const request = new control.control_client._CreateSigningKeyRequest();
+    const request = new grpcControl._CreateSigningKeyRequest();
     request.ttl_minutes = ttlMinutes;
     return await new Promise<CreateSigningKey.Response>(resolve => {
       this.clientWrapper
@@ -163,7 +164,7 @@ export class ControlClient {
   public async revokeSigningKey(
     keyId: string
   ): Promise<RevokeSigningKey.Response> {
-    const request = new control.control_client._RevokeSigningKeyRequest();
+    const request = new grpcControl._RevokeSigningKeyRequest();
     request.key_id = keyId;
     this.logger.debug("Issuing 'revokeSigningKey' request");
     return await new Promise<RevokeSigningKey.Response>(resolve => {
@@ -183,7 +184,7 @@ export class ControlClient {
     endpoint: string,
     nextToken?: string
   ): Promise<ListSigningKeys.Response> {
-    const request = new control.control_client._ListSigningKeysRequest();
+    const request = new grpcControl._ListSigningKeysRequest();
     request.next_token = nextToken ?? '';
     this.logger.debug("Issuing 'listSigningKeys' request");
     return await new Promise<ListSigningKeys.Response>(resolve => {


### PR DESCRIPTION
It was unclear to me that cache.cache_client and control.control_client are GRPC types. They can be confused with the actual client objects.