### PR TITLE
chore: refactor common string array display logic for re-use

### DIFF
--- a/src/messages/responses/cache-list-fetch.ts
+++ b/src/messages/responses/cache-list-fetch.ts
@@ -6,7 +6,7 @@ import {
   ResponseMiss,
 } from './response-base';
 import {TextDecoder} from 'util';
-import {truncateString} from '../../utils/display';
+import {truncateStringArray} from '../../utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
@@ -28,21 +28,9 @@ class _Hit extends Response {
     return this._values.map(v => TEXT_DECODER.decode(v));
   }
 
-  private truncateValueStrings(): string[] {
-    const values = this.valueListString();
-    if (values.length <= this._displayListSizeLimit) {
-      return values;
-    } else {
-      return values.slice(0, this._displayListSizeLimit).concat(['...']);
-    }
-  }
-
   public override toString(): string {
-    const displayList = this.truncateValueStrings();
-    const asStrings = displayList.map(v => {
-      return truncateString(v);
-    });
-    return `${super.toString()}: [${asStrings.toString()}]`;
+    const truncatedStringArray = truncateStringArray(this.valueListString());
+    return `${super.toString()}: [${truncatedStringArray.toString()}]`;
   }
 }
 export class Hit extends ResponseHit(_Hit) {}

--- a/src/messages/responses/cache-list-fetch.ts
+++ b/src/messages/responses/cache-list-fetch.ts
@@ -13,7 +13,6 @@ const TEXT_DECODER = new TextDecoder();
 export abstract class Response extends ResponseBase {}
 
 class _Hit extends Response {
-  private readonly _displayListSizeLimit = 5;
   private readonly _values: Uint8Array[];
   constructor(values: Uint8Array[]) {
     super();

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -10,20 +10,23 @@ export function truncateString(value: string, maxLength = 32) {
 
 const DISPLAY_SIZE_LIMIT = 5;
 
-function truncateStringArrayToSize(xs: string[], length: number): string[] {
-  if (xs.length <= length) {
-    return xs;
+function truncateStringArrayToSize(
+  stringArray: string[],
+  length: number
+): string[] {
+  if (stringArray.length <= length) {
+    return stringArray;
   } else {
-    return xs.slice(0, length).concat(['...']);
+    return stringArray.slice(0, length).concat(['...']);
   }
 }
 
 export function truncateStringArray(
-  xs: string[],
+  stringArray: string[],
   length: number = DISPLAY_SIZE_LIMIT
 ): string[] {
-  const xss = truncateStringArrayToSize(xs, length);
-  return xss.map(v => {
-    return truncateString(v);
+  const truncatedStringArray = truncateStringArrayToSize(stringArray, length);
+  return truncatedStringArray.map(s => {
+    return truncateString(s);
   });
 }

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -7,3 +7,23 @@ export function truncateString(value: string, maxLength = 32) {
     return value;
   }
 }
+
+const DISPLAY_SIZE_LIMIT = 5;
+
+function truncateStringArrayToSize(xs: string[], length: number): string[] {
+  if (xs.length <= length) {
+    return xs;
+  } else {
+    return xs.slice(0, length).concat(['...']);
+  }
+}
+
+export function truncateStringArray(
+  xs: string[],
+  length: number = DISPLAY_SIZE_LIMIT
+): string[] {
+  const xss = truncateStringArrayToSize(xs, length);
+  return xss.map(v => {
+    return truncateString(v);
+  });
+}

--- a/test/utils/display.test.ts
+++ b/test/utils/display.test.ts
@@ -1,0 +1,34 @@
+import {truncateStringArray} from '../../src/utils/display';
+
+describe('string array trunctation logic', () => {
+  it('should not truncate when array is not that big', () => {
+    const result = truncateStringArray(['foo', 'bar']);
+    expect(result).toEqual(['foo', 'bar']);
+  });
+  it('should truncate a single element that is too long', () => {
+    const result = truncateStringArray([
+      'foooooooooooooooooooooooooooooooooooo',
+      'bar',
+    ]);
+    expect(result).toEqual(['fooooooooooooooooooooooooooooooo...', 'bar']);
+  });
+  it('should truncate both on elements and on the whole list', () => {
+    const result = truncateStringArray([
+      'foooooooooooooooooooooooooooooooooooo',
+      'bar',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+    ]);
+    expect(result).toEqual([
+      'fooooooooooooooooooooooooooooooo...',
+      'bar',
+      '1',
+      '2',
+      '3',
+      '...',
+    ]);
+  });
+});


### PR DESCRIPTION
In a subsequent PR I'll need this common logic for set-fetch-response.
