### PR TITLE
fix: Differenciate response classes.

### DIFF
--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -142,7 +142,7 @@ describe('Integration tests for dictionary operations', () => {
         value: 'value2',
         ttl: CollectionTtl.of(timeout * 10).withNoRefreshTtlOnUpdates(),
       });
-      expect(changeResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(changeResponse).toBeInstanceOf(Success);
       await sleep(timeout * 1000);
 
       const getResponse = await Momento.dictionaryGetField(
@@ -174,7 +174,7 @@ describe('Integration tests for dictionary operations', () => {
         value: 'value2',
         ttl: CollectionTtl.of(timeout * 10).withRefreshTtlOnUpdates(),
       });
-      expect(changeResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      expect(changeResponse).toBeInstanceOf(Success);
       await sleep(timeout * 1000);
 
       const getResponse = await Momento.dictionaryGetField(
@@ -902,7 +902,7 @@ describe('Integration tests for dictionary operations', () => {
           dictionaryName,
           fields
         )
-      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
       expect(
         await Momento.dictionaryGetFields(
           IntegrationTestCacheName,
@@ -918,7 +918,7 @@ describe('Integration tests for dictionary operations', () => {
           dictionaryName,
           setFields
         )
-      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      ).toBeInstanceOf(CacheDictionarySetFields.Success);
       expect(
         await Momento.dictionaryGetFields(
           IntegrationTestCacheName,
@@ -964,7 +964,7 @@ describe('Integration tests for dictionary operations', () => {
           dictionaryName,
           fields
         )
-      ).toBeInstanceOf(CacheDictionaryRemoveField.Success);
+      ).toBeInstanceOf(CacheDictionaryRemoveFields.Success);
       expect(
         await Momento.dictionaryGetFields(
           IntegrationTestCacheName,
@@ -980,7 +980,7 @@ describe('Integration tests for dictionary operations', () => {
           dictionaryName,
           setFields
         )
-      ).toBeInstanceOf(CacheDictionarySetField.Success);
+      ).toBeInstanceOf(CacheDictionarySetFields.Success);
       expect(
         await Momento.dictionaryGetFields(
           IntegrationTestCacheName,

--- a/integration/integration-setup.ts
+++ b/integration/integration-setup.ts
@@ -9,7 +9,10 @@ import {
   MomentoErrorCode,
   SimpleCacheClient,
 } from '../src';
-import {Error, Response} from '../src/messages/responses/response-base';
+import {
+  IResponseError,
+  ResponseBase,
+} from '../src/messages/responses/response-base';
 
 function testCacheName(): string {
   const name = process.env.TEST_CACHE_NAME || 'js-integration-test-default';
@@ -107,12 +110,12 @@ export interface ValidateSetProps extends ValidateCacheProps {
 }
 
 export function ItBehavesLikeItValidatesCacheName(
-  getResponse: (props: ValidateCacheProps) => Promise<Response>
+  getResponse: (props: ValidateCacheProps) => Promise<ResponseBase>
 ) {
   it('validates its cache name', async () => {
     const response = await getResponse({cacheName: '   '});
 
-    expect((response as Error).errorCode()).toEqual(
+    expect((response as IResponseError).errorCode()).toEqual(
       MomentoErrorCode.INVALID_ARGUMENT_ERROR
     );
   });

--- a/integration/list.test.ts
+++ b/integration/list.test.ts
@@ -14,8 +14,8 @@ import {
   MomentoErrorCode,
 } from '../src';
 import {
-  Response,
-  Error,
+  ResponseBase,
+  IResponseError,
   IListResponseSuccess,
 } from '../src/messages/responses/response-base';
 import {
@@ -29,7 +29,7 @@ const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
 describe('lists', () => {
   const itBehavesLikeItValidates = (
-    getResponse: (props: ValidateListProps) => Promise<Response>
+    getResponse: (props: ValidateListProps) => Promise<ResponseBase>
   ) => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
       return getResponse({cacheName: props.cacheName, listName: v4()});
@@ -41,7 +41,7 @@ describe('lists', () => {
         listName: '  ',
       });
 
-      expect((response as Error).errorCode()).toEqual(
+      expect((response as IResponseError).errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
     });
@@ -56,7 +56,7 @@ describe('lists', () => {
   }
 
   const itBehavesLikeItHasACollectionTtl = (
-    addValue: (props: addValueProps) => Promise<Response>
+    addValue: (props: addValueProps) => Promise<ResponseBase>
   ) => {
     it('sets ttl', async () => {
       const listName = v4();
@@ -109,7 +109,7 @@ describe('lists', () => {
   };
 
   const itBehavesLikeItAddsValues = (
-    addValue: (props: addValueProps) => Promise<Response>
+    addValue: (props: addValueProps) => Promise<ResponseBase>
   ) => {
     it('returns the new list length', async () => {
       const listName = v4();
@@ -129,7 +129,7 @@ describe('lists', () => {
   };
 
   const itBehavesLikeItAddsValuesToTheBack = (
-    addValue: (props: addValueProps) => Promise<Response>
+    addValue: (props: addValueProps) => Promise<ResponseBase>
   ) => {
     itBehavesLikeItHasACollectionTtl(addValue);
     itBehavesLikeItAddsValues(addValue);
@@ -180,7 +180,7 @@ describe('lists', () => {
   };
 
   const itBehavesLikeItAddsValuesToTheFront = (
-    addValue: (props: addValueProps) => Promise<Response>
+    addValue: (props: addValueProps) => Promise<ResponseBase>
   ) => {
     itBehavesLikeItHasACollectionTtl(addValue);
     itBehavesLikeItAddsValues(addValue);

--- a/integration/set.test.ts
+++ b/integration/set.test.ts
@@ -15,7 +15,10 @@ import {
   ValidateSetProps,
   SetupIntegrationTest,
 } from './integration-setup';
-import {Response, Error} from '../src/messages/responses/response-base';
+import {
+  ResponseBase,
+  IResponseError,
+} from '../src/messages/responses/response-base';
 
 const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
 
@@ -24,7 +27,7 @@ const FOO_BYTE_ARRAY = Uint8Array.of(102, 111, 111);
 
 describe('Integration tests for convenience operations on sets datastructure', () => {
   const itBehavesLikeItValidates = (
-    getResponse: (props: ValidateSetProps) => Promise<Response>
+    getResponse: (props: ValidateSetProps) => Promise<ResponseBase>
   ) => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
       return getResponse({cacheName: props.cacheName, setName: v4()});
@@ -36,7 +39,7 @@ describe('Integration tests for convenience operations on sets datastructure', (
         setName: '  ',
       });
 
-      expect((response as Error).errorCode()).toEqual(
+      expect((response as IResponseError).errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
     });

--- a/src/messages/responses/cache-dictionary-fetch.ts
+++ b/src/messages/responses/cache-dictionary-fetch.ts
@@ -1,12 +1,18 @@
-import * as ResponseBase from './response-base';
+import {
+  ResponseBase,
+  ResponseHit,
+  ResponseMiss,
+  ResponseError,
+} from './response-base';
+import {SdkError} from '../../errors/errors';
 import {TextDecoder} from 'util';
 import {cache_client} from '@gomomento/generated-types/dist/cacheclient';
 
 const TEXT_DECODER = new TextDecoder();
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly items: cache_client._DictionaryFieldValuePair[];
   private readonly dictionaryUint8ArrayUint8Array: Map<Uint8Array, Uint8Array> =
     new Map();
@@ -70,3 +76,14 @@ export class Hit extends ResponseBase.Hit {
     return `${super.toString()}: valueDictionaryStringString: ${this.truncateValueStrings()}`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-dictionary-get-field.ts
+++ b/src/messages/responses/cache-dictionary-get-field.ts
@@ -1,11 +1,11 @@
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {TextDecoder} from 'util';
 import * as GetValue from './response-get-value';
+import {TextDecoder} from 'util';
 import {SdkError} from '../../errors/errors';
 
 const TEXT_DECODER = new TextDecoder();
 
-export {Response} from './response-get-value';
+export abstract class Response extends GetValue.Response {}
 
 export class Hit extends GetValue.Hit {
   private readonly field: Uint8Array;

--- a/src/messages/responses/cache-dictionary-get-fields.ts
+++ b/src/messages/responses/cache-dictionary-get-fields.ts
@@ -1,9 +1,14 @@
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
-import {TextDecoder} from 'util';
 import {cache} from '@gomomento/generated-types';
 import grpcCache = cache.cache_client;
-import {UnknownError} from '../../errors/errors';
-import * as ResponseBase from './response-base';
+import {TextDecoder} from 'util';
+import {SdkError, UnknownError} from '../../errors/errors';
+import {
+  ResponseBase,
+  ResponseHit,
+  ResponseMiss,
+  ResponseError,
+} from './response-base';
 import * as CacheDictionaryGetFieldResponse from './cache-dictionary-get-field';
 
 const TEXT_DECODER = new TextDecoder();
@@ -12,9 +17,9 @@ type CacheDictionaryGetFieldResponseType =
   | CacheDictionaryGetFieldResponse.Miss
   | CacheDictionaryGetFieldResponse.Error;
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly items: grpcCache._DictionaryGetResponse._DictionaryGetResponsePart[];
   private readonly fields: Uint8Array[];
   private readonly dictionaryUint8ArrayUint8Array: Map<Uint8Array, Uint8Array> =
@@ -102,3 +107,14 @@ export class Hit extends ResponseBase.Hit {
     )}`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(public _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-dictionary-increment.ts
+++ b/src/messages/responses/cache-dictionary-increment.ts
@@ -1,8 +1,10 @@
-import * as ResponseBase from './response-base';
+// older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success extends ResponseBase.Success {
+class _Success extends Response {
   private readonly value: number;
 
   constructor(value: number) {
@@ -18,3 +20,11 @@ export class Success extends ResponseBase.Success {
     return `${super.toString()}: value: ${this.valueNumber()}`;
   }
 }
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-list-concatenate.ts
+++ b/src/messages/responses/cache-list-concatenate.ts
@@ -1,11 +1,14 @@
-import * as ResponseBase from './response-base';
+import {
+  IListResponseSuccess,
+  ResponseBase,
+  ResponseError,
+  ResponseSuccess,
+} from './response-base';
+import {SdkError} from '../../errors/errors';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success
-  extends ResponseBase.Success
-  implements ResponseBase.IListResponseSuccess
-{
+class _Success extends Response implements IListResponseSuccess {
   private readonly _list_length: number;
   constructor(list_length: number) {
     super();
@@ -18,5 +21,13 @@ export class Success
 
   public override toString(): string {
     return `${super.toString()}: listLength: ${this._list_length}`;
+  }
+}
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {}
+export class Error extends ResponseError(_Error) {
+  constructor(public _innerException: SdkError) {
+    super();
   }
 }

--- a/src/messages/responses/cache-list-fetch.ts
+++ b/src/messages/responses/cache-list-fetch.ts
@@ -1,12 +1,18 @@
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseHit,
+  ResponseMiss,
+} from './response-base';
 import {TextDecoder} from 'util';
 import {truncateStringArray} from '../../utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly _values: Uint8Array[];
   constructor(values: Uint8Array[]) {
     super();
@@ -26,3 +32,14 @@ export class Hit extends ResponseBase.Hit {
     return `${super.toString()}: [${truncatedStringArray.toString()}]`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-list-length.ts
+++ b/src/messages/responses/cache-list-length.ts
@@ -1,8 +1,14 @@
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseHit,
+  ResponseMiss,
+} from './response-base';
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly _length: number;
   constructor(length: number) {
     super();
@@ -17,3 +23,14 @@ export class Hit extends ResponseBase.Hit {
     return `${super.toString()}: length ${this._length}`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-list-push.ts
+++ b/src/messages/responses/cache-list-push.ts
@@ -1,11 +1,14 @@
-import * as ResponseBase from './response-base';
+import {
+  IListResponseSuccess,
+  ResponseBase,
+  ResponseError,
+  ResponseSuccess,
+} from './response-base';
+import {SdkError} from '../../errors/errors';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success
-  extends ResponseBase.Success
-  implements ResponseBase.IListResponseSuccess
-{
+class _Success extends Response implements IListResponseSuccess {
   private readonly _list_length: number;
   constructor(list_length: number) {
     super();
@@ -18,5 +21,13 @@ export class Success
 
   public override toString(): string {
     return `${super.toString()}: listLength: ${this._list_length}`;
+  }
+}
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {}
+export class Error extends ResponseError(_Error) {
+  constructor(public _innerException: SdkError) {
+    super();
   }
 }

--- a/src/messages/responses/cache-set-add-elements.ts
+++ b/src/messages/responses/cache-set-add-elements.ts
@@ -1,18 +1,25 @@
-import * as ResponseBase from './response-base';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {SdkError} from '../../errors/errors';
 import * as CacheSetAddElement from './cache-set-add-element';
 
-export abstract class Response extends ResponseBase.Response {
+export abstract class Response extends ResponseBase {
   abstract toSingularResponse(): CacheSetAddElement.Response;
 }
 
-export class Success extends ResponseBase.Success {
+class _Success extends Response {
   toSingularResponse(): CacheSetAddElement.Response {
     return new CacheSetAddElement.Success();
   }
 }
+export class Success extends ResponseSuccess(_Success) {}
 
-export class Error extends ResponseBase.Error {
+class _Error extends Response {
+  constructor(public _innerException: SdkError) {
+    super();
+  }
+
   toSingularResponse(): CacheSetAddElement.Response {
     return new CacheSetAddElement.Error(this._innerException);
   }
 }
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-set-fetch.ts
+++ b/src/messages/responses/cache-set-fetch.ts
@@ -1,12 +1,18 @@
-import * as ResponseBase from './response-base';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseMiss,
+  ResponseHit,
+} from './response-base';
+import {SdkError} from '../../errors/errors';
 import {TextDecoder} from 'util';
 import {truncateStringArray} from '../../utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly elements: Uint8Array[];
 
   constructor(elements: Uint8Array[]) {
@@ -29,3 +35,14 @@ export class Hit extends ResponseBase.Hit {
     return `${super.toString()}: [${truncatedStringArray.toString()}]`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(public _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/cache-set-remove-elements.ts
+++ b/src/messages/responses/cache-set-remove-elements.ts
@@ -1,18 +1,18 @@
 import * as SimpleSuccess from './response-simple-success';
-import * as CacheSetAddElement from './cache-set-add-element';
+import * as CacheSetRemoveElement from './cache-set-remove-element';
 
 export abstract class Response extends SimpleSuccess.Response {
-  abstract toSingularResponse(): CacheSetAddElement.Response;
+  abstract toSingularResponse(): CacheSetRemoveElement.Response;
 }
 
 export class Success extends SimpleSuccess.Success {
-  toSingularResponse(): CacheSetAddElement.Response {
-    return new CacheSetAddElement.Success();
+  toSingularResponse(): CacheSetRemoveElement.Response {
+    return new CacheSetRemoveElement.Success();
   }
 }
 
 export class Error extends SimpleSuccess.Error {
-  toSingularResponse(): CacheSetAddElement.Response {
-    return new CacheSetAddElement.Error(this._innerException);
+  toSingularResponse(): CacheSetRemoveElement.Response {
+    return new CacheSetRemoveElement.Error(this._innerException);
   }
 }

--- a/src/messages/responses/create-signing-key.ts
+++ b/src/messages/responses/create-signing-key.ts
@@ -1,9 +1,10 @@
 import {control} from '@gomomento/generated-types';
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success extends ResponseBase.Success {
+class _Success extends Response {
   private readonly keyId: string;
   private readonly endpoint: string;
   private readonly key: string;
@@ -38,3 +39,11 @@ export class Success extends ResponseBase.Success {
     return this.expiresAt;
   }
 }
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/list-caches.ts
+++ b/src/messages/responses/list-caches.ts
@@ -1,10 +1,11 @@
 import {CacheInfo} from '../cache-info';
 import {control} from '@gomomento/generated-types';
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success extends ResponseBase.Success {
+class _Success extends Response {
   private readonly nextToken?: string;
   private readonly caches: CacheInfo[];
   constructor(result?: control.control_client._ListCachesResponse) {
@@ -28,3 +29,11 @@ export class Success extends ResponseBase.Success {
     return super.toString() + ': ' + caches.join(', ');
   }
 }
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/list-signing-keys.ts
+++ b/src/messages/responses/list-signing-keys.ts
@@ -1,10 +1,11 @@
 import {SigningKey} from '../signing-key';
 import {control} from '@gomomento/generated-types';
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
 
-export {Response, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Success extends ResponseBase.Success {
+class _Success extends Response {
   private readonly nextToken?: string;
   private readonly signingKeys: SigningKey[];
 
@@ -33,3 +34,11 @@ export class Success extends ResponseBase.Success {
     return this.signingKeys;
   }
 }
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/response-base.ts
+++ b/src/messages/responses/response-base.ts
@@ -9,6 +9,9 @@ export abstract class ResponseBase {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
 type Constructor = new (...args: any[]) => {};
 
+// These interfaces allow us to identify responses by their mixins.
+// They are only used to make shared tests work.
+// They are not for public consumption.
 export interface IResponseError {
   message(): string;
   innerException(): object;

--- a/src/messages/responses/response-base.ts
+++ b/src/messages/responses/response-base.ts
@@ -1,40 +1,67 @@
 import {MomentoErrorCode, SdkError} from '../../errors/errors';
 
-export abstract class Response {
+export abstract class ResponseBase {
   public toString(): string {
     return this.constructor.name;
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+type Constructor = new (...args: any[]) => {};
+
+export interface IResponseError {
+  message(): string;
+  innerException(): object;
+  errorCode(): MomentoErrorCode;
+  toString(): string;
+}
+
+export interface IResponseSuccess {
+  is_success: boolean;
+}
+
+export interface IResponseMiss {
+  is_miss: boolean;
 }
 
 export interface IListResponseSuccess {
   listLength(): number;
 }
 
-export class Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-    this._innerException = _innerException;
-  }
+export function ResponseError<TBase extends Constructor>(Base: TBase) {
+  return class ResponseError extends Base {
+    public _innerException: SdkError;
 
-  public message(): string {
-    return this._innerException.wrappedErrorMessage();
-  }
+    public message(): string {
+      return this._innerException.wrappedErrorMessage();
+    }
 
-  public innerException(): object {
-    return this._innerException;
-  }
+    public innerException(): object {
+      return this._innerException;
+    }
 
-  public errorCode(): MomentoErrorCode {
-    return this._innerException.errorCode();
-  }
+    public errorCode(): MomentoErrorCode {
+      return this._innerException.errorCode();
+    }
 
-  public toString(): string {
-    return this.message();
-  }
+    public toString(): string {
+      return this.message();
+    }
+  };
 }
 
-export class Hit extends Response {}
+export function ResponseHit<TBase extends Constructor>(Base: TBase) {
+  return class ResponseHit extends Base {};
+}
 
-export class Miss extends Response {}
+export function ResponseMiss<TBase extends Constructor>(Base: TBase) {
+  return class ResponseMiss extends Base {
+    public readonly is_miss: boolean = true;
+  };
+}
 
-export class Success extends Response {}
+export function ResponseSuccess<TBase extends Constructor>(Base: TBase) {
+  return class ResponseSuccess extends Base {
+    public readonly is_success: boolean = true;
+  };
+}

--- a/src/messages/responses/response-get-value.ts
+++ b/src/messages/responses/response-get-value.ts
@@ -1,13 +1,19 @@
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
 import {TextDecoder} from 'util';
-import * as ResponseBase from './response-base';
+import {SdkError} from '../../errors/errors';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseHit,
+  ResponseMiss,
+} from './response-base';
 import {truncateString} from '../../utils/display';
 
 const TEXT_DECODER = new TextDecoder();
 
-export {Response, Miss, Error} from './response-base';
+export abstract class Response extends ResponseBase {}
 
-export class Hit extends ResponseBase.Hit {
+class _Hit extends Response {
   private readonly body: Uint8Array;
   constructor(body: Uint8Array) {
     super();
@@ -30,3 +36,14 @@ export class Hit extends ResponseBase.Hit {
     return `${super.toString()}: ${display}`;
   }
 }
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}

--- a/src/messages/responses/response-simple-success.ts
+++ b/src/messages/responses/response-simple-success.ts
@@ -1,1 +1,14 @@
-export {Response, Error, Success} from './response-base';
+import {SdkError} from '../../errors/errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+
+export abstract class Response extends ResponseBase {}
+
+class _Success extends Response {}
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+export class Error extends ResponseError(_Error) {}


### PR DESCRIPTION
The switch from classes to mixins in 8d8757a98257ccc0ed6344e611026e24d7912240 caused many classes to actually be aliases. For example, `CacheDictionaryRemoveField.Success` and `CacheDictionaryRemoveFields.Success` were the same class. That means a response from DictionaryRemoveFields was an instance of both `CacheDictionaryRemoveField.Success` and `CacheDictionaryRemoveFields.Success`. The dictionary tests had several bugs of this kind.

This also confused IDEs, they would report the incorrect return type for responses.

<img width="565" alt="Screen Shot 2023-01-30 at 17 16 06" src="https://user-images.githubusercontent.com/25888/215656876-ddfcdc8e-0543-4faa-b3af-bf754b07e395.png">