### PR TITLE
feat: improve logger exports, add DefaultMomentoLoggerFactory

### DIFF
--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -6,15 +6,15 @@ import {
 } from './transport/transport-strategy';
 import {GrpcConfiguration} from './transport/grpc-configuration';
 import {FixedCountRetryStrategy} from './retry/fixed-count-retry-strategy';
-import {PinoMomentoLoggerFactory} from './logging/pino-momento-logger';
 import {MomentoLoggerFactory} from './logging/momento-logger';
 import {RetryStrategy} from './retry/retry-strategy';
+import {DefaultMomentoLoggerFactory} from './logging/default-momento-logger';
 
 // 4 minutes.  We want to remain comfortably underneath the idle timeout for AWS NLB, which is 350s.
 const defaultMaxIdleMillis = 4 * 60 * 1_000;
 const defaultMaxSessionMemoryMb = 256;
 const defaultLoggerFactory: MomentoLoggerFactory =
-  new PinoMomentoLoggerFactory();
+  new DefaultMomentoLoggerFactory();
 
 function defaultRetryStrategy(
   loggerFactory: MomentoLoggerFactory

--- a/src/config/logging/default-momento-logger.ts
+++ b/src/config/logging/default-momento-logger.ts
@@ -1,0 +1,25 @@
+import {PinoMomentoLoggerFactory} from './pino-momento-logger';
+
+export enum DefaultMomentoLoggerLevel {
+  TRACE = 'trace',
+  DEBUG = 'debug',
+  INFO = 'info',
+  WARN = 'warn',
+  ERROR = 'error',
+}
+
+export class DefaultMomentoLoggerFactory extends PinoMomentoLoggerFactory {
+  constructor(
+    level: DefaultMomentoLoggerLevel = DefaultMomentoLoggerLevel.INFO
+  ) {
+    super({
+      level: level.valueOf(),
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+        },
+      },
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,16 @@ export {
 } from './config/logging/momento-logger';
 
 export {
+  PinoMomentoLogger,
+  PinoMomentoLoggerFactory,
+} from './config/logging/pino-momento-logger';
+
+export {
+  DefaultMomentoLoggerFactory,
+  DefaultMomentoLoggerLevel,
+} from './config/logging/default-momento-logger';
+
+export {
   CollectionTtl,
   Configurations,
   Configuration,

--- a/test/config/configuration.test.ts
+++ b/test/config/configuration.test.ts
@@ -4,11 +4,11 @@ import {
   StaticTransportStrategy,
 } from '../../src/config/transport/transport-strategy';
 import {FixedCountRetryStrategy} from '../../src/config/retry/fixed-count-retry-strategy';
-import {PinoMomentoLoggerFactory} from '../../src/config/logging/pino-momento-logger';
 import {NoopMomentoLoggerFactory} from '../../src/config/logging/noop-momento-logger';
+import {DefaultMomentoLoggerFactory} from '../../src';
 
 describe('configuration.ts', () => {
-  const testLoggerFactory = new PinoMomentoLoggerFactory();
+  const testLoggerFactory = new DefaultMomentoLoggerFactory();
   const testRetryStrategy = new FixedCountRetryStrategy({
     loggerFactory: testLoggerFactory,
     maxAttempts: 1,


### PR DESCRIPTION
While updating the examples to use the new logging API, I found a
few things that didn't feel right:

1. The pino logger wasn't exported properly so the imports looked weird
2. It felt weird for users to have to be exposed to the name Pino if they
   weren't really interested in digging in to logs.

This commit fixes the imports, and adds DefaultMomentoLoggerFactory
as a wrapper around the Pino factory to make the UX a little better
for users who don't care about the underlying logger details.
