### PR TITLE
feat: use new `web.` prefix for DNS names for web sdk

### DIFF
--- a/packages/client-sdk-web/src/cache-client.ts
+++ b/packages/client-sdk-web/src/cache-client.ts
@@ -9,6 +9,7 @@ import {
   IPingClient,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import {CacheClientProps} from './cache-client-props';
+import {getWebCacheEndpoint} from './utils/web-client-utils';
 
 export class CacheClient extends AbstractCacheClient implements ICacheClient {
   constructor(props: CacheClientProps) {
@@ -36,7 +37,7 @@ function createDataClient(props: CacheClientProps): IDataClient {
 
 function createPingClient(props: CacheClientProps): IPingClient {
   return new PingClient({
-    endpoint: props.credentialProvider.getCacheEndpoint(),
+    endpoint: getWebCacheEndpoint(props.credentialProvider),
     configuration: props.configuration,
   });
 }

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -27,6 +27,7 @@ import {
   validateValidForSeconds,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
+import {getWebControlEndpoint} from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 
 export class InternalWebGrpcAuthClient<
@@ -43,7 +44,7 @@ export class InternalWebGrpcAuthClient<
     this.clientMetadataProvider = new ClientMetadataProvider({});
     this.authClient = new auth.AuthClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://web.${this.creds.getControlEndpoint()}`,
+      `https://${getWebControlEndpoint(this.creds)}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/control-client.ts
+++ b/packages/client-sdk-web/src/internal/control-client.ts
@@ -50,7 +50,8 @@ export class ControlClient<
       authToken: props.credentialProvider.getAuthToken(),
     });
     this.clientWrapper = new control.ScsControlClient(
-      `https://${props.credentialProvider.getControlEndpoint()}`,
+      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+      `https://web.${props.credentialProvider.getControlEndpoint()}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/control-client.ts
+++ b/packages/client-sdk-web/src/internal/control-client.ts
@@ -20,6 +20,7 @@ import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {IControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {validateCacheName} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {getWebControlEndpoint} from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 
 export interface ControlClientProps {
@@ -43,7 +44,9 @@ export class ControlClient<
   constructor(props: ControlClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
     this.logger.debug(
-      `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
+      `Creating control client using endpoint: '${getWebControlEndpoint(
+        props.credentialProvider
+      )}`
     );
 
     this.clientMetadataProvider = new ClientMetadataProvider({
@@ -51,7 +54,7 @@ export class ControlClient<
     });
     this.clientWrapper = new control.ScsControlClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://web.${props.credentialProvider.getControlEndpoint()}`,
+      `https://${getWebControlEndpoint(props.credentialProvider)}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -152,7 +152,8 @@ export class DataClient<
       authToken: props.credentialProvider.getAuthToken(),
     });
     this.clientWrapper = new cache.ScsClient(
-      `https://${props.credentialProvider.getCacheEndpoint()}`,
+      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+      `https://web.${props.credentialProvider.getCacheEndpoint()}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -110,6 +110,7 @@ import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   convertToB64String,
   createCallMetadata,
+  getWebCacheEndpoint,
 } from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 
@@ -140,7 +141,9 @@ export class DataClient<
   constructor(props: DataClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
     this.logger.debug(
-      `Creating data client using endpoint: '${props.credentialProvider.getCacheEndpoint()}`
+      `Creating data client using endpoint: '${getWebCacheEndpoint(
+        props.credentialProvider
+      )}`
     );
 
     this.deadlineMillis = props.configuration
@@ -153,7 +156,7 @@ export class DataClient<
     });
     this.clientWrapper = new cache.ScsClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://web.${props.credentialProvider.getCacheEndpoint()}`,
+      `https://${getWebCacheEndpoint(props.credentialProvider)}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/ping-client.ts
+++ b/packages/client-sdk-web/src/internal/ping-client.ts
@@ -27,7 +27,8 @@ export class PingClient<
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
     this.clientMetadataProvider = new ClientMetadataProvider({});
     this.clientWrapper = new ping.PingClient(
-      `https://${props.endpoint}:443`,
+      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+      `https://web.${props.endpoint}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/ping-client.ts
+++ b/packages/client-sdk-web/src/internal/ping-client.ts
@@ -28,7 +28,7 @@ export class PingClient<
     this.clientMetadataProvider = new ClientMetadataProvider({});
     this.clientWrapper = new ping.PingClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://web.${props.endpoint}`,
+      `https://${props.endpoint}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -21,6 +21,7 @@ import {
 import {
   convertToB64String,
   createCallMetadata,
+  getWebCacheEndpoint,
 } from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 
@@ -53,12 +54,14 @@ export class PubsubClient<
     this.requestTimeoutMs =
       grpcConfig.getDeadlineMillis() || PubsubClient.DEFAULT_REQUEST_TIMEOUT_MS;
     this.logger.debug(
-      `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
+      `Creating topic client using endpoint: '${getWebCacheEndpoint(
+        this.credentialProvider
+      )}'`
     );
 
     this.client = new pubsub.PubsubClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://web.${props.credentialProvider.getCacheEndpoint()}`,
+      `https://${getWebCacheEndpoint(props.credentialProvider)}`,
       null,
       {}
     );
@@ -68,7 +71,7 @@ export class PubsubClient<
   }
 
   public getEndpoint(): string {
-    const endpoint = this.credentialProvider.getCacheEndpoint();
+    const endpoint = getWebCacheEndpoint(this.credentialProvider);
     this.logger.debug(`Using cache endpoint: ${endpoint}`);
     return endpoint;
   }

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -57,7 +57,8 @@ export class PubsubClient<
     );
 
     this.client = new pubsub.PubsubClient(
-      `https://${props.credentialProvider.getCacheEndpoint()}`,
+      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+      `https://web.${props.credentialProvider.getCacheEndpoint()}`,
       null,
       {}
     );

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -1,3 +1,5 @@
+import {CredentialProvider} from '@gomomento/sdk-core';
+
 export function convertToB64String(v: string | Uint8Array): string {
   if (typeof v === 'string') {
     return btoa(v);
@@ -13,4 +15,16 @@ export function createCallMetadata(
 ): {cache: string; deadline: string} {
   const deadline = Date.now() + timeoutMillis;
   return {cache: cacheName, deadline: deadline.toString()};
+}
+
+export function getWebControlEndpoint(
+  credentialProvider: CredentialProvider
+): string {
+  return `web.${credentialProvider.getControlEndpoint()}`;
+}
+
+export function getWebCacheEndpoint(
+  credentialProvider: CredentialProvider
+): string {
+  return `web.${credentialProvider.getCacheEndpoint()}`;
 }


### PR DESCRIPTION
We are using distinct DNS names for the grpc-web endpoints to give
us maximum flexibility on the server going forward. This commit updates
the web SDK clients to use the new prefix.
