### PR TITLE
refactor: DRY the simple success responses.

### DIFF
--- a/src/messages/responses/cache-delete.ts
+++ b/src/messages/responses/cache-delete.ts
@@ -1,14 +1,1 @@
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-dictionary-remove-field.ts
+++ b/src/messages/responses/cache-dictionary-remove-field.ts
@@ -1,15 +1,1 @@
-// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-dictionary-remove-fields.ts
+++ b/src/messages/responses/cache-dictionary-remove-fields.ts
@@ -1,15 +1,1 @@
-// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-dictionary-set-field.ts
+++ b/src/messages/responses/cache-dictionary-set-field.ts
@@ -1,15 +1,1 @@
-// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-dictionary-set-fields.ts
+++ b/src/messages/responses/cache-dictionary-set-fields.ts
@@ -1,15 +1,1 @@
-// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-set-add-element.ts
+++ b/src/messages/responses/cache-set-add-element.ts
@@ -1,14 +1,1 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-import {SdkError} from '../../errors/errors';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(public _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-set-remove-elements.ts
+++ b/src/messages/responses/cache-set-remove-elements.ts
@@ -1,14 +1,1 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-import {SdkError} from '../../errors/errors';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/cache-set.ts
+++ b/src/messages/responses/cache-set.ts
@@ -1,15 +1,1 @@
-// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(public _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/create-cache.ts
+++ b/src/messages/responses/create-cache.ts
@@ -1,16 +1,4 @@
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
+import {Response} from './response-simple-success';
+export * from './response-simple-success';
 
 export class AlreadyExists extends Response {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/delete-cache.ts
+++ b/src/messages/responses/delete-cache.ts
@@ -1,14 +1,1 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-import {SdkError} from '../../errors/errors';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';

--- a/src/messages/responses/response-simple-success.ts
+++ b/src/messages/responses/response-simple-success.ts
@@ -1,0 +1,14 @@
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+
+export abstract class Response extends ResponseBase {}
+
+class _Success extends Response {}
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/revoke-signing-key.ts
+++ b/src/messages/responses/revoke-signing-key.ts
@@ -1,14 +1,1 @@
-import {SdkError} from '../../errors/errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
-
-export abstract class Response extends ResponseBase {}
-
-class _Success extends ResponseBase {}
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-export class Error extends ResponseError(_Error) {}
+export * from './response-simple-success';


### PR DESCRIPTION
A lot of responses are the same: an empty Success and a simple Error. This avoids having to copy them.