### PR TITLE
fix: remove environment variable requirement for test

### DIFF
--- a/test/simple-cache-client.test.ts
+++ b/test/simple-cache-client.test.ts
@@ -1,12 +1,9 @@
-import {
-  Configurations,
-  InvalidArgumentError,
-  SimpleCacheClient,
-  EnvMomentoTokenProvider,
-} from '../src';
+import {Configurations, InvalidArgumentError, SimpleCacheClient} from '../src';
 import * as CreateCache from '../src/messages/responses/create-cache';
-const credentialProvider = new EnvMomentoTokenProvider({
-  environmentVariableName: 'TEST_AUTH_TOKEN',
+import {StringMomentoTokenProvider} from '../src/auth/credential-provider';
+const credentialProvider = new StringMomentoTokenProvider({
+  authToken:
+    'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI',
 });
 const configuration = Configurations.Laptop.latest();
 


### PR DESCRIPTION
Hardcode a fake auth token in simple-cache-client.test.ts to stop it from requiring the TEST_AUTH_TOKEN environment variable. The auth token was taken from an older version of the test.