### PR TITLE
feat: add StringMomentoTokenProvider and use interfaces for constructor args

### DIFF
--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -44,7 +44,9 @@ export async function WithCache(
 
 export const CacheClientProps: SimpleCacheClientProps = {
   configuration: Configurations.Laptop.latest(),
-  credentialProvider: new EnvMomentoTokenProvider('TEST_AUTH_TOKEN'),
+  credentialProvider: new EnvMomentoTokenProvider({
+    environmentVariableName: 'TEST_AUTH_TOKEN',
+  }),
   defaultTtlSeconds: 1111,
 };
 

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -24,35 +24,41 @@ export interface CredentialProvider {
 }
 
 /**
- * Reads and parses a momento auth token stored as an environment variable.
+ * Encapsulates arguments for instantiating a StringMomentoTokenProvider
+ */
+export interface StringMomentoTokenProviderProps {
+  /**
+   * authToken the momento auth token
+   */
+  authToken: string;
+  /**
+   * optionally overrides the default controlEndpoint
+   */
+  controlEndpoint?: string;
+  /**
+   * optionally overrides the default cacheEndpoint
+   */
+  cacheEndpoint?: string;
+}
+
+/**
+ * Reads and parses a momento auth token stored in a String
  * @export
  * @class EnvMomentoTokenProvider
  */
-export class EnvMomentoTokenProvider implements CredentialProvider {
+export class StringMomentoTokenProvider implements CredentialProvider {
   private readonly authToken: string;
   private readonly controlEndpoint: string;
   private readonly cacheEndpoint: string;
 
   /**
-   * @param {string} envVariableName the name of the environment variable from which the auth token will be read
-   * @param {string} [controlEndpoint] optionally overrides the default controlEndpoint
-   * @param {string} [cacheEndpoint] optionally overrides the default cacheEndpoint
+   * @param {StringMomentoTokenProviderProps} props configuration options for the token provider
    */
-  constructor(
-    envVariableName: string,
-    controlEndpoint?: string,
-    cacheEndpoint?: string
-  ) {
-    const authToken = process.env[envVariableName];
-    if (!authToken) {
-      throw new Error(
-        `Missing required environment variable ${envVariableName}`
-      );
-    }
-    this.authToken = authToken;
-    const claims = decodeJwt(authToken);
-    this.controlEndpoint = controlEndpoint ?? claims.cp;
-    this.cacheEndpoint = cacheEndpoint ?? claims.c;
+  constructor(props: StringMomentoTokenProviderProps) {
+    this.authToken = props.authToken;
+    const claims = decodeJwt(props.authToken);
+    this.controlEndpoint = props.controlEndpoint ?? claims.cp;
+    this.cacheEndpoint = props.cacheEndpoint ?? claims.c;
   }
 
   getAuthToken(): string {
@@ -65,5 +71,47 @@ export class EnvMomentoTokenProvider implements CredentialProvider {
 
   getControlEndpoint(): string {
     return this.controlEndpoint;
+  }
+}
+
+/**
+ * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
+ */
+export interface EnvMomentoTokenProviderProps {
+  /**
+   * the name of the environment variable from which the auth token will be read
+   */
+  environmentVariableName: string;
+  /**
+   * optionally overrides the default controlEndpoint
+   */
+  controlEndpoint?: string;
+  /**
+   * optionally overrides the default cacheEndpoint
+   */
+  cacheEndpoint?: string;
+}
+
+/**
+ * Reads and parses a momento auth token stored as an environment variable.
+ * @export
+ * @class EnvMomentoTokenProvider
+ */
+export class EnvMomentoTokenProvider extends StringMomentoTokenProvider {
+  /**
+   * @param {EnvMomentoTokenProviderProps} props configuration options for the token provider
+   */
+  constructor(props: EnvMomentoTokenProviderProps) {
+    const authToken = process.env[props.environmentVariableName];
+    if (!authToken) {
+      throw new Error(
+        `Missing required environment variable ${props.environmentVariableName}`
+      );
+    }
+    super({
+      authToken: authToken,
+      controlEndpoint: props.controlEndpoint,
+      cacheEndpoint: props.cacheEndpoint,
+    });
   }
 }

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -44,7 +44,7 @@ export interface StringMomentoTokenProviderProps {
 /**
  * Reads and parses a momento auth token stored in a String
  * @export
- * @class EnvMomentoTokenProvider
+ * @class StringMomentoTokenProvider
  */
 export class StringMomentoTokenProvider implements CredentialProvider {
   private readonly authToken: string;

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -1,6 +1,20 @@
 import {decodeJwt} from '../utils/jwt';
 
 /**
+ * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
+ */
+interface CredentialProviderProps {
+  /**
+   * optionally overrides the default controlEndpoint
+   */
+  controlEndpoint?: string;
+  /**
+   * optionally overrides the default cacheEndpoint
+   */
+  cacheEndpoint?: string;
+}
+
+/**
  * Provides information that the SimpleCacheClient needs in order to establish a connection to and authenticate with
  * the Momento service.
  * @export
@@ -23,22 +37,12 @@ export interface CredentialProvider {
   getCacheEndpoint(): string;
 }
 
-/**
- * Encapsulates arguments for instantiating a StringMomentoTokenProvider
- */
-export interface StringMomentoTokenProviderProps {
+export interface StringMomentoTokenProviderProps
+  extends CredentialProviderProps {
   /**
    * authToken the momento auth token
    */
   authToken: string;
-  /**
-   * optionally overrides the default controlEndpoint
-   */
-  controlEndpoint?: string;
-  /**
-   * optionally overrides the default cacheEndpoint
-   */
-  cacheEndpoint?: string;
 }
 
 /**
@@ -74,32 +78,11 @@ export class StringMomentoTokenProvider implements CredentialProvider {
   }
 }
 
-/**
- * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
- */
-export interface CredentialProviderProps {
-  /**
-   * optionally overrides the default controlEndpoint
-   */
-  controlEndpoint?: string;
-  /**
-   * optionally overrides the default cacheEndpoint
-   */
-  cacheEndpoint?: string;
-}
-
 export interface EnvMomentoTokenProviderProps extends CredentialProviderProps {
   /**
    * the name of the environment variable from which the auth token will be read
    */
   environmentVariableName: string;
-}
-
-export interface StringMomentoTokenProviderProps extends CredentialProviderProps {
-  /**
-   * authToken the momento auth token
-   */
-  authToken: string;
 }
 
 /**

--- a/src/auth/credential-provider.ts
+++ b/src/auth/credential-provider.ts
@@ -77,11 +77,7 @@ export class StringMomentoTokenProvider implements CredentialProvider {
 /**
  * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
  */
-export interface EnvMomentoTokenProviderProps {
-  /**
-   * the name of the environment variable from which the auth token will be read
-   */
-  environmentVariableName: string;
+export interface CredentialProviderProps {
   /**
    * optionally overrides the default controlEndpoint
    */
@@ -90,6 +86,20 @@ export interface EnvMomentoTokenProviderProps {
    * optionally overrides the default cacheEndpoint
    */
   cacheEndpoint?: string;
+}
+
+export interface EnvMomentoTokenProviderProps extends CredentialProviderProps {
+  /**
+   * the name of the environment variable from which the auth token will be read
+   */
+  environmentVariableName: string;
+}
+
+export interface StringMomentoTokenProviderProps extends CredentialProviderProps {
+  /**
+   * authToken the momento auth token
+   */
+  authToken: string;
 }
 
 /**

--- a/test/auth/credential-provider.test.ts
+++ b/test/auth/credential-provider.test.ts
@@ -1,0 +1,72 @@
+import {
+  StringMomentoTokenProvider,
+  EnvMomentoTokenProvider,
+} from '../../src/auth/credential-provider';
+
+const testToken =
+  'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmb29AYmFyLmNvbSIsImNwIjoiY29udHJvbC1wbGFuZS1lbmRwb2ludC5iYXIuY29tIiwiYyI6ImNhY2hlLWVuZHBvaW50LmJhci5jb20ifQo.rtxfu4miBHQ1uptWJ2x3UiAwwJYcMeYIkkpXxUno_wIavg4h6YJStcbxk32NDBbmJkJS7mUw6MsvJNWaxfdPOw';
+const testControlEndpoint = 'control-plane-endpoint.bar.com';
+const testCacheEndpoint = 'cache-endpoint.bar.com';
+
+describe('StringMomentoTokenProvider', () => {
+  it('parses a valid token', () => {
+    const authProvider = new StringMomentoTokenProvider({authToken: testToken});
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
+    expect(authProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
+  });
+
+  it('supports overriding control endpoint', () => {
+    const authProvider = new StringMomentoTokenProvider({
+      authToken: testToken,
+      controlEndpoint: 'foo',
+    });
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual('foo');
+    expect(authProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
+  });
+
+  it('supports overriding cache endpoint', () => {
+    const authProvider = new StringMomentoTokenProvider({
+      authToken: testToken,
+      cacheEndpoint: 'foo',
+    });
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
+    expect(authProvider.getCacheEndpoint()).toEqual('foo');
+  });
+});
+
+describe('EnvMomentoTokenProvider', () => {
+  const testEnvVarName = 'TEST_AUTH_TOKEN_ENV_VAR';
+  process.env[testEnvVarName] = testToken;
+
+  it('parses a valid token', () => {
+    const authProvider = new EnvMomentoTokenProvider({
+      environmentVariableName: testEnvVarName,
+    });
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
+    expect(authProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
+  });
+
+  it('supports overriding control endpoint', () => {
+    const authProvider = new EnvMomentoTokenProvider({
+      environmentVariableName: testEnvVarName,
+      controlEndpoint: 'foo',
+    });
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual('foo');
+    expect(authProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
+  });
+
+  it('supports overriding cache endpoint', () => {
+    const authProvider = new EnvMomentoTokenProvider({
+      environmentVariableName: testEnvVarName,
+      cacheEndpoint: 'foo',
+    });
+    expect(authProvider.getAuthToken()).toEqual(testToken);
+    expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
+    expect(authProvider.getCacheEndpoint()).toEqual('foo');
+  });
+});

--- a/test/auth/credential-provider.test.ts
+++ b/test/auth/credential-provider.test.ts
@@ -4,9 +4,9 @@ import {
 } from '../../src/auth/credential-provider';
 
 const testToken =
-  'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmb29AYmFyLmNvbSIsImNwIjoiY29udHJvbC1wbGFuZS1lbmRwb2ludC5iYXIuY29tIiwiYyI6ImNhY2hlLWVuZHBvaW50LmJhci5jb20ifQo.rtxfu4miBHQ1uptWJ2x3UiAwwJYcMeYIkkpXxUno_wIavg4h6YJStcbxk32NDBbmJkJS7mUw6MsvJNWaxfdPOw';
-const testControlEndpoint = 'control-plane-endpoint.bar.com';
-const testCacheEndpoint = 'cache-endpoint.bar.com';
+  'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmb29Abm90LmEuZG9tYWluIiwiY3AiOiJjb250cm9sLXBsYW5lLWVuZHBvaW50Lm5vdC5hLmRvbWFpbiIsImMiOiJjYWNoZS1lbmRwb2ludC5ub3QuYS5kb21haW4ifQo.rtxfu4miBHQ1uptWJ2x3UiAwwJYcMeYIkkpXxUno_wIavg4h6YJStcbxk32NDBbmJkJS7mUw6MsvJNWaxfdPOw';
+const testControlEndpoint = 'control-plane-endpoint.not.a.domain';
+const testCacheEndpoint = 'cache-endpoint.not.a.domain';
 
 describe('StringMomentoTokenProvider', () => {
   it('parses a valid token', () => {

--- a/test/simple-cache-client.test.ts
+++ b/test/simple-cache-client.test.ts
@@ -5,7 +5,9 @@ import {
   EnvMomentoTokenProvider,
 } from '../src';
 import * as CreateCache from '../src/messages/responses/create-cache';
-const credentialProvider = new EnvMomentoTokenProvider('TEST_AUTH_TOKEN');
+const credentialProvider = new EnvMomentoTokenProvider({
+  environmentVariableName: 'TEST_AUTH_TOKEN',
+});
 const configuration = Configurations.Laptop.latest();
 
 describe('SimpleCacheClient.ts', () => {


### PR DESCRIPTION
This commit adds StringMomentoTokenProvider alongside the existing
EnvMomentoTokenProvider, for parity with other SDKs.  Also tweaks
the constructor for the auth providers to use an interface, to make
it easier to provide keyword-style arguments for the cases where
you want to override the endpoints.
