### PR TITLE
feat: add CacheSetAddElement that accepts a single element

### DIFF
--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -2,6 +2,7 @@ import {v4} from 'uuid';
 import {sleep} from '../src/utils/sleep';
 import {
   CacheSetAddElements,
+  CacheSetAddElement,
   CacheSetFetch,
   CacheSetRemoveElements,
   CollectionTtl,
@@ -21,7 +22,7 @@ describe('Integration tests for convenience operations on sets datastructure', (
       setName,
       LOL_BYTE_ARRAY
     );
-    expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+    expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
 
     const fetchResponse = await Momento.setFetch(
       IntegrationTestCacheName,
@@ -39,7 +40,7 @@ describe('Integration tests for convenience operations on sets datastructure', (
       setName,
       'lol'
     );
-    expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+    expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
 
     const fetchResponse = await Momento.setFetch(
       IntegrationTestCacheName,

--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -10,9 +10,49 @@ import {SetupIntegrationTest} from './integration-setup';
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
+const LOL_BYTE_ARRAY = Uint8Array.of(108, 111, 108);
+const FOO_BYTE_ARRAY = Uint8Array.of(102, 111, 111);
+
+describe('Integration tests for convenience operations on sets datastructure', () => {
+  it('should succeed for addElement with a byte array happy path', async () => {
+    const setName = v4();
+    const addResponse = await Momento.setAddElement(
+      IntegrationTestCacheName,
+      setName,
+      LOL_BYTE_ARRAY
+    );
+    expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+
+    const fetchResponse = await Momento.setFetch(
+      IntegrationTestCacheName,
+      setName
+    );
+    expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+    expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
+      new Set([LOL_BYTE_ARRAY])
+    );
+  });
+  it('should succeed for addElement with a string happy path', async () => {
+    const setName = v4();
+    const addResponse = await Momento.setAddElement(
+      IntegrationTestCacheName,
+      setName,
+      'lol'
+    );
+    expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+
+    const fetchResponse = await Momento.setFetch(
+      IntegrationTestCacheName,
+      setName
+    );
+    expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+    expect((fetchResponse as CacheSetFetch.Hit).valueSetUint8Array()).toEqual(
+      new Set([LOL_BYTE_ARRAY])
+    );
+  });
+});
+
 describe('Integration Tests for operations on sets datastructure', () => {
-  const LOL_BYTE_ARRAY = Uint8Array.of(108, 111, 108);
-  const FOO_BYTE_ARRAY = Uint8Array.of(102, 111, 111);
   it('should succeed for addElements with byte arrays happy path', async () => {
     const setName = v4();
     const addResponse = await Momento.setAddElements(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import * as CacheDictionaryRemoveField from './messages/responses/cache-dictiona
 import * as CacheDictionaryRemoveFields from './messages/responses/cache-dictionary-remove-fields';
 import * as CacheDictionaryIncrement from './messages/responses/cache-dictionary-increment';
 import * as CacheSetAddElements from './messages/responses/cache-set-add-elements';
+import * as CacheSetAddElement from './messages/responses/cache-set-add-element';
 import * as CacheSetRemoveElements from './messages/responses/cache-set-remove-elements';
 import {CacheInfo} from './messages/cache-info';
 import {CollectionTtl} from './utils/collection-ttl';
@@ -88,6 +89,7 @@ export {
   CacheDictionaryRemoveFields,
   CacheDictionaryIncrement,
   CacheSetAddElements,
+  CacheSetAddElement,
   CacheSetRemoveElements,
   MomentoErrorCode,
   AlreadyExistsError,

--- a/src/messages/responses/cache-set-add-element.ts
+++ b/src/messages/responses/cache-set-add-element.ts
@@ -1,0 +1,14 @@
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {SdkError} from '../../errors/errors';
+
+export abstract class Response extends ResponseBase {}
+
+class _Success extends Response {}
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(public _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-set-add-elements.ts
+++ b/src/messages/responses/cache-set-add-elements.ts
@@ -1,14 +1,25 @@
 import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
 import {SdkError} from '../../errors/errors';
+import * as CacheSetAddElement from './cache-set-add-element';
 
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  abstract toSingularResponse(): CacheSetAddElement.Response;
+}
 
-class _Success extends Response {}
+class _Success extends Response {
+  toSingularResponse(): CacheSetAddElement.Response {
+    return new CacheSetAddElement.Success();
+  }
+}
 export class Success extends ResponseSuccess(_Success) {}
 
 class _Error extends Response {
   constructor(public _innerException: SdkError) {
     super();
+  }
+
+  toSingularResponse(): CacheSetAddElement.Response {
+    return new CacheSetAddElement.Error(this._innerException);
   }
 }
 export class Error extends ResponseError(_Error) {}

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -182,12 +182,14 @@ export class SimpleCacheClient {
     element: string | Uint8Array,
     ttl?: CollectionTtl
   ): Promise<CacheSetAddElement.Response> {
-    return await this.setAddElements(
-      cacheName,
-      setName,
-      [element] as string[] | Uint8Array[],
-      ttl
-    );
+    return (
+      await this.setAddElements(
+        cacheName,
+        setName,
+        [element] as string[] | Uint8Array[],
+        ttl
+      )
+    ).toSingularResponse();
   }
 
   /**

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -18,6 +18,7 @@ import * as CacheDictionaryGetFields from './messages/responses/cache-dictionary
 import * as CacheDictionaryIncrement from './messages/responses/cache-dictionary-increment';
 import * as CacheSetFetch from './messages/responses/cache-set-fetch';
 import * as CacheSetAddElements from './messages/responses/cache-set-add-elements';
+import * as CacheSetAddElement from './messages/responses/cache-set-add-element';
 import * as CacheSetRemoveElements from './messages/responses/cache-set-remove-elements';
 import {getLogger, initializeMomentoLogging, Logger} from './utils/logging';
 import {range} from './utils/collections';
@@ -163,6 +164,30 @@ export class SimpleCacheClient {
   ): Promise<CacheSetFetch.Response> {
     const client = this.getNextDataClient();
     return await client.setFetch(cacheName, setName);
+  }
+
+  /**
+   * Add an element to a set in the cache.
+   *
+   * After this operation, the set will contain the union
+   * of the element passed in and the elements of the set.
+   * @param {string} cacheName - Name of the cache to store the set in.
+   * @param {string} setName - The set to add elements to.
+   * @param {(string | Uint8Array)} element - The data to add to the set.
+   * @param {CollectionTtl} [ttl] - TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+   */
+  public async setAddElement(
+    cacheName: string,
+    setName: string,
+    element: string | Uint8Array,
+    ttl?: CollectionTtl
+  ): Promise<CacheSetAddElement.Response> {
+    return await this.setAddElements(
+      cacheName,
+      setName,
+      [element] as string[] | Uint8Array[],
+      ttl
+    );
   }
 
   /**


### PR DESCRIPTION
For integ-testing, since CacheSetAddElement simply delegates
to CacheSetAddElements, the integ test cases are basic smoke
test cases and are not as exhaustive as CacheSetAddElements
integ test cases.

https://github.com/momentohq/client-sdk-javascript/issues/170
