### PR TITLE
refactor: DRY and speed up dictionary tests

### DIFF
--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -923,6 +923,114 @@ describe('Integration tests for dictionary operations', () => {
 
     itBehavesLikeItValidates(responder);
     itBehavesLikeItHasACollectionTtl(changeResponder);
+
+    it('should set fields with Uint8Array items', async () => {
+      const dictionaryName = v4();
+      const field1 = new TextEncoder().encode(v4());
+      const value1 = new TextEncoder().encode(v4());
+      const field2 = new TextEncoder().encode(v4());
+      const value2 = new TextEncoder().encode(v4());
+      const response = await Momento.dictionarySetFields(
+        IntegrationTestCacheName,
+        dictionaryName,
+        [
+          {field: field1, value: value1},
+          {field: field2, value: value2},
+        ],
+        CollectionTtl.of(10)
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+      let getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field1
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueUint8Array()).toEqual(value1);
+      }
+      getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field2
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueUint8Array()).toEqual(value2);
+      }
+    });
+
+    it('should set fields with string items', async () => {
+      const dictionaryName = v4();
+      const field1 = v4();
+      const value1 = v4();
+      const field2 = v4();
+      const value2 = v4();
+      const response = await Momento.dictionarySetFields(
+        IntegrationTestCacheName,
+        dictionaryName,
+        [
+          {field: field1, value: value1},
+          {field: field2, value: value2},
+        ],
+        CollectionTtl.of(10)
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+      let getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field1
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueString()).toEqual(value1);
+      }
+      getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field2
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueString()).toEqual(value2);
+      }
+    });
+
+    it('should set fields with string field/Uint8Array value items', async () => {
+      const dictionaryName = v4();
+      const field1 = v4();
+      const value1 = new TextEncoder().encode(v4());
+      const field2 = v4();
+      const value2 = new TextEncoder().encode(v4());
+      const response = await Momento.dictionarySetFields(
+        IntegrationTestCacheName,
+        dictionaryName,
+        [
+          {field: field1, value: value1},
+          {field: field2, value: value2},
+        ],
+        CollectionTtl.of(10)
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
+      let getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field1
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueUint8Array()).toEqual(value1);
+      }
+      getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field2
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueUint8Array()).toEqual(value2);
+      }
+    });
   });
 
   it('should set/get a dictionary with Uint8Array field/value', async () => {
@@ -989,114 +1097,6 @@ describe('Integration tests for dictionary operations', () => {
     expect(
       (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
     ).toEqual(value);
-  });
-
-  it('should dictionarySetFields/dictionaryGetField with Uint8Array items', async () => {
-    const dictionaryName = v4();
-    const field1 = new TextEncoder().encode(v4());
-    const value1 = new TextEncoder().encode(v4());
-    const field2 = new TextEncoder().encode(v4());
-    const value2 = new TextEncoder().encode(v4());
-    const response = await Momento.dictionarySetFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      [
-        {field: field1, value: value1},
-        {field: field2, value: value2},
-      ],
-      CollectionTtl.of(10)
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
-    let getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(value1);
-    }
-    getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(value2);
-    }
-  });
-
-  it('should dictionarySetFields/dictionaryGetField with string items', async () => {
-    const dictionaryName = v4();
-    const field1 = v4();
-    const value1 = v4();
-    const field2 = v4();
-    const value2 = v4();
-    const response = await Momento.dictionarySetFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      [
-        {field: field1, value: value1},
-        {field: field2, value: value2},
-      ],
-      CollectionTtl.of(10)
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
-    let getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueString()).toEqual(value1);
-    }
-    getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueString()).toEqual(value2);
-    }
-  });
-
-  it('should dictionarySetFields/dictionaryGetField with string field/Uint8Array value items', async () => {
-    const dictionaryName = v4();
-    const field1 = v4();
-    const value1 = new TextEncoder().encode(v4());
-    const field2 = v4();
-    const value2 = new TextEncoder().encode(v4());
-    const response = await Momento.dictionarySetFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      [
-        {field: field1, value: value1},
-        {field: field2, value: value2},
-      ],
-      CollectionTtl.of(10)
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
-    let getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(value1);
-    }
-    getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(value2);
-    }
   });
 
   it('should dictionarySetField/dictionaryGetFields with Uint8Array fields/values', async () => {

--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -5,6 +5,7 @@ import {
   CacheDelete,
   MomentoErrorCode,
   CacheDictionaryFetch,
+  CacheDictionaryRemoveField,
   CacheDictionarySetField,
   CacheDictionarySetFields,
   CacheDictionaryGetField,
@@ -616,6 +617,126 @@ describe('Integration tests for dictionary operations', () => {
     };
 
     itBehavesLikeItValidates(responder);
+
+    it('should remove a Uint8Array field', async () => {
+      const dictionaryName = v4();
+      const field = new TextEncoder().encode(v4());
+      const value = new TextEncoder().encode(v4());
+
+      // When the field does not exist.
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+      expect(
+        await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+
+      // When the field exists.
+      expect(
+        await Momento.dictionarySetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field,
+          value
+        )
+      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      expect(
+        await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+    });
+
+    it('should remove a string field', async () => {
+      const dictionaryName = v4();
+      const field = v4();
+      const value = v4();
+
+      // When the field does not exist.
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+      expect(
+        await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+
+      // When the field exists.
+      expect(
+        await Momento.dictionarySetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field,
+          value
+        )
+      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      expect(
+        await Momento.dictionaryRemoveField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetField(
+          IntegrationTestCacheName,
+          dictionaryName,
+          field
+        )
+      ).toBeInstanceOf(CacheDictionaryGetField.Miss);
+    });
   });
 
   describe('#dictionaryRemoveFields', () => {
@@ -974,130 +1095,6 @@ describe('Integration tests for dictionary operations', () => {
     expect(otherDictionary.get(field2)).toEqual(
       new TextEncoder().encode(value2)
     );
-  });
-
-  it('should remove a dictionary with dictionaryRemoveField with Uint8Array field', async () => {
-    const dictionaryName = v4();
-    const field1 = new TextEncoder().encode(v4());
-    const value1 = new TextEncoder().encode(v4());
-    const field2 = new TextEncoder().encode(v4());
-
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1,
-      value1
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Hit);
-
-    await Momento.dictionaryRemoveField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-
-    // Test no-op
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field2
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    await Momento.dictionaryRemoveField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field2
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-  });
-
-  it('should remove a dictionary with dictionaryRemoveField with string field', async () => {
-    const dictionaryName = v4();
-    const field1 = v4();
-    const value1 = v4();
-    const field2 = v4();
-
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1,
-      value1
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Hit);
-
-    await Momento.dictionaryRemoveField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field1
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-
-    // Test no-op
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field2
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    await Momento.dictionaryRemoveField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        field2
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
   });
 
   it('should remove a dictionary with dictionaryRemoveFields with string field', async () => {

--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -41,57 +41,82 @@ describe('Integration tests for dictionary operations', () => {
     });
   };
 
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryFetch(props.cacheName, props.dictionaryName);
+  describe('#dictionaryFetch', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryFetch(props.cacheName, props.dictionaryName);
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryGetField(
-      props.cacheName,
-      props.dictionaryName,
-      v4()
-    );
+
+  describe('#dictionaryGetField', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryGetField(
+        props.cacheName,
+        props.dictionaryName,
+        v4()
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryGetFields(props.cacheName, props.dictionaryName, [
-      v4(),
-    ]);
+
+  describe('#dictionaryGetFields', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryGetFields(
+        props.cacheName,
+        props.dictionaryName,
+        [v4()]
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryIncrement(
-      props.cacheName,
-      props.dictionaryName,
-      v4()
-    );
+
+  describe('#dictionaryIncrement', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryIncrement(
+        props.cacheName,
+        props.dictionaryName,
+        v4()
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryRemoveField(
-      props.cacheName,
-      props.dictionaryName,
-      v4()
-    );
+
+  describe('#dictionaryRemoveField', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryRemoveField(
+        props.cacheName,
+        props.dictionaryName,
+        v4()
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionaryRemoveFields(
-      props.cacheName,
-      props.dictionaryName,
-      [v4()]
-    );
+
+  describe('#dictionaryRemoveFields', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionaryRemoveFields(
+        props.cacheName,
+        props.dictionaryName,
+        [v4()]
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    return Momento.dictionarySetField(
-      props.cacheName,
-      props.dictionaryName,
-      v4(),
-      v4()
-    );
+
+  describe('#dictionarySetField', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      return Momento.dictionarySetField(
+        props.cacheName,
+        props.dictionaryName,
+        v4(),
+        v4()
+      );
+    });
   });
-  itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-    const items = [{field: v4(), value: v4()}];
-    return Momento.dictionarySetFields(
-      props.cacheName,
-      props.dictionaryName,
-      items
-    );
+
+  describe('#dictinoarySetFields', () => {
+    itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
+      const items = [{field: v4(), value: v4()}];
+      return Momento.dictionarySetFields(
+        props.cacheName,
+        props.dictionaryName,
+        items
+      );
+    });
   });
 
   it('should set/get a dictionary with Uint8Array field/value', async () => {

--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -6,6 +6,7 @@ import {
   MomentoErrorCode,
   CacheDictionaryFetch,
   CacheDictionaryRemoveField,
+  CacheDictionaryRemoveFields,
   CacheDictionarySetField,
   CacheDictionarySetFields,
   CacheDictionaryGetField,
@@ -749,6 +750,133 @@ describe('Integration tests for dictionary operations', () => {
     };
 
     itBehavesLikeItValidates(responder);
+
+    it('should remove Uint8Array fields', async () => {
+      const dictionaryName = v4();
+      const fields = [
+        new TextEncoder().encode(v4()),
+        new TextEncoder().encode(v4()),
+      ];
+      const setFields = [
+        {field: fields[0], value: v4()},
+        {field: fields[1], value: v4()},
+      ];
+
+      // When the fields do not exist.
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+      expect(
+        await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+
+      // When the fields exist.
+      expect(
+        await Momento.dictionarySetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          setFields
+        )
+      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+      expect(
+        await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+    });
+
+    it('should remove string fields', async () => {
+      const dictionaryName = v4();
+      const fields = [v4(), v4()];
+      const setFields = [
+        {field: fields[0], value: v4()},
+        {field: fields[1], value: v4()},
+      ];
+
+      // When the fields do not exist.
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+      expect(
+        await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+
+      // When the fields exist.
+      expect(
+        await Momento.dictionarySetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          setFields
+        )
+      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+      expect(
+        await Momento.dictionaryRemoveFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
+      expect(
+        await Momento.dictionaryGetFields(
+          IntegrationTestCacheName,
+          dictionaryName,
+          fields
+        )
+      ).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+    });
   });
 
   describe('#dictionarySetField', () => {
@@ -1095,57 +1223,5 @@ describe('Integration tests for dictionary operations', () => {
     expect(otherDictionary.get(field2)).toEqual(
       new TextEncoder().encode(value2)
     );
-  });
-
-  it('should remove a dictionary with dictionaryRemoveFields with string field', async () => {
-    const dictionaryName = v4();
-    const fields = [v4(), v4()];
-    const otherField = v4();
-
-    await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      fields[0],
-      v4()
-    );
-    await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      fields[1],
-      v4()
-    );
-    await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      otherField,
-      v4()
-    );
-
-    await Momento.dictionaryRemoveFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      fields
-    );
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        fields[0]
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        fields[1]
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Miss);
-    expect(
-      await Momento.dictionaryGetField(
-        IntegrationTestCacheName,
-        dictionaryName,
-        otherField
-      )
-    ).toBeInstanceOf(CacheDictionaryGetField.Hit);
   });
 });

--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -425,6 +425,132 @@ describe('Integration tests for dictionary operations', () => {
         'Hit: valueDictionaryStringString: a: b, c: d'
       );
     });
+
+    it('should dictionarySetField/dictionaryGetFields with string fields/values', async () => {
+      const dictionaryName = v4();
+      const field1 = v4();
+      const value1 = v4();
+      const field2 = v4();
+      const value2 = v4();
+      const field3 = v4();
+      let response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field1,
+        value1
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field2,
+        value2
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      const getResponse = await Momento.dictionaryGetFields(
+        IntegrationTestCacheName,
+        dictionaryName,
+        [field1, field2, field3]
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+      const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
+      expect(hitResponse.responsesList).toHaveLength(3);
+      expect(hitResponse.responsesList[0]).toBeInstanceOf(
+        CacheDictionaryGetField.Hit
+      );
+      const hitResponse1 = hitResponse
+        .responsesList[0] as CacheDictionaryGetField.Hit;
+      expect(hitResponse1.fieldString()).toEqual(field1);
+
+      expect(hitResponse.responsesList[1]).toBeInstanceOf(
+        CacheDictionaryGetField.Hit
+      );
+      const hitResponse2 = hitResponse
+        .responsesList[1] as CacheDictionaryGetField.Hit;
+      expect(hitResponse2.fieldString()).toEqual(field2);
+
+      expect(hitResponse.responsesList[2]).toBeInstanceOf(
+        CacheDictionaryGetField.Miss
+      );
+      const missResponse = hitResponse
+        .responsesList[2] as CacheDictionaryGetField.Miss;
+      expect(missResponse.fieldString()).toEqual(field3);
+
+      const expectedMap = new Map<string, string>([
+        [field1, value1],
+        [field2, value2],
+      ]);
+      expect(expectedMap).toEqual(hitResponse.valueDictionaryStringString());
+
+      const otherDictionary = hitResponse.valueDictionaryStringUint8Array();
+      expect(otherDictionary.size).toEqual(2);
+      expect(otherDictionary.get(field1)).toEqual(
+        new TextEncoder().encode(value1)
+      );
+      expect(otherDictionary.get(field2)).toEqual(
+        new TextEncoder().encode(value2)
+      );
+    });
+
+    it('should dictionarySetField/dictionaryGetFields with Uint8Array fields/values', async () => {
+      const dictionaryName = v4();
+      const field1 = new TextEncoder().encode(v4());
+      const value1 = new TextEncoder().encode(v4());
+      const field2 = new TextEncoder().encode(v4());
+      const value2 = new TextEncoder().encode(v4());
+      const field3 = new TextEncoder().encode(v4());
+      let response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field1,
+        value1
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field2,
+        value2
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      const getResponse = await Momento.dictionaryGetFields(
+        IntegrationTestCacheName,
+        dictionaryName,
+        [field1, field2, field3]
+      );
+
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+      const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
+      expect(hitResponse.responsesList).toHaveLength(3);
+      expect(hitResponse.responsesList[0]).toBeInstanceOf(
+        CacheDictionaryGetField.Hit
+      );
+      const hitResponse1 = hitResponse
+        .responsesList[0] as CacheDictionaryGetField.Hit;
+      expect(hitResponse1.fieldUint8Array()).toEqual(field1);
+
+      expect(hitResponse.responsesList[1]).toBeInstanceOf(
+        CacheDictionaryGetField.Hit
+      );
+      const hitResponse2 = hitResponse
+        .responsesList[1] as CacheDictionaryGetField.Hit;
+      expect(hitResponse2.fieldUint8Array()).toEqual(field2);
+
+      expect(hitResponse.responsesList[2]).toBeInstanceOf(
+        CacheDictionaryGetField.Miss
+      );
+      const missResponse = hitResponse
+        .responsesList[2] as CacheDictionaryGetField.Miss;
+      expect(missResponse.fieldUint8Array()).toEqual(field3);
+
+      const expectedMap = new Map<Uint8Array, Uint8Array>([
+        [field1, value1],
+        [field2, value2],
+      ]);
+      expect(expectedMap).toEqual(
+        hitResponse.valueDictionaryUint8ArrayUint8Array()
+      );
+    });
   });
 
   describe('#dictionaryIncrement', () => {
@@ -901,6 +1027,72 @@ describe('Integration tests for dictionary operations', () => {
 
     itBehavesLikeItValidates(responder);
     itBehavesLikeItHasACollectionTtl(changeResponder);
+
+    it('should set/get a dictionary with Uint8Array field/value', async () => {
+      const dictionaryName = v4();
+      const field = new TextEncoder().encode(v4());
+      const value = new TextEncoder().encode(v4());
+      const response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field,
+        value
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      const getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueUint8Array()).toEqual(value);
+      }
+    });
+
+    it('should set/get a dictionary with string field/value', async () => {
+      const dictionaryName = v4();
+      const field = v4();
+      const value = v4();
+      const response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field,
+        value
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      const getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      if (getResponse instanceof CacheDictionaryGetField.Hit) {
+        expect(getResponse.valueString()).toEqual(value);
+      }
+    });
+
+    it('should set/get a dictionary with string field and Uint8Array value', async () => {
+      const dictionaryName = v4();
+      const field = v4();
+      const value = new TextEncoder().encode(v4());
+      const response = await Momento.dictionarySetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field,
+        value
+      );
+      expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
+      const getResponse = await Momento.dictionaryGetField(
+        IntegrationTestCacheName,
+        dictionaryName,
+        field
+      );
+      expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+      expect(
+        (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
+      ).toEqual(value);
+    });
   });
 
   describe('#dictionarySetFields', () => {
@@ -1031,197 +1223,5 @@ describe('Integration tests for dictionary operations', () => {
         expect(getResponse.valueUint8Array()).toEqual(value2);
       }
     });
-  });
-
-  it('should set/get a dictionary with Uint8Array field/value', async () => {
-    const dictionaryName = v4();
-    const field = new TextEncoder().encode(v4());
-    const value = new TextEncoder().encode(v4());
-    const response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field,
-      value
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    const getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueUint8Array()).toEqual(value);
-    }
-  });
-
-  it('should set/get a dictionary with string field/value', async () => {
-    const dictionaryName = v4();
-    const field = v4();
-    const value = v4();
-    const response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field,
-      value
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    const getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    if (getResponse instanceof CacheDictionaryGetField.Hit) {
-      expect(getResponse.valueString()).toEqual(value);
-    }
-  });
-
-  it('should set/get a dictionary with string field and Uint8Array value', async () => {
-    const dictionaryName = v4();
-    const field = v4();
-    const value = new TextEncoder().encode(v4());
-    const response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field,
-      value
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    const getResponse = await Momento.dictionaryGetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
-    expect(
-      (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
-    ).toEqual(value);
-  });
-
-  it('should dictionarySetField/dictionaryGetFields with Uint8Array fields/values', async () => {
-    const dictionaryName = v4();
-    const field1 = new TextEncoder().encode(v4());
-    const value1 = new TextEncoder().encode(v4());
-    const field2 = new TextEncoder().encode(v4());
-    const value2 = new TextEncoder().encode(v4());
-    const field3 = new TextEncoder().encode(v4());
-    let response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1,
-      value1
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2,
-      value2
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    const getResponse = await Momento.dictionaryGetFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      [field1, field2, field3]
-    );
-
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
-    const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
-    expect(hitResponse.responsesList).toHaveLength(3);
-    expect(hitResponse.responsesList[0]).toBeInstanceOf(
-      CacheDictionaryGetField.Hit
-    );
-    const hitResponse1 = hitResponse
-      .responsesList[0] as CacheDictionaryGetField.Hit;
-    expect(hitResponse1.fieldUint8Array()).toEqual(field1);
-
-    expect(hitResponse.responsesList[1]).toBeInstanceOf(
-      CacheDictionaryGetField.Hit
-    );
-    const hitResponse2 = hitResponse
-      .responsesList[1] as CacheDictionaryGetField.Hit;
-    expect(hitResponse2.fieldUint8Array()).toEqual(field2);
-
-    expect(hitResponse.responsesList[2]).toBeInstanceOf(
-      CacheDictionaryGetField.Miss
-    );
-    const missResponse = hitResponse
-      .responsesList[2] as CacheDictionaryGetField.Miss;
-    expect(missResponse.fieldUint8Array()).toEqual(field3);
-
-    const expectedMap = new Map<Uint8Array, Uint8Array>([
-      [field1, value1],
-      [field2, value2],
-    ]);
-    expect(expectedMap).toEqual(
-      hitResponse.valueDictionaryUint8ArrayUint8Array()
-    );
-  });
-
-  it('should dictionarySetField/dictionaryGetFields with string fields/values', async () => {
-    const dictionaryName = v4();
-    const field1 = v4();
-    const value1 = v4();
-    const field2 = v4();
-    const value2 = v4();
-    const field3 = v4();
-    let response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field1,
-      value1
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    response = await Momento.dictionarySetField(
-      IntegrationTestCacheName,
-      dictionaryName,
-      field2,
-      value2
-    );
-    expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
-    const getResponse = await Momento.dictionaryGetFields(
-      IntegrationTestCacheName,
-      dictionaryName,
-      [field1, field2, field3]
-    );
-    expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
-    const hitResponse = getResponse as CacheDictionaryGetFields.Hit;
-    expect(hitResponse.responsesList).toHaveLength(3);
-    expect(hitResponse.responsesList[0]).toBeInstanceOf(
-      CacheDictionaryGetField.Hit
-    );
-    const hitResponse1 = hitResponse
-      .responsesList[0] as CacheDictionaryGetField.Hit;
-    expect(hitResponse1.fieldString()).toEqual(field1);
-
-    expect(hitResponse.responsesList[1]).toBeInstanceOf(
-      CacheDictionaryGetField.Hit
-    );
-    const hitResponse2 = hitResponse
-      .responsesList[1] as CacheDictionaryGetField.Hit;
-    expect(hitResponse2.fieldString()).toEqual(field2);
-
-    expect(hitResponse.responsesList[2]).toBeInstanceOf(
-      CacheDictionaryGetField.Miss
-    );
-    const missResponse = hitResponse
-      .responsesList[2] as CacheDictionaryGetField.Miss;
-    expect(missResponse.fieldString()).toEqual(field3);
-
-    const expectedMap = new Map<string, string>([
-      [field1, value1],
-      [field2, value2],
-    ]);
-    expect(expectedMap).toEqual(hitResponse.valueDictionaryStringString());
-
-    const otherDictionary = hitResponse.valueDictionaryStringUint8Array();
-    expect(otherDictionary.size).toEqual(2);
-    expect(otherDictionary.get(field1)).toEqual(
-      new TextEncoder().encode(value1)
-    );
-    expect(otherDictionary.get(field2)).toEqual(
-      new TextEncoder().encode(value2)
-    );
   });
 });

--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -90,6 +90,7 @@ export interface ValidateListProps extends ValidateCacheProps {
 
 export interface ValidateDictionaryProps extends ValidateCacheProps {
   dictionaryName: string;
+  field: string | Uint8Array;
 }
 
 export interface ValidateSetProps extends ValidateCacheProps {

--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -5,6 +5,7 @@ import {
   Configurations,
   DeleteCache,
   EnvMomentoTokenProvider,
+  CollectionTtl,
   MomentoErrorCode,
   SimpleCacheClient,
 } from '../src';
@@ -91,6 +92,12 @@ export interface ValidateListProps extends ValidateCacheProps {
 export interface ValidateDictionaryProps extends ValidateCacheProps {
   dictionaryName: string;
   field: string | Uint8Array;
+}
+
+export interface ValidateDictionaryChangerProps
+  extends ValidateDictionaryProps {
+  value: string | Uint8Array;
+  ttl?: CollectionTtl;
 }
 
 export interface ValidateSetProps extends ValidateCacheProps {


### PR DESCRIPTION
* Extract shared tests
* Speed up the TTL tests by reducing the timeouts (60s -> 20s)
* Move method tests into individual describe blocks for easier reading.