### PR TITLE
Update constructor in docs for EnvMomentoTokenProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const cacheName = 'cache';
 const cacheKey = 'key';
 const cacheValue = 'value';
 
-const credentialsProvider = new EnvMomentoTokenProvider('MOMENTO_AUTH_TOKEN');
+const credentialsProvider = new EnvMomentoTokenProvider({ environmentVariableName: 'MOMENTO_AUTH_TOKEN' });
 
 const loggerOptions: LoggerOptions = {
   level: LogLevel.INFO,


### PR DESCRIPTION
The example in the README passed the env variable as a param. But it actually needs to be in a `props` object.