### PR TITLE
chore: move max idle millis setting into transport strategy

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,6 +1,17 @@
 import {TransportStrategy} from './transport/transport-strategy';
 import {LoggerOptions} from '../utils/logging';
 
+export interface ConfigurationProps {
+  /**
+   * Configures logging verbosity and format
+   */
+  loggerOptions: LoggerOptions;
+  /**
+   * Configures low-level options for network interactions with the Momento service
+   */
+  transportStrategy: TransportStrategy;
+}
+
 /**
  * Configuration options for Momento Simple Cache client.
  *
@@ -46,12 +57,9 @@ export class SimpleCacheConfiguration implements Configuration {
   private readonly loggerOptions: LoggerOptions;
   private readonly transportStrategy: TransportStrategy;
 
-  constructor(
-    loggerOptions: LoggerOptions,
-    transportStrategy: TransportStrategy
-  ) {
-    this.loggerOptions = loggerOptions;
-    this.transportStrategy = transportStrategy;
+  constructor(props: ConfigurationProps) {
+    this.loggerOptions = props.loggerOptions;
+    this.transportStrategy = props.transportStrategy;
   }
 
   getLoggerOptions(): LoggerOptions {
@@ -63,17 +71,24 @@ export class SimpleCacheConfiguration implements Configuration {
   }
 
   withLoggerOptions(loggerOptions: LoggerOptions): Configuration {
-    return new SimpleCacheConfiguration(loggerOptions, this.transportStrategy);
+    return new SimpleCacheConfiguration({
+      loggerOptions: loggerOptions,
+      transportStrategy: this.transportStrategy,
+    });
   }
 
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration {
-    return new SimpleCacheConfiguration(this.loggerOptions, transportStrategy);
+    return new SimpleCacheConfiguration({
+      loggerOptions: this.loggerOptions,
+      transportStrategy: transportStrategy,
+    });
   }
 
   withClientTimeoutMillis(clientTimeout: number): Configuration {
-    return new SimpleCacheConfiguration(
-      this.loggerOptions,
-      this.transportStrategy.withClientTimeoutMillis(clientTimeout)
-    );
+    return new SimpleCacheConfiguration({
+      loggerOptions: this.loggerOptions,
+      transportStrategy:
+        this.transportStrategy.withClientTimeoutMillis(clientTimeout),
+    });
   }
 }

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -33,10 +33,6 @@ export interface Configuration {
    * @returns {Configuration} a new Configuration object with the specified TransportStrategy
    */
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration;
-  // TODO: move idle millis into transport strategy
-  getMaxIdleMillis(): number;
-  // TODO: move idle millis into transport strategy
-  withMaxIdleMillis(maxIdleMillis: number): Configuration;
 
   /**
    * Convenience copy constructor that updates the client-side timeout setting in the TransportStrategy
@@ -49,16 +45,13 @@ export interface Configuration {
 export class SimpleCacheConfiguration implements Configuration {
   private readonly loggerOptions: LoggerOptions;
   private readonly transportStrategy: TransportStrategy;
-  private readonly maxIdleMillis: number;
 
   constructor(
     loggerOptions: LoggerOptions,
-    transportStrategy: TransportStrategy,
-    maxIdleMillis: number
+    transportStrategy: TransportStrategy
   ) {
     this.loggerOptions = loggerOptions;
     this.transportStrategy = transportStrategy;
-    this.maxIdleMillis = maxIdleMillis;
   }
 
   getLoggerOptions(): LoggerOptions {
@@ -69,39 +62,18 @@ export class SimpleCacheConfiguration implements Configuration {
     return this.transportStrategy;
   }
 
-  getMaxIdleMillis(): number {
-    return this.maxIdleMillis;
-  }
-
   withLoggerOptions(loggerOptions: LoggerOptions): Configuration {
-    return new SimpleCacheConfiguration(
-      loggerOptions,
-      this.transportStrategy,
-      this.maxIdleMillis
-    );
+    return new SimpleCacheConfiguration(loggerOptions, this.transportStrategy);
   }
 
   withTransportStrategy(transportStrategy: TransportStrategy): Configuration {
-    return new SimpleCacheConfiguration(
-      this.loggerOptions,
-      transportStrategy,
-      this.maxIdleMillis
-    );
-  }
-
-  withMaxIdleMillis(maxIdleMillis: number) {
-    return new SimpleCacheConfiguration(
-      this.loggerOptions,
-      this.transportStrategy,
-      maxIdleMillis
-    );
+    return new SimpleCacheConfiguration(this.loggerOptions, transportStrategy);
   }
 
   withClientTimeoutMillis(clientTimeout: number): Configuration {
     return new SimpleCacheConfiguration(
       this.loggerOptions,
-      this.transportStrategy.withClientTimeoutMillis(clientTimeout),
-      this.maxIdleMillis
+      this.transportStrategy.withClientTimeoutMillis(clientTimeout)
     );
   }
 }

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -28,16 +28,16 @@ export class Laptop extends SimpleCacheConfiguration {
    * @returns {Laptop}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 5000;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
       deadlineMilliseconds,
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig
+      grpcConfig,
+      defaultMaxIdleMillis
     );
-    return new Laptop(loggerOptions, transportStrategy, maxIdleMillis);
+    return new Laptop(loggerOptions, transportStrategy);
   }
 }
 
@@ -50,16 +50,16 @@ class InRegionDefault extends SimpleCacheConfiguration {
    * @returns {InRegionDefault}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 1100;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
       deadlineMilliseconds,
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig
+      grpcConfig,
+      defaultMaxIdleMillis
     );
-    return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
+    return new InRegionDefault(loggerOptions, transportStrategy);
   }
 }
 
@@ -70,16 +70,16 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
    * @returns {InRegionLowLatency}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const maxIdleMillis = defaultMaxIdleMillis;
     const deadlineMilliseconds = 500;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
       deadlineMilliseconds,
       defaultMaxSessionMemoryMb
     );
     const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig
+      grpcConfig,
+      defaultMaxIdleMillis
     );
-    return new InRegionDefault(loggerOptions, transportStrategy, maxIdleMillis);
+    return new InRegionDefault(loggerOptions, transportStrategy);
   }
 }
 

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -28,16 +28,19 @@ export class Laptop extends SimpleCacheConfiguration {
    * @returns {Laptop}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const deadlineMilliseconds = 5000;
-    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
-      deadlineMilliseconds,
-      defaultMaxSessionMemoryMb
-    );
-    const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig,
-      defaultMaxIdleMillis
-    );
-    return new Laptop(loggerOptions, transportStrategy);
+    const deadlineMillis = 5000;
+    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+    });
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: defaultMaxIdleMillis,
+    });
+    return new Laptop({
+      loggerOptions: loggerOptions,
+      transportStrategy: transportStrategy,
+    });
   }
 }
 
@@ -50,16 +53,19 @@ class InRegionDefault extends SimpleCacheConfiguration {
    * @returns {InRegionDefault}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const deadlineMilliseconds = 1100;
-    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
-      deadlineMilliseconds,
-      defaultMaxSessionMemoryMb
-    );
-    const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig,
-      defaultMaxIdleMillis
-    );
-    return new InRegionDefault(loggerOptions, transportStrategy);
+    const deadlineMillis = 1100;
+    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+    });
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: defaultMaxIdleMillis,
+    });
+    return new InRegionDefault({
+      loggerOptions: loggerOptions,
+      transportStrategy: transportStrategy,
+    });
   }
 }
 
@@ -70,16 +76,19 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
    * @returns {InRegionLowLatency}
    */
   static latest(loggerOptions: LoggerOptions = defaultLoggerOptions) {
-    const deadlineMilliseconds = 500;
-    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration(
-      deadlineMilliseconds,
-      defaultMaxSessionMemoryMb
-    );
-    const transportStrategy: TransportStrategy = new StaticTransportStrategy(
-      grpcConfig,
-      defaultMaxIdleMillis
-    );
-    return new InRegionDefault(loggerOptions, transportStrategy);
+    const deadlineMillis = 500;
+    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+    });
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: defaultMaxIdleMillis,
+    });
+    return new InRegionDefault({
+      loggerOptions: loggerOptions,
+      transportStrategy: transportStrategy,
+    });
   }
 }
 

