### PR TITLE
chore: Differentiate web from nodejs agent

### DIFF
--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -40,7 +40,7 @@ export class InternalWebGrpcAuthClient<
 
   constructor(props: AuthClientProps) {
     this.creds = props.credentialProvider;
-    const headers = [new Header('Agent', `nodejs:${version}`)];
+    const headers = [new Header('Agent', `web:${version}`)];
 
     this.interceptors = [
       new HeaderInterceptorProvider<REQ, RESP>(

--- a/packages/client-sdk-web/src/internal/client-metadata-provider.ts
+++ b/packages/client-sdk-web/src/internal/client-metadata-provider.ts
@@ -1,0 +1,33 @@
+import {version} from '../../package.json';
+
+export interface ClientMetadataProps {
+  authToken?: string;
+}
+
+/**
+ * Provider for metadata about a client.
+ */
+export class ClientMetadataProvider {
+  private static readonly agentName: string = 'js-web';
+  private readonly authToken?: string;
+  private isAgentSent = false;
+  constructor(props: ClientMetadataProps) {
+    this.authToken = props.authToken;
+  }
+
+  /**
+   * Creates a client metadata header map. Provides an authorization header if an auth token is present. Provides an
+   * agent string on the first call.
+   */
+  public createClientMetadata(): {[key: string]: string} {
+    const metadata: {[key: string]: string} = {};
+    if (this.authToken) {
+      metadata['authorization'] = this.authToken;
+    }
+    if (!this.isAgentSent) {
+      this.isAgentSent = true;
+      metadata['Agent'] = `${ClientMetadataProvider.agentName}:${version}`;
+    }
+    return metadata;
+  }
+}

--- a/packages/client-sdk-web/src/internal/control-client.ts
+++ b/packages/client-sdk-web/src/internal/control-client.ts
@@ -43,7 +43,7 @@ export class ControlClient<
    */
   constructor(props: ControlClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    const headers = [new Header('Agent', `nodejs:${version}`)];
+    const headers = [new Header('Agent', `web:${version}`)];
     this.interceptors = [
       new HeaderInterceptorProvider<REQ, RESP>(
         headers

--- a/packages/client-sdk-web/src/internal/control-client.ts
+++ b/packages/client-sdk-web/src/internal/control-client.ts
@@ -8,10 +8,8 @@ import {
   CacheFlush,
   CacheInfo,
 } from '..';
-import {version} from '../../package.json';
 import {Configuration} from '../config/configuration';
-import {Request, StatusCode, UnaryInterceptor, UnaryResponse} from 'grpc-web';
-import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
+import {Request, StatusCode, UnaryResponse} from 'grpc-web';
 import {
   _CreateCacheRequest,
   _DeleteCacheRequest,
@@ -22,6 +20,7 @@ import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {IControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {validateCacheName} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {ClientMetadataProvider} from './client-metadata-provider';
 
 export interface ControlClientProps {
   configuration: Configuration;
@@ -34,32 +33,26 @@ export class ControlClient<
 > implements IControlClient
 {
   private readonly clientWrapper: control.ScsControlClient;
-  private readonly interceptors: UnaryInterceptor<REQ, RESP>[];
   private readonly logger: MomentoLogger;
-  private readonly authHeaders: {authorization: string};
+
+  private readonly clientMetadataProvider: ClientMetadataProvider;
 
   /**
    * @param {ControlClientProps} props
    */
   constructor(props: ControlClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    const headers = [new Header('Agent', `web:${version}`)];
-    this.interceptors = [
-      new HeaderInterceptorProvider<REQ, RESP>(
-        headers
-      ).createHeadersInterceptor(),
-    ];
     this.logger.debug(
       `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
     );
 
-    this.authHeaders = {authorization: props.credentialProvider.getAuthToken()};
+    this.clientMetadataProvider = new ClientMetadataProvider({
+      authToken: props.credentialProvider.getAuthToken(),
+    });
     this.clientWrapper = new control.ScsControlClient(
       `https://${props.credentialProvider.getControlEndpoint()}`,
       null,
-      {
-        unaryInterceptors: this.interceptors,
-      }
+      {}
     );
   }
 
@@ -76,7 +69,7 @@ export class ControlClient<
     return await new Promise<CreateCache.Response>(resolve => {
       this.clientWrapper.createCache(
         request,
-        this.authHeaders,
+        this.clientMetadataProvider.createClientMetadata(),
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (err) {
@@ -105,7 +98,7 @@ export class ControlClient<
     return await new Promise<DeleteCache.Response>(resolve => {
       this.clientWrapper.deleteCache(
         request,
-        this.authHeaders,
+        this.clientMetadataProvider.createClientMetadata(),
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (err) {
@@ -136,7 +129,7 @@ export class ControlClient<
     return await new Promise<CacheFlush.Response>(resolve => {
       this.clientWrapper.flushCache(
         request,
-        this.authHeaders,
+        this.clientMetadataProvider.createClientMetadata(),
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (resp) {
@@ -154,16 +147,20 @@ export class ControlClient<
     request.setNextToken('');
     this.logger.debug("Issuing 'listCaches' request");
     return await new Promise<ListCaches.Response>(resolve => {
-      this.clientWrapper.listCaches(request, this.authHeaders, (err, resp) => {
-        if (err) {
-          resolve(new ListCaches.Error(cacheServiceErrorMapper(err)));
-        } else {
-          const caches = resp
-            .getCacheList()
-            .map(cache => new CacheInfo(cache.getCacheName()));
-          resolve(new ListCaches.Success(caches));
+      this.clientWrapper.listCaches(
+        request,
+        this.clientMetadataProvider.createClientMetadata(),
+        (err, resp) => {
+          if (err) {
+            resolve(new ListCaches.Error(cacheServiceErrorMapper(err)));
+          } else {
+            const caches = resp
+              .getCacheList()
+              .map(cache => new CacheInfo(cache.getCacheName()));
+            resolve(new ListCaches.Success(caches));
+          }
         }
-      });
+      );
     });
   }
 }

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -142,7 +142,7 @@ export class DataClient<
    */
   constructor(props: DataClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    const headers = [new Header('Agent', `nodejs:${version}`)];
+    const headers = [new Header('Agent', `web:${version}`)];
     this.interceptors = [
       new HeaderInterceptorProvider<REQ, RESP>(
         headers

--- a/packages/client-sdk-web/src/internal/ping-client.ts
+++ b/packages/client-sdk-web/src/internal/ping-client.ts
@@ -26,7 +26,7 @@ export class PingClient<
    */
   constructor(props: PingClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    const headers = [new Header('Agent', `nodejs:${version}`)];
+    const headers = [new Header('Agent', `web:${version}`)];
     this.unaryInterceptors = [
       new HeaderInterceptorProvider<REQ, RESP>(
         headers

--- a/packages/client-sdk-web/src/internal/ping-client.ts
+++ b/packages/client-sdk-web/src/internal/ping-client.ts
@@ -1,11 +1,10 @@
 import {ping} from '@gomomento/generated-types-webtext';
-import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
-import {version} from '../../package.json';
-import {Request, UnaryInterceptor, UnaryResponse} from 'grpc-web';
+import {Request, UnaryResponse} from 'grpc-web';
 import {_PingRequest} from '@gomomento/generated-types-webtext/dist/cacheping_pb';
 import {Configuration} from '../config/configuration';
 import {MomentoLogger} from '@gomomento/sdk-core';
 import {IPingClient} from '@gomomento/sdk-core/dist/src/internal/clients';
+import {ClientMetadataProvider} from './client-metadata-provider';
 
 export interface PingClientProps {
   endpoint: string;
@@ -18,7 +17,7 @@ export class PingClient<
 > implements IPingClient
 {
   private readonly clientWrapper: ping.PingClient;
-  private readonly unaryInterceptors: UnaryInterceptor<REQ, RESP>[];
+  private readonly clientMetadataProvider: ClientMetadataProvider;
   private readonly logger: MomentoLogger;
 
   /**
@@ -26,25 +25,21 @@ export class PingClient<
    */
   constructor(props: PingClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
-    const headers = [new Header('Agent', `web:${version}`)];
-    this.unaryInterceptors = [
-      new HeaderInterceptorProvider<REQ, RESP>(
-        headers
-      ).createHeadersInterceptor(),
-    ];
+    this.clientMetadataProvider = new ClientMetadataProvider({});
     this.clientWrapper = new ping.PingClient(
       `https://${props.endpoint}:443`,
       null,
-      {
-        unaryInterceptors: this.unaryInterceptors,
-      }
+      {}
     );
   }
 
   public async ping(): Promise<void> {
     this.logger.debug('pinging...');
     const request = new _PingRequest();
-    await this.clientWrapper.ping(request, null);
+    await this.clientWrapper.ping(
+      request,
+      this.clientMetadataProvider.createClientMetadata()
+    );
     return;
   }
 }

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -67,7 +67,7 @@ export class PubsubClient<
       `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
     );
 
-    const headers: Header[] = [new Header('Agent', `nodejs:${version}`)];
+    const headers: Header[] = [new Header('Agent', `web:${version}`)];
     this.unaryInterceptors = this.initializeUnaryInterceptors(headers);
     this.streamingInterceptors = this.initializeStreamingInterceptors(headers);
     this.client = new pubsub.PubsubClient(

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -8,17 +8,8 @@ import {
   TopicItem,
   UnknownError,
 } from '@gomomento/sdk-core';
-import {
-  Request,
-  StreamInterceptor,
-  UnaryInterceptor,
-  UnaryResponse,
-  RpcError,
-  StatusCode,
-} from 'grpc-web';
+import {Request, UnaryResponse, RpcError, StatusCode} from 'grpc-web';
 import {TopicClientProps} from '../topic-client-props';
-import {version} from '../../package.json';
-import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
 import {truncateString} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {TopicPublish, TopicSubscribe} from '../index';
 import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
@@ -29,9 +20,9 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/clients/pubsub/AbstractPubsubClient';
 import {
   convertToB64String,
-  createDeadline,
-  createMetadata,
+  createCallMetadata,
 } from '../utils/web-client-utils';
+import {ClientMetadataProvider} from './client-metadata-provider';
 
 export class PubsubClient<
   REQ extends Request<REQ, RESP>,
@@ -43,9 +34,7 @@ export class PubsubClient<
   private readonly requestTimeoutMs: number;
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
   protected readonly logger: MomentoLogger;
-  private readonly authHeaders: {authorization: string};
-  private readonly unaryInterceptors: UnaryInterceptor<REQ, RESP>[];
-  private readonly streamingInterceptors: StreamInterceptor<REQ, RESP>[];
+  private readonly clientMetadataProvider: ClientMetadataProvider;
 
   private static readonly RST_STREAM_NO_ERROR_MESSAGE =
     'Received RST_STREAM with code 0';
@@ -67,18 +56,14 @@ export class PubsubClient<
       `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
     );
 
-    const headers: Header[] = [new Header('Agent', `web:${version}`)];
-    this.unaryInterceptors = this.initializeUnaryInterceptors(headers);
-    this.streamingInterceptors = this.initializeStreamingInterceptors(headers);
     this.client = new pubsub.PubsubClient(
       `https://${props.credentialProvider.getCacheEndpoint()}`,
       null,
-      {
-        unaryInterceptors: this.unaryInterceptors,
-        streamInterceptors: this.streamingInterceptors,
-      }
+      {}
     );
-    this.authHeaders = {authorization: props.credentialProvider.getAuthToken()};
+    this.clientMetadataProvider = new ClientMetadataProvider({
+      authToken: props.credentialProvider.getAuthToken(),
+    });
   }
 
   public getEndpoint(): string {
@@ -112,15 +97,13 @@ export class PubsubClient<
     request.setCacheName(cacheName);
     request.setTopic(topicName);
     request.setValue(topicValue);
-    const metadata = createMetadata(cacheName);
 
     return await new Promise(resolve => {
       this.client.publish(
         request,
         {
-          ...this.authHeaders,
-          ...metadata,
-          ...createDeadline(this.requestTimeoutMs),
+          ...this.clientMetadataProvider.createClientMetadata(),
+          ...createCallMetadata(cacheName, this.requestTimeoutMs),
         },
         (err, resp) => {
           if (resp) {
@@ -156,7 +139,9 @@ export class PubsubClient<
       options.subscriptionState.resumeAtTopicSequenceNumber
     );
 
-    const call = this.client.subscribe(request, {...this.authHeaders});
+    const call = this.client.subscribe(request, {
+      ...this.clientMetadataProvider.createClientMetadata(),
+    });
     options.subscriptionState.setSubscribed();
 
     // Allow the caller to cancel the stream.
@@ -252,27 +237,5 @@ export class PubsubClient<
       );
       this.handleSubscribeError(options, momentoError, isRstStreamNoError);
     };
-  }
-
-  private initializeUnaryInterceptors(
-    headers: Header[]
-  ): UnaryInterceptor<REQ, RESP>[] {
-    return [
-      new HeaderInterceptorProvider<REQ, RESP>(
-        headers
-      ).createHeadersInterceptor(),
-    ];
-  }
-
-  // TODO https://github.com/momentohq/client-sdk-nodejs/issues/349
-  // decide on streaming interceptors and middlewares
-  private initializeStreamingInterceptors(
-    headers: Header[]
-  ): StreamInterceptor<REQ, RESP>[] {
-    return [
-      new HeaderInterceptorProvider<REQ, RESP>(
-        headers
-      ).createStreamingHeadersInterceptor(),
-    ];
   }
 }

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -7,11 +7,10 @@ export function convertToB64String(v: string | Uint8Array): string {
   return btoa(String.fromCharCode.apply(null, v));
 }
 
-export function createMetadata(cacheName: string): {cache: string} {
-  return {cache: cacheName};
-}
-
-export function createDeadline(timeoutMillis: number): {deadline: string} {
+export function createCallMetadata(
+  cacheName: string,
+  timeoutMillis: number
+): {cache: string; deadline: string} {
   const deadline = Date.now() + timeoutMillis;
-  return {deadline: deadline.toString()};
+  return {cache: cacheName, deadline: deadline.toString()};
 }


### PR DESCRIPTION
Change web sdk agent to 'js-web'.

Switch from an interceptor to metadata for supplying the agent string
since interceptors don't work for the majority of clients.

Make a client metadata provider that provides the agent and
authorization headers.

Combine the deadline and cache name metadata into one call.