### PR TITLE
feat: rename dictionary value accessors, add Record accessors

### DIFF
--- a/src/messages/responses/cache-dictionary-fetch.ts
+++ b/src/messages/responses/cache-dictionary-fetch.ts
@@ -14,11 +14,6 @@ export abstract class Response extends ResponseBase {}
 
 class _Hit extends Response {
   private readonly items: cache_client._DictionaryFieldValuePair[];
-  private readonly dictionaryUint8ArrayUint8Array: Map<Uint8Array, Uint8Array> =
-    new Map();
-  private readonly dictionaryStringString: Map<string, string> = new Map();
-  private readonly dictionaryStringArrayBuffer: Map<string, Uint8Array> =
-    new Map();
   private readonly _displayListSizeLimit = 5;
 
   constructor(items: cache_client._DictionaryFieldValuePair[]) {
@@ -26,35 +21,51 @@ class _Hit extends Response {
     this.items = items;
   }
 
-  public valueDictionaryUint8ArrayUint8Array(): Map<Uint8Array, Uint8Array> {
-    for (const item of this.items) {
-      this.dictionaryUint8ArrayUint8Array.set(item.field, item.value);
-    }
-    return this.dictionaryUint8ArrayUint8Array;
+  public valueMap(): Map<string, string> {
+    return this.valueMapStringString();
   }
 
-  public valueDictionaryStringString(): Map<string, string> {
-    for (const item of this.items) {
-      this.dictionaryStringString.set(
-        TEXT_DECODER.decode(item.field),
-        TEXT_DECODER.decode(item.value)
-      );
-    }
-    return this.dictionaryStringString;
+  public valueMapUint8ArrayUint8Array(): Map<Uint8Array, Uint8Array> {
+    return this.items.reduce((acc, item) => {
+      acc.set(item.field, item.value);
+      return acc;
+    }, new Map<Uint8Array, Uint8Array>());
   }
 
-  public valueDictionaryStringUint8Array(): Map<string, Uint8Array> {
-    for (const item of this.items) {
-      this.dictionaryStringArrayBuffer.set(
-        TEXT_DECODER.decode(item.field),
-        item.value
-      );
-    }
-    return this.dictionaryStringArrayBuffer;
+  public valueMapStringString(): Map<string, string> {
+    return this.items.reduce((acc, item) => {
+      acc.set(TEXT_DECODER.decode(item.field), TEXT_DECODER.decode(item.value));
+      return acc;
+    }, new Map<string, string>());
+  }
+
+  public valueMapStringUint8Array(): Map<string, Uint8Array> {
+    return this.items.reduce((acc, item) => {
+      acc.set(TEXT_DECODER.decode(item.field), item.value);
+      return acc;
+    }, new Map<string, Uint8Array>());
+  }
+
+  public valueRecord(): Record<string, string> {
+    return this.valueRecordStringString();
+  }
+
+  public valueRecordStringString(): Record<string, string> {
+    return this.items.reduce<Record<string, string>>((acc, item) => {
+      acc[TEXT_DECODER.decode(item.field)] = TEXT_DECODER.decode(item.value);
+      return acc;
+    }, {});
+  }
+
+  public valueRecordStringUint8Array(): Record<string, Uint8Array> {
+    return this.items.reduce<Record<string, Uint8Array>>((acc, item) => {
+      acc[TEXT_DECODER.decode(item.field)] = item.value;
+      return acc;
+    }, {});
   }
 
   private truncateValueStrings(): string {
-    const keyValueIterable = this.valueDictionaryStringString().entries();
+    const keyValueIterable = this.valueMapStringString().entries();
     const keyValueArray = Array.from(keyValueIterable);
     if (keyValueArray.length <= this._displayListSizeLimit) {
       const pairs: string[] = [];

--- a/src/simple-cache-client.ts
+++ b/src/simple-cache-client.ts
@@ -500,7 +500,9 @@ export class SimpleCacheClient {
   public async dictionarySetFields(
     cacheName: string,
     dictionaryName: string,
-    items: Map<string | Uint8Array, string | Uint8Array>,
+    items:
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Record<string, string | Uint8Array>,
     ttl?: CollectionTtl
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();


### PR DESCRIPTION
This commit makes a few changes to the Dictionary APIs to help
simplify our in-browser demo code.

Changes include:
* DictionarySetFields can now be called with a Record literal input
  rather than needing to construct a Map.
* DictionaryFetch and DictonaryGetFields: renamed `valueDictionary*`
  value accessor names to `valueMap*` to make it more obvious what
  the return type will be.
* DictionaryFetch and DictonaryGetFields: added `valueRecord*` accessors
  so that users can avoid dealing with `Map`s if their field names
  are strings.
* DictionarySetFields now accepts a Record or a Map as input.
