### PR TITLE
fix: Make UNAVAILABLE errors retry correctly

### DIFF
--- a/src/grpc/retry-interceptor.ts
+++ b/src/grpc/retry-interceptor.ts
@@ -120,6 +120,8 @@ export class RetryInterceptor {
                     }
                   },
                 });
+                newCall.sendMessage(savedSendMessage);
+                newCall.halfClose();
               };
               if (retryableGrpcStatusCodes.includes(status.code)) {
                 logger.debug(
@@ -136,6 +138,10 @@ export class RetryInterceptor {
             },
           };
           next(metadata, newListener);
+        },
+        sendMessage: function (message, next) {
+          savedSendMessage = message;
+          next(message);
         },
       });
     };


### PR DESCRIPTION
Resend the retrying message and close the old one to make the retry
interceptor work on all retryable error types. Fix found on the grpc
github. Manually tested using the FAILED_PRECONDITION error type.

The changes to the retry interceptor were found [here](https://github.com/grpc/grpc-node/issues/284#issuecomment-415543782).

Using a CHECK_PRECONDITION error caused by a dictionary increment overflow, the code before the fix would get into the retryer but not actually retry:

> Request path: /cache_client.Scs/DictionaryIncrement; response status code: 9; number of retries (0) is less than max (3), retrying.
Increment failed! TIMEOUT_ERROR: The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts: 4 DEADLINE_EXCEEDED: undefined

By adding the half close, the retry would occur, but it wouldn't actually retry and would fail with an INTERNAL_SERVER_ERROR:

> Request path: /cache_client.Scs/DictionaryIncrement; response status code: 9; number of retries (0) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 13; number of retries (1) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 13; number of retries (2) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 13; number of retries (3) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 13; number of retries (4) has exceeded max (3), not retrying.
Increment failed! INTERNAL_SERVER_ERROR: An unexpected error occurred while trying to fulfill the request;

With both the close and the send, the code properly retries before giving up and returning the correct error:

> Request path: /cache_client.Scs/DictionaryIncrement; response status code: 9; number of retries (0) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 9; number of retries (1) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 9; number of retries (2) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 9; number of retries (3) is less than max (3), retrying.
Request path: /cache_client.Scs/DictionaryIncrement; retryable status code: 9; number of retries (4) has exceeded max (3), not retrying.
Increment failed! FAILED_PRECONDITION_ERROR: System is not in a state required for the operation's execution