### PR TITLE
feat: introduce API for RetryStrategy

### DIFF
--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -6,6 +6,7 @@ import {
 } from './transport/transport-strategy';
 import {GrpcConfiguration} from './transport/grpc-configuration';
 import {LogFormat, LoggerOptions, LogLevel} from '../utils/logging';
+import {FixedCountRetryStrategy} from './retry/fixed-count-retry-strategy';
 
 // 4 minutes.  We want to remain comfortably underneath the idle timeout for AWS NLB, which is 350s.
 const defaultMaxIdleMillis = 4 * 60 * 1_000;
@@ -14,6 +15,7 @@ const defaultLoggerOptions: LoggerOptions = {
   level: LogLevel.WARN,
   format: LogFormat.CONSOLE,
 };
+const defaultRetryStrategy = new FixedCountRetryStrategy({maxAttempts: 3});
 
 /**
  * Laptop config provides defaults suitable for a medium-to-high-latency dev environment.  Permissive timeouts, retries, and
@@ -39,6 +41,7 @@ export class Laptop extends SimpleCacheConfiguration {
     });
     return new Laptop({
       loggerOptions: loggerOptions,
+      retryStrategy: defaultRetryStrategy,
       transportStrategy: transportStrategy,
     });
   }
@@ -64,6 +67,7 @@ class InRegionDefault extends SimpleCacheConfiguration {
     });
     return new InRegionDefault({
       loggerOptions: loggerOptions,
+      retryStrategy: defaultRetryStrategy,
       transportStrategy: transportStrategy,
     });
   }
@@ -87,6 +91,7 @@ class InRegionLowLatency extends SimpleCacheConfiguration {
     });
     return new InRegionDefault({
       loggerOptions: loggerOptions,
+      retryStrategy: defaultRetryStrategy,
       transportStrategy: transportStrategy,
     });
   }

--- a/src/config/retry/default-eligibility-strategy.ts
+++ b/src/config/retry/default-eligibility-strategy.ts
@@ -1,0 +1,131 @@
+import {Status} from '@grpc/grpc-js/build/src/constants';
+import {
+  EligibilityStrategy,
+  EligibleForRetryProps,
+} from './eligibility-strategy';
+import {getLogger, Logger} from '../../utils/logging';
+
+const retryableGrpcStatusCodes: Array<Status> = [
+  // including all the status codes for reference, but
+  // commenting out the ones we don't want to retry on for now.
+
+  // Status.OK,
+  // Status.CANCELLED,
+  // Status.UNKNOWN,
+  // Status.INVALID_ARGUMENT,
+  // Status.DEADLINE_EXCEEDED,
+  // Status.NOT_FOUND,
+  // Status.ALREADY_EXISTS,
+  // Status.PERMISSION_DENIED,
+  // Status.RESOURCE_EXHAUSTED,
+  Status.FAILED_PRECONDITION,
+  // Status.ABORTED,
+  // Status.OUT_OF_RANGE,
+  // Status.UNIMPLEMENTED,
+  Status.INTERNAL,
+  Status.UNAVAILABLE,
+  // Status.DATA_LOSS,
+  // Status.UNAUTHENTICATED
+];
+
+const retryableRequestTypes: Array<string> = [
+  '/cache_client.Scs/Set',
+  '/cache_client.Scs/Get',
+  '/cache_client.Scs/Delete',
+  '/cache_client.Scs/DictionarySet',
+  // not idempotent: '/cache_client.Scs/DictionaryIncrement',
+  '/cache_client.Scs/DictionaryGet',
+  '/cache_client.Scs/DictionaryFetch',
+  '/cache_client.Scs/DictionaryDelete',
+  '/cache_client.Scs/SetUnion',
+  '/cache_client.Scs/SetDifference',
+  '/cache_client.Scs/SetFetch',
+  // not idempotent: '/cache_client.Scs/ListPushFront',
+  // not idempotent: '/cache_client.Scs/ListPushBack',
+  // not idempotent: '/cache_client.Scs/ListPopFront',
+  // not idempotent: '/cache_client.Scs/ListPopBack',
+  '/cache_client.Scs/ListFetch',
+  /*
+   *  Warning: in the future, this may not be idempotent
+   *  Currently it supports removing all occurrences of a value.
+   *  In the future, we may also add "the first/last N occurrences of a value".
+   *  In the latter case it is not idempotent.
+   */
+  '/cache_client.Scs/ListRemove',
+  '/cache_client.Scs/ListLength',
+  // not idempotent: '/cache_client.Scs/ListConcatenateFront',
+  // not idempotent: '/cache_client.Scs/ListConcatenateBack'
+];
+
+//
+// private readonly HashSet<Type> _retryableRequestTypes = new HashSet<Type>
+//   {
+//     typeof(_SetRequest),
+//     typeof(_GetRequest),
+//     typeof(_DeleteRequest),
+//     typeof(_DictionarySetRequest),
+//     // not idempotent: typeof(_DictionaryIncrementRequest),
+//     typeof(_DictionaryGetRequest),
+//     typeof(_DictionaryFetchRequest),
+//     typeof(_DictionaryDeleteRequest),
+//     typeof(_SetUnionRequest),
+//     typeof(_SetDifferenceRequest),
+//     typeof(_SetFetchRequest),
+//     // not idempotent: typeof(_ListPushFrontRequest),
+//     // not idempotent: typeof(_ListPushBackRequest),
+//     // not idempotent: typeof(_ListPopFrontRequest),
+//     // not idempotent: typeof(_ListPopBackRequest),
+//     typeof(_ListFetchRequest),
+//     /*
+//      *  Warning: in the future, this may not be idempotent
+//      *  Currently it supports removing all occurrences of a value.
+//      *  In the future, we may also add "the first/last N occurrences of a value".
+//      *  In the latter case it is not idempotent.
+//      */
+//     typeof(_ListRemoveRequest),
+//     typeof(_ListLengthRequest),
+//     // not idempotent: typeof(_ListConcatenateFrontRequest),
+//     // not idempotent: typeof(_ListConcatenateBackRequest)
+//   };
+
+export class DefaultEligibilityStrategy implements EligibilityStrategy {
+  private readonly logger: Logger;
+
+  constructor() {
+    this.logger = getLogger(this);
+  }
+
+  isEligibleForRetry(props: EligibleForRetryProps): boolean {
+    /*
+    if (!_retryableStatusCodes.Contains(status.StatusCode))
+            {
+                _logger.LogDebug("Response with status code {} is not retryable.", status.StatusCode);
+                return false;
+            }
+
+            if (!_retryableRequestTypes.Contains(request.GetType()))
+            {
+                _logger.LogDebug("Request with type {} is not retryable.", request.GetType());
+                return false;
+            }
+
+            return true;
+     */
+
+    if (!retryableGrpcStatusCodes.includes(props.grpcStatus.code)) {
+      this.logger.debug(
+        `Response with status code ${props.grpcStatus.code} is not retryable.`
+      );
+      return false;
+    }
+
+    if (!retryableRequestTypes.includes(props.grpcRequest.path)) {
+      this.logger.debug(
+        `Request with type ${props.grpcRequest.path} is not retryable.`
+      );
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/config/retry/default-eligibility-strategy.ts
+++ b/src/config/retry/default-eligibility-strategy.ts
@@ -18,7 +18,7 @@ const retryableGrpcStatusCodes: Array<Status> = [
   // Status.ALREADY_EXISTS,
   // Status.PERMISSION_DENIED,
   // Status.RESOURCE_EXHAUSTED,
-  Status.FAILED_PRECONDITION,
+  // Status.FAILED_PRECONDITION,
   // Status.ABORTED,
   // Status.OUT_OF_RANGE,
   // Status.UNIMPLEMENTED,

--- a/src/config/retry/default-eligibility-strategy.ts
+++ b/src/config/retry/default-eligibility-strategy.ts
@@ -57,37 +57,6 @@ const retryableRequestTypes: Array<string> = [
   // not idempotent: '/cache_client.Scs/ListConcatenateBack'
 ];
 
-//
-// private readonly HashSet<Type> _retryableRequestTypes = new HashSet<Type>
-//   {
-//     typeof(_SetRequest),
-//     typeof(_GetRequest),
-//     typeof(_DeleteRequest),
-//     typeof(_DictionarySetRequest),
-//     // not idempotent: typeof(_DictionaryIncrementRequest),
-//     typeof(_DictionaryGetRequest),
-//     typeof(_DictionaryFetchRequest),
-//     typeof(_DictionaryDeleteRequest),
-//     typeof(_SetUnionRequest),
-//     typeof(_SetDifferenceRequest),
-//     typeof(_SetFetchRequest),
-//     // not idempotent: typeof(_ListPushFrontRequest),
-//     // not idempotent: typeof(_ListPushBackRequest),
-//     // not idempotent: typeof(_ListPopFrontRequest),
-//     // not idempotent: typeof(_ListPopBackRequest),
-//     typeof(_ListFetchRequest),
-//     /*
-//      *  Warning: in the future, this may not be idempotent
-//      *  Currently it supports removing all occurrences of a value.
-//      *  In the future, we may also add "the first/last N occurrences of a value".
-//      *  In the latter case it is not idempotent.
-//      */
-//     typeof(_ListRemoveRequest),
-//     typeof(_ListLengthRequest),
-//     // not idempotent: typeof(_ListConcatenateFrontRequest),
-//     // not idempotent: typeof(_ListConcatenateBackRequest)
-//   };
-
 export class DefaultEligibilityStrategy implements EligibilityStrategy {
   private readonly logger: Logger;
 
@@ -96,22 +65,6 @@ export class DefaultEligibilityStrategy implements EligibilityStrategy {
   }
 
   isEligibleForRetry(props: EligibleForRetryProps): boolean {
-    /*
-    if (!_retryableStatusCodes.Contains(status.StatusCode))
-            {
-                _logger.LogDebug("Response with status code {} is not retryable.", status.StatusCode);
-                return false;
-            }
-
-            if (!_retryableRequestTypes.Contains(request.GetType()))
-            {
-                _logger.LogDebug("Request with type {} is not retryable.", request.GetType());
-                return false;
-            }
-
-            return true;
-     */
-
     if (!retryableGrpcStatusCodes.includes(props.grpcStatus.code)) {
       this.logger.debug(
         `Response with status code ${props.grpcStatus.code} is not retryable.`

--- a/src/config/retry/eligibility-strategy.ts
+++ b/src/config/retry/eligibility-strategy.ts
@@ -1,0 +1,11 @@
+import {StatusObject} from '@grpc/grpc-js';
+import {ClientMethodDefinition} from '@grpc/grpc-js/build/src/make-client';
+
+export interface EligibleForRetryProps {
+  grpcStatus: StatusObject;
+  grpcRequest: ClientMethodDefinition<unknown, unknown>;
+}
+
+export interface EligibilityStrategy {
+  isEligibleForRetry(props: EligibleForRetryProps): boolean;
+}

--- a/src/config/retry/fixed-count-retry-strategy.ts
+++ b/src/config/retry/fixed-count-retry-strategy.ts
@@ -1,0 +1,47 @@
+import {
+  DeterminewhenToRetryRequestProps,
+  RetryStrategy,
+} from './retry-strategy';
+import {getLogger, Logger} from '../../utils/logging';
+import {EligibilityStrategy} from './eligibility-strategy';
+import {DefaultEligibilityStrategy} from './default-eligibility-strategy';
+
+export interface FixedCountRetryStrategyProps {
+  maxAttempts: number;
+  eligibilityStrategy?: EligibilityStrategy;
+}
+
+export class FixedCountRetryStrategy implements RetryStrategy {
+  private readonly logger: Logger;
+  private readonly eligibilityStrategy: EligibilityStrategy;
+  private readonly maxAttempts: number;
+
+  constructor(props: FixedCountRetryStrategyProps) {
+    this.logger = getLogger(this);
+    this.eligibilityStrategy =
+      props.eligibilityStrategy ?? new DefaultEligibilityStrategy();
+    this.maxAttempts = props.maxAttempts;
+  }
+
+  determineWhenToRetryRequest(
+    props: DeterminewhenToRetryRequestProps
+  ): number | null {
+    this.logger.debug(
+      `Determining whether request is eligible for retry; status code: ${props.grpcStatus.code}, request type: ${props.grpcRequest.path}, attemptNumber: ${props.attemptNumber}, maxAttempts: ${this.maxAttempts}`
+    );
+    if (!this.eligibilityStrategy.isEligibleForRetry(props)) {
+      // null means do not retry
+      return null;
+    }
+    if (props.attemptNumber > this.maxAttempts) {
+      this.logger.debug(`Exceeded max attempt count (${this.maxAttempts})`);
+      // null means do not retry
+      return null;
+    }
+    this.logger.debug(
+      `Request is eligible for retry (attempt ${props.attemptNumber} of ${this.maxAttempts}, retrying immediately.`
+    );
+    // 0 means retry immediately
+    return 0;
+  }
+}

--- a/src/config/retry/retry-strategy.ts
+++ b/src/config/retry/retry-strategy.ts
@@ -1,0 +1,14 @@
+import {StatusObject} from '@grpc/grpc-js';
+import {ClientMethodDefinition} from '@grpc/grpc-js/build/src/make-client';
+
+export interface DeterminewhenToRetryRequestProps {
+  grpcStatus: StatusObject;
+  grpcRequest: ClientMethodDefinition<unknown, unknown>;
+  attemptNumber: number;
+}
+
+export interface RetryStrategy {
+  determineWhenToRetryRequest(
+    props: DeterminewhenToRetryRequestProps
+  ): number | null;
+}

--- a/src/grpc/retry-interceptor.ts
+++ b/src/grpc/retry-interceptor.ts
@@ -85,7 +85,9 @@ export class RetryInterceptor {
                       savedMessageNext(savedReceiveMessage);
                       next(status);
                     } else {
-                      `Request eligible for retry: path: ${options.method_definition.path}; response status code: ${status.code}; number of attempts (${attempts}); will retry in ${whenToRetry}ms`;
+                      logger.debug(
+                        `Request eligible for retry: path: ${options.method_definition.path}; response status code: ${status.code}; number of attempts (${attempts}); will retry in ${whenToRetry}ms`
+                      );
                       setTimeout(() => retry(message, metadata), whenToRetry);
                     }
                   },
@@ -104,13 +106,15 @@ export class RetryInterceptor {
                   attemptNumber: attempts,
                 });
                 if (whenToRetry === null) {
-                  logger.trace(
+                  logger.debug(
                     `Request not eligible for retry: path: ${options.method_definition.path}; response status code: ${status.code}.`
                   );
                   savedMessageNext(savedReceiveMessage);
                   next(status);
                 } else {
-                  `Request eligible for retry: path: ${options.method_definition.path}; response status code: ${status.code}; number of attempts (${attempts}); will retry in ${whenToRetry}ms`;
+                  logger.debug(
+                    `Request eligible for retry: path: ${options.method_definition.path}; response status code: ${status.code}; number of attempts (${attempts}); will retry in ${whenToRetry}ms`
+                  );
                   setTimeout(
                     () => retry(savedSendMessage, savedMetadata),
                     whenToRetry

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -1504,7 +1504,7 @@ export class CacheClient {
     return [
       new HeaderInterceptor(headers).addHeadersInterceptor(),
       ClientTimeoutInterceptor(this.requestTimeoutMs),
-      ...createRetryInterceptorIfEnabled(),
+      ...createRetryInterceptorIfEnabled(this.configuration.getRetryStrategy()),
     ];
   }
 

--- a/src/internal/control-client.ts
+++ b/src/internal/control-client.ts
@@ -2,7 +2,6 @@ import {control} from '@gomomento/generated-types';
 import grpcControl = control.control_client;
 import {Header, HeaderInterceptor} from '../grpc/headers-interceptor';
 import {ClientTimeoutInterceptor} from '../grpc/client-timeout-interceptor';
-import {createRetryInterceptorIfEnabled} from '../grpc/retry-interceptor';
 import {Status} from '@grpc/grpc-js/build/src/constants';
 import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
@@ -46,7 +45,6 @@ export class ControlClient {
     this.interceptors = [
       new HeaderInterceptor(headers).addHeadersInterceptor(),
       ClientTimeoutInterceptor(ControlClient.REQUEST_TIMEOUT_MS),
-      ...createRetryInterceptorIfEnabled(),
     ];
     this.logger.debug(
       `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -33,6 +33,8 @@ import {
   CacheSetAddElement,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
+  Logger,
+  getLogger,
 } from '.';
 import {initializeMomentoLogging} from './utils/logging';
 import {range} from './utils/collections';
@@ -49,6 +51,7 @@ import {SimpleCacheClientProps} from './simple-cache-client-props';
  * @class SimpleCacheClient
  */
 export class SimpleCacheClient {
+  private readonly logger: Logger;
   private readonly configuration: Configuration;
   private readonly credentialProvider: CredentialProvider;
   private readonly dataClients: Array<CacheClient>;
@@ -60,6 +63,8 @@ export class SimpleCacheClient {
    */
   constructor(props: SimpleCacheClientProps) {
     initializeMomentoLogging(props.configuration.getLoggerOptions());
+    this.logger = getLogger(this);
+    this.logger.info('Instantiating Momento SimpleCacheClient');
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
 

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -37,8 +37,8 @@ interface InitializedLoggerOptions {
 }
 
 const _MOMENTO_LOGGING_OPTIONS: InitializedLoggerOptions = {
-  level: LogLevel.WARN,
-  format: LogFormat.JSON,
+  level: LogLevel.DEBUG,
+  format: LogFormat.CONSOLE,
 };
 
 export function initializeMomentoLogging(options?: LoggerOptions) {

--- a/test/config/configuration.test.ts
+++ b/test/config/configuration.test.ts
@@ -4,12 +4,14 @@ import {
   StaticGrpcConfiguration,
   StaticTransportStrategy,
 } from '../../src/config/transport/transport-strategy';
+import {FixedCountRetryStrategy} from '../../src/config/retry/fixed-count-retry-strategy';
 
 describe('configuration.ts', () => {
   const testLoggerOptions: LoggerOptions = {
     level: LogLevel.WARN,
     format: LogFormat.CONSOLE,
   };
+  const testRetryStrategy = new FixedCountRetryStrategy({maxAttempts: 1});
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: 90210,
     maxSessionMemoryMb: 90211,
@@ -21,6 +23,7 @@ describe('configuration.ts', () => {
   });
   const testConfiguration = new SimpleCacheConfiguration({
     loggerOptions: testLoggerOptions,
+    retryStrategy: testRetryStrategy,
     transportStrategy: testTransportStrategy,
   });
 
@@ -34,7 +37,25 @@ describe('configuration.ts', () => {
     expect(configWithNewLoggerOptions.getLoggerOptions()).toEqual(
       newLoggerOptions
     );
+    expect(configWithNewLoggerOptions.getRetryStrategy()).toEqual(
+      testRetryStrategy
+    );
     expect(configWithNewLoggerOptions.getTransportStrategy()).toEqual(
+      testTransportStrategy
+    );
+  });
+
+  it('should support overriding retry strategy', () => {
+    const newRetryStrategy = new FixedCountRetryStrategy({maxAttempts: 42});
+    const configWithNewRetryStrategy =
+      testConfiguration.withRetryStrategy(newRetryStrategy);
+    expect(configWithNewRetryStrategy.getLoggerOptions()).toEqual(
+      testLoggerOptions
+    );
+    expect(configWithNewRetryStrategy.getRetryStrategy()).toEqual(
+      newRetryStrategy
+    );
+    expect(configWithNewRetryStrategy.getTransportStrategy()).toEqual(
       testTransportStrategy
     );
   });
@@ -54,6 +75,9 @@ describe('configuration.ts', () => {
     expect(configWithNewTransportStrategy.getLoggerOptions()).toEqual(
       testLoggerOptions
     );
+    expect(configWithNewTransportStrategy.getRetryStrategy()).toEqual(
+      testRetryStrategy
+    );
     expect(configWithNewTransportStrategy.getTransportStrategy()).toEqual(
       newTransportStrategy
     );
@@ -72,6 +96,9 @@ describe('configuration.ts', () => {
       testConfiguration.withClientTimeoutMillis(newClientTimeoutMillis);
     expect(configWithNewClientTimeout.getLoggerOptions()).toEqual(
       testLoggerOptions
+    );
+    expect(configWithNewClientTimeout.getRetryStrategy()).toEqual(
+      testRetryStrategy
     );
     expect(configWithNewClientTimeout.getTransportStrategy()).toEqual(
       expectedTransportStrategy


### PR DESCRIPTION
This commit introduces the RetryStrategy interface as part of
our Configuration object.  Also introduces the most basic
retry strategy, FixedCountRetryStrategy, and wires it up
to the RetryInterceptor.

This causes some quirkiness with logging initialization and
highlights that the logging API needs to be re-worked a bit.
Will tackle that in a follow-up PR; in the meantime the logger
will log at DEBUG level.