### PR TITLE
fix: Set ops return INVALID_ARGUMENT_ERROR, not raise.

### DIFF
--- a/integration/create-delete-list-cache.test.ts
+++ b/integration/create-delete-list-cache.test.ts
@@ -1,32 +1,21 @@
 import {v4} from 'uuid';
-import {SetupIntegrationTest, WithCache} from './integration-setup';
-import {CreateCache, DeleteCache, ListCaches, MomentoErrorCode} from '../src';
 import {
-  ResponseBase,
-  IResponseError,
-} from '../src/messages/responses/response-base';
+  ValidateCacheProps,
+  ItBehavesLikeItValidatesCacheName,
+  SetupIntegrationTest,
+  WithCache,
+} from './integration-setup';
+import {CreateCache, DeleteCache, ListCaches, MomentoErrorCode} from '../src';
 
 const {Momento} = SetupIntegrationTest();
 
 describe('create/delete cache', () => {
-  const sharedValidationSpecs = (
-    getResponse: (cacheName: string) => Promise<ResponseBase>
-  ) => {
-    it('validates its cache name', async () => {
-      const response = await getResponse('   ');
-
-      expect((response as IResponseError).errorCode()).toEqual(
-        MomentoErrorCode.INVALID_ARGUMENT_ERROR
-      );
-    });
-  };
-
-  sharedValidationSpecs((cacheName: string) => {
-    return Momento.createCache(cacheName);
+  ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+    return Momento.createCache(props.cacheName);
   });
 
-  sharedValidationSpecs((cacheName: string) => {
-    return Momento.deleteCache(cacheName);
+  ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+    return Momento.deleteCache(props.cacheName);
   });
 
   it('should return NotFoundError if deleting a non-existent cache', async () => {

--- a/integration/get-set-delete.test.ts
+++ b/integration/get-set-delete.test.ts
@@ -6,40 +6,26 @@ import {
   MomentoErrorCode,
   SimpleCacheClient,
 } from '../src';
-import {
-  ResponseBase,
-  IResponseError,
-} from '../src/messages/responses/response-base';
 import {TextEncoder} from 'util';
 import {
   SetupIntegrationTest,
+  ValidateCacheProps,
   CacheClientProps,
+  ItBehavesLikeItValidatesCacheName,
   WithCache,
 } from './integration-setup';
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
 describe('get/set/delete', () => {
-  const sharedValidationSpecs = (
-    getResponse: (cacheName: string, key: string) => Promise<ResponseBase>
-  ) => {
-    it('validates its cache name', async () => {
-      const response = await getResponse('   ', v4());
-
-      expect((response as IResponseError).errorCode()).toEqual(
-        MomentoErrorCode.INVALID_ARGUMENT_ERROR
-      );
-    });
-  };
-
-  sharedValidationSpecs((cacheName: string, key: string) => {
-    return Momento.get(cacheName, key);
+  ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+    return Momento.get(props.cacheName, v4());
   });
-  sharedValidationSpecs((cacheName: string, key: string) => {
-    return Momento.set(cacheName, key, v4());
+  ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+    return Momento.set(props.cacheName, v4(), v4());
   });
-  sharedValidationSpecs((cacheName: string, key: string) => {
-    return Momento.delete(cacheName, key);
+  ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+    return Momento.delete(props.cacheName, v4());
   });
 
   it('should set and get string from cache', async () => {

--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -8,6 +8,10 @@ import {
   MomentoErrorCode,
   SimpleCacheClient,
 } from '../src';
+import {
+  IResponseError,
+  ResponseBase,
+} from '../src/messages/responses/response-base';
 
 function testCacheName(): string {
   const name = process.env.TEST_CACHE_NAME || 'js-integration-test-default';
@@ -77,4 +81,32 @@ export function SetupIntegrationTest(): {
 
   const client = momentoClientForTesting();
   return {Momento: client, IntegrationTestCacheName: cacheName};
+}
+
+export interface ValidateCacheProps {
+  cacheName: string;
+}
+
+export interface ValidateListProps extends ValidateCacheProps {
+  listName: string;
+}
+
+export interface ValidateDictionaryProps extends ValidateCacheProps {
+  dictionaryName: string;
+}
+
+export interface ValidateSetProps extends ValidateCacheProps {
+  setName: string;
+}
+
+export function ItBehavesLikeItValidatesCacheName(
+  getResponse: (props: ValidateCacheProps) => Promise<ResponseBase>
+) {
+  it('validates its cache name', async () => {
+    const response = await getResponse({cacheName: '   '});
+
+    expect((response as IResponseError).errorCode()).toEqual(
+      MomentoErrorCode.INVALID_ARGUMENT_ERROR
+    );
+  });
 }

--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -18,24 +18,28 @@ import {
   IResponseError,
   IListResponseSuccess,
 } from '../src/messages/responses/response-base';
-import {SetupIntegrationTest} from './integration-setup';
+import {
+  ValidateCacheProps,
+  ValidateListProps,
+  ItBehavesLikeItValidatesCacheName,
+  SetupIntegrationTest,
+} from './integration-setup';
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
 describe('lists', () => {
   const itBehavesLikeItValidates = (
-    getResponse: (cacheName: string, listName: string) => Promise<ResponseBase>
+    getResponse: (props: ValidateListProps) => Promise<ResponseBase>
   ) => {
-    it('validates its cache name', async () => {
-      const response = await getResponse('   ', v4());
-
-      expect((response as IResponseError).errorCode()).toEqual(
-        MomentoErrorCode.INVALID_ARGUMENT_ERROR
-      );
+    ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
+      return getResponse({cacheName: props.cacheName, listName: v4()});
     });
 
     it('validates its list name', async () => {
-      const response = await getResponse(IntegrationTestCacheName, '  ');
+      const response = await getResponse({
+        cacheName: IntegrationTestCacheName,
+        listName: '  ',
+      });
 
       expect((response as IResponseError).errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
@@ -227,8 +231,8 @@ describe('lists', () => {
   };
 
   describe('#listFetch', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listFetch(cacheName, listName);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listFetch(props.cacheName, props.listName);
     });
 
     it('returns a miss if the list does not exist', async () => {
@@ -256,8 +260,8 @@ describe('lists', () => {
   });
 
   describe('#listLength', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listLength(cacheName, listName);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listLength(props.cacheName, props.listName);
     });
 
     it('returns a miss if the list does not exist', async () => {
@@ -282,8 +286,8 @@ describe('lists', () => {
   });
 
   describe('#listPopBack', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listPopBack(cacheName, listName);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listPopBack(props.cacheName, props.listName);
     });
 
     it('misses when the list does not exist', async () => {
@@ -316,8 +320,8 @@ describe('lists', () => {
   });
 
   describe('#listPopFront', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listPopFront(cacheName, listName);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listPopFront(props.cacheName, props.listName);
     });
 
     it('misses when the list does not exist', async () => {
@@ -352,8 +356,8 @@ describe('lists', () => {
   });
 
   describe('#listPushBack', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listPushBack(cacheName, listName, v4());
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listPushBack(props.cacheName, props.listName, v4());
     });
 
     itBehavesLikeItAddsValuesToTheBack((props: addValueProps) => {
@@ -377,8 +381,8 @@ describe('lists', () => {
   });
 
   describe('#listPushFront', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listPushFront(cacheName, listName, v4());
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listPushFront(props.cacheName, props.listName, v4());
     });
 
     itBehavesLikeItAddsValuesToTheFront((props: addValueProps) => {
@@ -402,8 +406,8 @@ describe('lists', () => {
   });
 
   describe('#listRemoveValue', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listRemoveValue(cacheName, listName, v4());
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listRemoveValue(props.cacheName, props.listName, v4());
     });
 
     it('removes values', async () => {
@@ -442,8 +446,10 @@ describe('lists', () => {
   });
 
   describe('#listConcatenateBack', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listConcatenateBack(cacheName, listName, [v4()]);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listConcatenateBack(props.cacheName, props.listName, [
+        v4(),
+      ]);
     });
 
     itBehavesLikeItAddsValuesToTheBack((props: addValueProps) => {
@@ -495,8 +501,10 @@ describe('lists', () => {
   });
 
   describe('#listConcatenateFront', () => {
-    itBehavesLikeItValidates((cacheName: string, listName: string) => {
-      return Momento.listConcatenateFront(cacheName, listName, [v4()]);
+    itBehavesLikeItValidates((props: ValidateListProps) => {
+      return Momento.listConcatenateFront(props.cacheName, props.listName, [
+        v4(),
+      ]);
     });
 
     itBehavesLikeItAddsValuesToTheFront((props: addValueProps) => {

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -62,7 +62,7 @@ export class CacheClient {
   private readonly interceptors: Interceptor[];
 
   /**
-   * @param {MomentoCacheProps} props
+   * @param {MomentoValidateCacheProps} props
    */
   constructor(props: SimpleCacheClientProps) {
     this.configuration = props.configuration;
@@ -184,8 +184,12 @@ export class CacheClient {
     cacheName: string,
     setName: string
   ): Promise<CacheSetFetch.Response> {
-    validateCacheName(cacheName);
-    validateSetName(setName);
+    try {
+      validateCacheName(cacheName);
+      validateSetName(setName);
+    } catch (err) {
+      return new CacheSetFetch.Error(normalizeSdkError(err as Error));
+    }
     return await this.sendSetFetch(cacheName, this.convert(setName));
   }
 
@@ -223,8 +227,12 @@ export class CacheClient {
     elements: string[] | Uint8Array[],
     ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheSetAddElements.Response> {
-    validateCacheName(cacheName);
-    validateSetName(setName);
+    try {
+      validateCacheName(cacheName);
+      validateSetName(setName);
+    } catch (err) {
+      return new CacheSetAddElements.Error(normalizeSdkError(err as Error));
+    }
     return await this.sendSetAddElements(
       cacheName,
       this.convert(setName),
@@ -273,8 +281,12 @@ export class CacheClient {
     setName: string,
     elements: string[] | Uint8Array[]
   ): Promise<CacheSetRemoveElements.Response> {
-    validateCacheName(cacheName);
-    validateSetName(setName);
+    try {
+      validateCacheName(cacheName);
+      validateSetName(setName);
+    } catch (err) {
+      return new CacheSetRemoveElements.Error(normalizeSdkError(err as Error));
+    }
     return await this.sendSetRemoveElements(
       cacheName,
       this.convert(setName),


### PR DESCRIPTION
While DRYing up the tests, I discovered a bug in how Set is treating cache and set name validations.

Also
* DRY'd up the name validaton tests.
* Added name validation tests to Set.