### PR TITLE
refactor: Turn on noUnusedLocals, fix errors.

### DIFF
--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -55,7 +55,6 @@ export abstract class SdkError extends Error {
   protected readonly _errorCode: MomentoErrorCode;
   protected readonly _messageWrapper: string;
   private readonly _transportDetails: MomentoErrorTransportDetails;
-  private readonly _stack: string | undefined;
   constructor(
     message: string,
     code = 0,

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -34,7 +34,7 @@ import {
   CacheSetRemoveElements,
   CacheSetRemoveElement,
 } from '.';
-import {getLogger, initializeMomentoLogging, Logger} from './utils/logging';
+import {initializeMomentoLogging} from './utils/logging';
 import {range} from './utils/collections';
 import {SimpleCacheClientProps} from './simple-cache-client-props';
 
@@ -54,14 +54,12 @@ export class SimpleCacheClient {
   private readonly dataClients: Array<CacheClient>;
   private nextDataClientIndex: number;
   private readonly controlClient: ControlClient;
-  private readonly logger: Logger;
 
   /**
    * Creates an instance of SimpleCacheClient.
    */
   constructor(props: SimpleCacheClientProps) {
     initializeMomentoLogging(props.configuration.getLoggerOptions());
-    this.logger = getLogger(this);
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "strictNullChecks": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": false,


### PR DESCRIPTION
For some reason, the linter was configured to allow unused local properties. The check is off on nearly all our Typescript repos. There doesn't seem to be a reason not to turn the check on.

Closes #116 