### PR TITLE
fix: Prevent infinite loop in example

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -39,9 +39,9 @@ const main = async () => {
   }
 
   console.log('Listing caches:');
-  let token;
+  let token:string|undefined;
   do {
-    const listResponse = await momento.listCaches();
+    const listResponse = await momento.listCaches(token);
     if (listResponse instanceof ListCaches.Error) {
       console.log(`Error listing caches: ${listResponse.message()}`);
       break;
@@ -51,7 +51,7 @@ const main = async () => {
       });
       token = listResponse.getNextToken();
     }
-  } while (token !== null);
+  } while (token != null);
 
   const exampleTtlSeconds = 10;
   console.log(

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^16.11.4",
         "@types/node-fetch": "2.6.2",
         "@typescript-eslint/eslint-plugin": "5.30.5",
+        "@typescript-eslint/parser": "^5.0.0",
         "eslint": "8.19.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
@@ -364,7 +365,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
       "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.48.1",
         "@typescript-eslint/types": "5.48.1",
@@ -392,7 +392,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
       "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.48.1",
         "@typescript-eslint/visitor-keys": "5.48.1"
@@ -410,7 +409,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
       "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.48.1",
         "eslint-visitor-keys": "^3.3.0"
@@ -484,7 +482,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
       "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -498,7 +495,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
       "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.48.1",
         "@typescript-eslint/visitor-keys": "5.48.1",
@@ -526,7 +522,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
       "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "5.48.1",
         "eslint-visitor-keys": "^3.3.0"
@@ -3840,7 +3835,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
       "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.48.1",
         "@typescript-eslint/types": "5.48.1",
@@ -3853,7 +3847,6 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
           "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "@typescript-eslint/types": "5.48.1",
             "@typescript-eslint/visitor-keys": "5.48.1"
@@ -3864,7 +3857,6 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
           "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "@typescript-eslint/types": "5.48.1",
             "eslint-visitor-keys": "^3.3.0"
@@ -3905,15 +3897,13 @@
       "version": "5.48.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
       "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.48.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
       "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/types": "5.48.1",
         "@typescript-eslint/visitor-keys": "5.48.1",
@@ -3929,7 +3919,6 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
           "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "@typescript-eslint/types": "5.48.1",
             "eslint-visitor-keys": "^3.3.0"


### PR DESCRIPTION
Use loose equality when checking for the presence of a list caches
token so that null can be compared to undefined. Fixes an infinte
loop that is only broken by rate limiting.

Give the token to the list caches call to prevent an infinite loop
that would occur if there were more than one page of caches.