--- a/src/config/transport/grpc-configuration.ts
+++ b/src/config/transport/grpc-configuration.ts
@@ -1,3 +1,16 @@
+export interface GrpcConfigurationProps {
+  /**
+   * number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
+   * with a DeadlineExceeded error.
+   */
+  deadlineMillis: number;
+  /**
+   * the maximum amount of memory, in megabytes, that a session is allowed to consume.  Sessions that consume
+   * more than this amount will return a ResourceExhausted error.
+   */
+  maxSessionMemoryMb: number;
+}
+
 /**
  * Encapsulates gRPC configuration tunables.
  * @export
@@ -8,14 +21,14 @@ export interface GrpcConfiguration {
    * @returns {number} number of milliseconds the client is willing to wait for an RPC to complete before it is terminated
    *    with a DeadlineExceeded error.
    */
-  getDeadlineMilliseconds(): number;
+  getDeadlineMillis(): number;
 
   /**
    * Copy constructor for overriding the client-side deadline
-   * @param {number} deadlineMilliseconds
+   * @param {number} deadlineMillis
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified client-side deadline
    */
-  withDeadlineMilliseconds(deadlineMilliseconds: number): GrpcConfiguration;
+  withDeadlineMillis(deadlineMillis: number): GrpcConfiguration;
 
   /**
    * @returns {number} the maximum amount of memory, in megabytes, that a session is allowed to consume.  Sessions that consume

--- a/src/config/transport/transport-strategy.ts
+++ b/src/config/transport/transport-strategy.ts
@@ -1,4 +1,21 @@
-import {GrpcConfiguration} from './grpc-configuration';
+import {GrpcConfiguration, GrpcConfigurationProps} from './grpc-configuration';
+
+export interface TransportStrategyProps {
+  /**
+   * low-level gRPC settings for communication with the Momento server
+   */
+  grpcConfiguration: GrpcConfiguration;
+  /**
+   * The maximum duration for which a connection may remain idle before being replaced.  This
+   * setting can be used to force re-connection of a client if it has been idle for too long.
+   * In environments such as AWS lambda, if the lambda is suspended for too long the connection
+   * may be closed by the load balancer, resulting in an error on the subsequent request.  If
+   * this setting is set to a duration less than the load balancer timeout, we can ensure that
+   * the connection will be refreshed to avoid errors.
+   * @returns {number}
+   */
+  maxIdleMillis: number;
+}
 
 /**
  * Configures the network options for communicating with the Momento service.
@@ -47,35 +64,33 @@ export interface TransportStrategy {
 }
 
 export class StaticGrpcConfiguration implements GrpcConfiguration {
-  private readonly deadlineMilliseconds: number;
-  private readonly maxSessionMemory: number;
-  constructor(deadlineMilliseconds: number, maxSessionMemory: number) {
-    this.deadlineMilliseconds = deadlineMilliseconds;
-    this.maxSessionMemory = maxSessionMemory;
+  private readonly deadlineMillis: number;
+  private readonly maxSessionMemoryMb: number;
+  constructor(props: GrpcConfigurationProps) {
+    this.deadlineMillis = props.deadlineMillis;
+    this.maxSessionMemoryMb = props.maxSessionMemoryMb;
   }
 
-  getDeadlineMilliseconds(): number {
-    return this.deadlineMilliseconds;
+  getDeadlineMillis(): number {
+    return this.deadlineMillis;
   }
 
   getMaxSessionMemoryMb(): number {
-    return this.maxSessionMemory;
+    return this.maxSessionMemoryMb;
   }
 
-  withDeadlineMilliseconds(
-    deadlineMilliseconds: number
-  ): StaticGrpcConfiguration {
-    return new StaticGrpcConfiguration(
-      deadlineMilliseconds,
-      this.maxSessionMemory
-    );
+  withDeadlineMillis(deadlineMillis: number): StaticGrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: this.maxSessionMemoryMb,
+    });
   }
 
-  withMaxSessionMemoryMb(maxSessionMemory: number): StaticGrpcConfiguration {
-    return new StaticGrpcConfiguration(
-      this.deadlineMilliseconds,
-      maxSessionMemory
-    );
+  withMaxSessionMemoryMb(maxSessionMemoryMb: number): StaticGrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      deadlineMillis: this.deadlineMillis,
+      maxSessionMemoryMb: maxSessionMemoryMb,
+    });
   }
 }
 
@@ -83,9 +98,9 @@ export class StaticTransportStrategy implements TransportStrategy {
   private readonly grpcConfig: GrpcConfiguration;
   private readonly maxIdleMillis: number;
 
-  constructor(grpcConfiguration: GrpcConfiguration, maxIdleMillis: number) {
-    this.grpcConfig = grpcConfiguration;
-    this.maxIdleMillis = maxIdleMillis;
+  constructor(props: TransportStrategyProps) {
+    this.grpcConfig = props.grpcConfiguration;
+    this.maxIdleMillis = props.maxIdleMillis;
   }
 
   getGrpcConfig(): GrpcConfiguration {
@@ -93,7 +108,10 @@ export class StaticTransportStrategy implements TransportStrategy {
   }
 
   withGrpcConfig(grpcConfig: GrpcConfiguration): StaticTransportStrategy {
-    return new StaticTransportStrategy(grpcConfig, this.maxIdleMillis);
+    return new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: this.maxIdleMillis,
+    });
   }
 
   getMaxIdleMillis(): number {
@@ -101,13 +119,16 @@ export class StaticTransportStrategy implements TransportStrategy {
   }
 
   withMaxIdleMillis(maxIdleMillis: number): TransportStrategy {
-    return new StaticTransportStrategy(this.grpcConfig, maxIdleMillis);
+    return new StaticTransportStrategy({
+      grpcConfiguration: this.grpcConfig,
+      maxIdleMillis: maxIdleMillis,
+    });
   }
 
   withClientTimeoutMillis(clientTimeout: number): StaticTransportStrategy {
-    return new StaticTransportStrategy(
-      this.grpcConfig.withDeadlineMilliseconds(clientTimeout),
-      this.maxIdleMillis
-    );
+    return new StaticTransportStrategy({
+      grpcConfiguration: this.grpcConfig.withDeadlineMillis(clientTimeout),
+      maxIdleMillis: this.maxIdleMillis,
+    });
   }
 }

--- a/src/grpc/idle-grpc-client-wrapper.ts
+++ b/src/grpc/idle-grpc-client-wrapper.ts
@@ -38,7 +38,9 @@ export class IdleGrpcClientWrapper<T extends CloseableGrpcClient>
     this.logger = getLogger(this);
     this.clientFactoryFn = props.clientFactoryFn;
     this.client = this.clientFactoryFn();
-    this.maxIdleMillis = props.configuration.getMaxIdleMillis();
+    this.maxIdleMillis = props.configuration
+      .getTransportStrategy()
+      .getMaxIdleMillis();
     this.lastAccessTime = Date.now();
   }
 

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -54,8 +54,7 @@ export class CacheClient {
       .getGrpcConfig();
 
     this.requestTimeoutMs =
-      grpcConfig.getDeadlineMilliseconds() ||
-      CacheClient.DEFAULT_REQUEST_TIMEOUT_MS;
+      grpcConfig.getDeadlineMillis() || CacheClient.DEFAULT_REQUEST_TIMEOUT_MS;
     this.validateRequestTimeout(this.requestTimeoutMs);
     this.logger.debug(
       `Creating cache client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`

--- a/test/config/configuration.test.ts
+++ b/test/config/configuration.test.ts
@@ -1,0 +1,80 @@
+import {SimpleCacheConfiguration} from '../../src/config/configuration';
+import {LogFormat, LoggerOptions, LogLevel} from '../../src';
+import {
+  StaticGrpcConfiguration,
+  StaticTransportStrategy,
+} from '../../src/config/transport/transport-strategy';
+
+describe('configuration.ts', () => {
+  const testLoggerOptions: LoggerOptions = {
+    level: LogLevel.WARN,
+    format: LogFormat.CONSOLE,
+  };
+  const testGrpcConfiguration = new StaticGrpcConfiguration({
+    deadlineMillis: 90210,
+    maxSessionMemoryMb: 90211,
+  });
+  const testMaxIdleMillis = 90212;
+  const testTransportStrategy = new StaticTransportStrategy({
+    grpcConfiguration: testGrpcConfiguration,
+    maxIdleMillis: testMaxIdleMillis,
+  });
+  const testConfiguration = new SimpleCacheConfiguration({
+    loggerOptions: testLoggerOptions,
+    transportStrategy: testTransportStrategy,
+  });
+
+  it('should support overriding logger options', () => {
+    const newLoggerOptions = {
+      level: LogLevel.DEBUG,
+      format: LogFormat.JSON,
+    };
+    const configWithNewLoggerOptions =
+      testConfiguration.withLoggerOptions(newLoggerOptions);
+    expect(configWithNewLoggerOptions.getLoggerOptions()).toEqual(
+      newLoggerOptions
+    );
+    expect(configWithNewLoggerOptions.getTransportStrategy()).toEqual(
+      testTransportStrategy
+    );
+  });
+
+  it('should support overriding transport strategy', () => {
+    const newGrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: 5000,
+      maxSessionMemoryMb: 5001,
+    });
+    const newMaxIdleMillis = 5002;
+    const newTransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: newGrpcConfiguration,
+      maxIdleMillis: newMaxIdleMillis,
+    });
+    const configWithNewTransportStrategy =
+      testConfiguration.withTransportStrategy(newTransportStrategy);
+    expect(configWithNewTransportStrategy.getLoggerOptions()).toEqual(
+      testLoggerOptions
+    );
+    expect(configWithNewTransportStrategy.getTransportStrategy()).toEqual(
+      newTransportStrategy
+    );
+  });
+
+  it('should support overriding client timeout in transport strategy', () => {
+    const newClientTimeoutMillis = 42;
+    const expectedTransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: new StaticGrpcConfiguration({
+        deadlineMillis: newClientTimeoutMillis,
+        maxSessionMemoryMb: testGrpcConfiguration.getMaxSessionMemoryMb(),
+      }),
+      maxIdleMillis: testMaxIdleMillis,
+    });
+    const configWithNewClientTimeout =
+      testConfiguration.withClientTimeoutMillis(newClientTimeoutMillis);
+    expect(configWithNewClientTimeout.getLoggerOptions()).toEqual(
+      testLoggerOptions
+    );
+    expect(configWithNewClientTimeout.getTransportStrategy()).toEqual(
+      expectedTransportStrategy
+    );
+  });
+});

--- a/test/config/transport/transport-strategy.test.ts
+++ b/test/config/transport/transport-strategy.test.ts
@@ -1,0 +1,95 @@
+import {
+  StaticGrpcConfiguration,
+  StaticTransportStrategy,
+} from '../../../src/config/transport/transport-strategy';
+
+describe('StaticGrpcConfiguration', () => {
+  const testDeadlineMillis = 90210;
+  const testMaxSessionMemoryMb = 90211;
+  const testGrpcConfiguration = new StaticGrpcConfiguration({
+    deadlineMillis: testDeadlineMillis,
+    maxSessionMemoryMb: testMaxSessionMemoryMb,
+  });
+
+  it('should support overriding deadline millis', () => {
+    const newDeadlineMillis = 42;
+    const configWithNewDeadline =
+      testGrpcConfiguration.withDeadlineMillis(newDeadlineMillis);
+    expect(configWithNewDeadline.getDeadlineMillis()).toEqual(
+      newDeadlineMillis
+    );
+    expect(configWithNewDeadline.getMaxSessionMemoryMb()).toEqual(
+      testMaxSessionMemoryMb
+    );
+  });
+
+  it('should support overriding max session memory', () => {
+    const newMaxSessionMemory = 42;
+    const configWithNewMaxSessionMemory =
+      testGrpcConfiguration.withMaxSessionMemoryMb(newMaxSessionMemory);
+    expect(configWithNewMaxSessionMemory.getDeadlineMillis()).toEqual(
+      testDeadlineMillis
+    );
+    expect(configWithNewMaxSessionMemory.getMaxSessionMemoryMb()).toEqual(
+      newMaxSessionMemory
+    );
+  });
+});
+
+describe('StaticTransportStrategy', () => {
+  const testDeadlineMillis = 90210;
+  const testMaxSessionMemoryMb = 90211;
+  const testGrpcConfiguration = new StaticGrpcConfiguration({
+    deadlineMillis: testDeadlineMillis,
+    maxSessionMemoryMb: testMaxSessionMemoryMb,
+  });
+
+  const testMaxIdleMillis = 90212;
+  const testTransportStrategy = new StaticTransportStrategy({
+    grpcConfiguration: testGrpcConfiguration,
+    maxIdleMillis: testMaxIdleMillis,
+  });
+
+  it('should support overriding grpc config', () => {
+    const newDeadlineMillis = 42;
+    const newMaxSessionMemoryMb = 43;
+    const newGrpcConfig = new StaticGrpcConfiguration({
+      deadlineMillis: newDeadlineMillis,
+      maxSessionMemoryMb: newMaxSessionMemoryMb,
+    });
+    const strategyWithNewGrpcConfig =
+      testTransportStrategy.withGrpcConfig(newGrpcConfig);
+    expect(strategyWithNewGrpcConfig.getGrpcConfig()).toEqual(newGrpcConfig);
+    expect(strategyWithNewGrpcConfig.getMaxIdleMillis()).toEqual(
+      testMaxIdleMillis
+    );
+  });
+
+  it('should support overriding max idle mills', () => {
+    const newMaxIdleMillis = 42;
+    const strategyWithNewMaxIdleMillis =
+      testTransportStrategy.withMaxIdleMillis(newMaxIdleMillis);
+    expect(strategyWithNewMaxIdleMillis.getGrpcConfig()).toEqual(
+      testGrpcConfiguration
+    );
+    expect(strategyWithNewMaxIdleMillis.getMaxIdleMillis()).toEqual(
+      newMaxIdleMillis
+    );
+  });
+
+  it('should support overriding client timeout', () => {
+    const newClientTimeout = 42;
+    const expectedGrpcConfig = new StaticGrpcConfiguration({
+      deadlineMillis: newClientTimeout,
+      maxSessionMemoryMb: testMaxSessionMemoryMb,
+    });
+    const strategyWithNewClientTimeout =
+      testTransportStrategy.withClientTimeoutMillis(newClientTimeout);
+    expect(strategyWithNewClientTimeout.getGrpcConfig()).toEqual(
+      expectedGrpcConfig
+    );
+    expect(strategyWithNewClientTimeout.getMaxIdleMillis()).toEqual(
+      testMaxIdleMillis
+    );
+  });
+});


### PR DESCRIPTION
This addresses one of the outstanding items from the list
of fast-follows for the Configuration API:

https://github.com/momentohq/client-sdk-javascript/issues/146

Prior to this commit we were exposing 'maxIdleMillis' as a
top-level setting on the Configuration.  However, we do not
expect users to need to know about this setting in the 90%
use case, so this commit moves it down into the TransportStrategy.
