### PR TITLE
fix: remove maxWorkers=1 flag for prod

### DIFF
--- a/scripts/build-and-test-package.sh
+++ b/scripts/build-and-test-package.sh
@@ -11,5 +11,5 @@ ${ROOT_DIR}/scripts/build-package.sh ${1}
 
 pushd ${ROOT_DIR}/packages/${1}
     npm run unit-test
-    npm run integration-test -- --maxWorkers 1
+    npm run integration-test
 popd


### PR DESCRIPTION
I added this flag a while back because without it, too many concurrent
tests will run on developer laptops and you get throttling errors.
I had added maxWorkers=1 to the script to allow the tests to pass on
my laptop, but did not mean to commit that for prod.
