### PR TITLE
chore: replace dictionary set fields array with map

### DIFF
--- a/integration/dictionary.test.ts
+++ b/integration/dictionary.test.ts
@@ -207,10 +207,10 @@ describe('Integration tests for dictionary operations', () => {
       await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ]
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ])
       );
 
       const response = await Momento.dictionaryFetch(
@@ -256,10 +256,10 @@ describe('Integration tests for dictionary operations', () => {
       await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ]
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ])
       );
 
       const response = await Momento.dictionaryFetch(
@@ -287,10 +287,10 @@ describe('Integration tests for dictionary operations', () => {
       const setResponse = await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ]
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ])
       );
       expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
 
@@ -327,11 +327,11 @@ describe('Integration tests for dictionary operations', () => {
       await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: v4(), value: v4()},
-          {field: v4(), value: v4()},
-          {field: v4(), value: v4()},
-        ]
+        new Map([
+          [v4(), v4()],
+          [v4(), v4()],
+          [v4(), v4()],
+        ])
       );
 
       let response = await Momento.dictionaryFetch(
@@ -883,10 +883,10 @@ describe('Integration tests for dictionary operations', () => {
         new TextEncoder().encode(v4()),
         new TextEncoder().encode(v4()),
       ];
-      const setFields = [
-        {field: fields[0], value: v4()},
-        {field: fields[1], value: v4()},
-      ];
+      const setFields = new Map([
+        [fields[0], v4()],
+        [fields[1], v4()],
+      ]);
 
       // When the fields do not exist.
       expect(
@@ -945,10 +945,10 @@ describe('Integration tests for dictionary operations', () => {
     it('should remove string fields', async () => {
       const dictionaryName = v4();
       const fields = [v4(), v4()];
-      const setFields = [
-        {field: fields[0], value: v4()},
-        {field: fields[1], value: v4()},
-      ];
+      const setFields = new Map([
+        [fields[0], v4()],
+        [fields[1], v4()],
+      ]);
 
       // When the fields do not exist.
       expect(
@@ -1100,7 +1100,7 @@ describe('Integration tests for dictionary operations', () => {
       return Momento.dictionarySetFields(
         props.cacheName,
         props.dictionaryName,
-        [{field: props.field, value: v4()}]
+        new Map([[props.field, v4()]])
       );
     };
 
@@ -1108,7 +1108,7 @@ describe('Integration tests for dictionary operations', () => {
       return Momento.dictionarySetFields(
         props.cacheName,
         props.dictionaryName,
-        [{field: props.field, value: props.value}],
+        new Map([[props.field, props.value]]),
         props.ttl
       );
     };
@@ -1125,10 +1125,10 @@ describe('Integration tests for dictionary operations', () => {
       const response = await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ],
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ]),
         CollectionTtl.of(10)
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
@@ -1161,10 +1161,10 @@ describe('Integration tests for dictionary operations', () => {
       const response = await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ],
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ]),
         CollectionTtl.of(10)
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
@@ -1197,10 +1197,10 @@ describe('Integration tests for dictionary operations', () => {
       const response = await Momento.dictionarySetFields(
         IntegrationTestCacheName,
         dictionaryName,
-        [
-          {field: field1, value: value1},
-          {field: field2, value: value2},
-        ],
+        new Map([
+          [field1, value1],
+          [field2, value2],
+        ]),
         CollectionTtl.of(10)
       );
       expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);

--- a/src/internal/cache-client.ts
+++ b/src/internal/cache-client.ts
@@ -1086,7 +1086,7 @@ export class CacheClient {
   public async dictionarySendFields(
     cacheName: string,
     dictionaryName: string,
-    items: {field: string | Uint8Array; value: string | Uint8Array}[],
+    items: Map<string | Uint8Array, string | Uint8Array>,
     ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
   ): Promise<CacheDictionarySetFields.Response> {
     try {
@@ -1103,11 +1103,11 @@ export class CacheClient {
       }`
     );
 
-    const dictionaryFieldValuePairs = items.map(
+    const dictionaryFieldValuePairs = [...items.entries()].map(
       item =>
         new grpcCache._DictionaryFieldValuePair({
-          field: this.convert(item.field),
-          value: this.convert(item.value),
+          field: this.convert(item[0]),
+          value: this.convert(item[1]),
         })
     );
     const result = await this.sendDictionarySetFields(

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -492,15 +492,15 @@ export class SimpleCacheClient {
    * Set several dictionary field-value pairs in the cache.
    * @param {string} cacheName - Name of the cache to store the dictionary in.
    * @param {string} dictionaryName - The dictionary to set.
-   * @param {{field: string | Uint8Array; value: string | Uint8Array}[]} items - The field-value pairs in the dictionary to set.
+   * @param {Map<string | Uint8Array, string | Uint8Array>} items - The field-value pairs in the dictionary to set.
    * @param {CollectionTtl} ttl -  TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
-   * @returns {Promise<CacheDictionarySetFieldsResponse>}- Promise containing the result of the cache operation.
+   * @returns {Promise<CacheDictionarySetFields.Response>}- Promise containing the result of the cache operation.
    * @memberof SimpleCacheClient
    */
   public async dictionarySetFields(
     cacheName: string,
     dictionaryName: string,
-    items: {field: string | Uint8Array; value: string | Uint8Array}[],
+    items: Map<string | Uint8Array, string | Uint8Array>,
     ttl?: CollectionTtl
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();


### PR DESCRIPTION
Replace the fields array of key value pairs with a Map.

Tested against the integration tests.