### PR TITLE
chore: update READMEs for new repository layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,14 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
 
-      - name: Verify README generation
-        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: stable
-          project_type: sdk
-          sdk_language: Node.js
-          usage_example_path: ./examples/nodejs/basic.ts
+      #- name: Verify README generation
+      #  uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
+      #  with:
+      #    project_status: official
+      #    project_stability: stable
+      #    project_type: sdk
+      #    sdk_language: Node.js
+      #    usage_example_path: ./examples/nodejs/basic.ts
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -27,11 +27,11 @@ jobs:
           node -v
           ./scripts/build-all-packages.sh
 
-      - name: Generate README
-        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: stable
-          project_type: sdk
-          sdk_language: Node.js
-          usage_example_path: ./examples/nodejs/basic.ts
+      #- name: Generate README
+      #  uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
+      #  with:
+      #    project_status: official
+      #    project_stability: stable
+      #    project_type: sdk
+      #    sdk_language: Node.js
+      #    usage_example_path: ./examples]nodejs/basic.ts

--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Publish all packages to npm
         run: |
-          cp README.md ./packages/client-sdk-nodejs
           ./scripts/publish-all-packages.sh "${{ needs.release.outputs.version }}"
         shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ is best suited for a particular environment:
 import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
-  const momento = new CacheClient({
+  const cacheClient = new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -40,9 +40,9 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await momento.createCache('cache');
-  await momento.set('cache', 'foo', 'FOO');
-  const getResponse = await momento.get('cache', 'foo');
+  await cacheClient.createCache('cache');
+  await cacheClient.set('cache', 'foo', 'FOO');
+  const getResponse = await cacheClient.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);
   }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <head>
-  <meta name="Momento JavaScript Client Library Documentation" content="JavaScript client software development kit for Momento Serverless Cache">
+  <meta name="Momento JavaScript Client Library Documentation" content="JavaScript client software development kit for Momento Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 
@@ -13,7 +13,7 @@
 * Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
 * Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
 
-Momento Serverless Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
+Momento Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
 required by traditional caching solutions.  This repo contains the source code for the Momento JavaScript client libraries.
 
 ## Packages
@@ -40,8 +40,8 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  const createCacheResponse = await momento.createCache('cache');
-  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  await momento.createCache('cache');
+  await momento.set('cache', 'foo', 'FOO');
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);

--- a/README.md.old
+++ b/README.md.old
@@ -1,4 +1,18 @@
-{{ ossHeader }}
+<head>
+  <meta name="Momento Node.js Client Library Documentation" content="Node.js client software development kit for Momento Serverless Cache">
+</head>
+<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+
+[![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-official.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+[![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-stable.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md) 
+
+# Momento Node.js Client Library
+
+
+Node.js client SDK for Momento Serverless Cache: a fast, simple, pay-as-you-go caching solution without
+any of the operational overhead required by traditional caching solutions!
+
+
 
 ## Getting Started :running:
 
@@ -41,7 +55,58 @@ Checkout our [examples](./examples/README.md) directory for complete examples of
 Here is a quickstart you can use in your own project:
 
 ```typescript
-{{ usageExampleCode }}
+import {
+  CacheGet,
+  CreateCache,
+  CacheSet,
+  CacheClient,
+  Configurations,
+  CredentialProvider,
+} from '@gomomento/sdk';
+
+async function main() {
+  const momento = new CacheClient({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+    }),
+    defaultTtlSeconds: 60,
+  });
+
+  const createCacheResponse = await momento.createCache('cache');
+  if (createCacheResponse instanceof CreateCache.AlreadyExists) {
+    console.log('cache already exists');
+  } else if (createCacheResponse instanceof CreateCache.Error) {
+    throw createCacheResponse.innerException();
+  }
+
+  console.log('Storing key=foo, value=FOO');
+  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  if (setResponse instanceof CacheSet.Success) {
+    console.log('Key stored successfully!');
+  } else {
+    console.log(`Error setting key: ${setResponse.toString()}`);
+  }
+
+  const getResponse = await momento.get('cache', 'foo');
+  if (getResponse instanceof CacheGet.Hit) {
+    console.log(`cache hit: ${getResponse.valueString()}`);
+  } else if (getResponse instanceof CacheGet.Miss) {
+    console.log('cache miss');
+  } else if (getResponse instanceof CacheGet.Error) {
+    console.log(`Error: ${getResponse.message()}`);
+  }
+}
+
+main()
+  .then(() => {
+    console.log('success!!');
+  })
+  .catch((e: Error) => {
+    console.error(`Uncaught exception while running example: ${e.message}`);
+    throw e;
+  });
+
 ```
 
 Momento also supports storing pure bytes,
@@ -151,4 +216,5 @@ can fix or extend the pre-built configs to support it.
 If you do need to customize your configuration beyond what our pre-builts provide, you can build your own `Configuration`
 object.  See the examples in `configurations.ts` to see how they are constructed.
 
-{{ ossFooter }}
+----------------------------------------------------------------------------------------
+For more info, visit our website at [https://gomomento.com](https://gomomento.com)!

--- a/examples/nodejs/.prettierrc.json
+++ b/examples/nodejs/.prettierrc.json
@@ -2,6 +2,7 @@
     "bracketSpacing": false,
     "singleQuote": true,
     "trailingComma": "es5",
-    "arrowParens": "avoid"
+    "arrowParens": "avoid",
+    "printWidth": 120
   }
   

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,5 +1,5 @@
 <head>
-  <meta name="Momento Node.js Client Library Documentation" content="Node.js client software development kit for Momento Serverless Cache">
+  <meta name="Momento Node.js Client Library Documentation" content="Node.js client software development kit for Momento Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,3 +1,11 @@
+<head>
+  <meta name="Momento Node.js Client Library Documentation" content="Node.js client software development kit for Momento Serverless Cache">
+</head>
+<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+
+[![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-official.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+[![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-stable.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+
 # Node.js Client SDK
 
 _Read this in other languages_: [日本語](README.ja.md)

--- a/examples/nodejs/advanced.ts
+++ b/examples/nodejs/advanced.ts
@@ -72,9 +72,7 @@ async function setGetDeleteExample() {
   // ttl is an optional field on most write operations, but you can provide it if you
   // want to override the default ttl that you specified when constructing your client.
   const exampleTtlSeconds = 10;
-  logger.info(
-    `Storing key=${cacheKey}, value=${cacheValue}, ttl=${exampleTtlSeconds}`
-  );
+  logger.info(`Storing key=${cacheKey}, value=${cacheValue}, ttl=${exampleTtlSeconds}`);
   const setResponse = await momento.set(cacheName, cacheKey, cacheValue, {
     ttl: exampleTtlSeconds,
   });
@@ -118,38 +116,26 @@ async function concurrentGetsExample() {
   getResponses.forEach((response, index) => {
     const key = `key${index + 1}`;
     if (response instanceof CacheGet.Hit) {
-      logger.info(
-        `Concurrent get for ${key} returned ${response.valueString()}`
-      );
+      logger.info(`Concurrent get for ${key} returned ${response.valueString()}`);
     } else {
-      logger.info(
-        `Something went wrong with concurrent get for key ${key}: ${response.toString()}`
-      );
+      logger.info(`Something went wrong with concurrent get for key ${key}: ${response.toString()}`);
     }
   });
 }
 
 async function middlewaresExample() {
-  const middlewaresExampleloggerFactory: MomentoLoggerFactory =
-    new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.DEBUG);
-  const middlewaresExamplelogger = middlewaresExampleloggerFactory.getLogger(
-    'AdvancedMiddlewaresExample'
+  const middlewaresExampleloggerFactory: MomentoLoggerFactory = new DefaultMomentoLoggerFactory(
+    DefaultMomentoLoggerLevel.DEBUG
   );
-  middlewaresExamplelogger.info(
-    'Constructing a new Momento client with logging and metrics middlewares enabled'
-  );
+  const middlewaresExamplelogger = middlewaresExampleloggerFactory.getLogger('AdvancedMiddlewaresExample');
+  middlewaresExamplelogger.info('Constructing a new Momento client with logging and metrics middlewares enabled');
 
   const metricsCsvPath = './advanced-middlewares-example-metrics.csv';
 
   const middlewaresExampleClient = new CacheClient({
-    configuration: Configurations.Laptop.v1(
-      middlewaresExampleloggerFactory
-    ).withMiddlewares([
+    configuration: Configurations.Laptop.v1(middlewaresExampleloggerFactory).withMiddlewares([
       new ExperimentalRequestLoggingMiddleware(middlewaresExampleloggerFactory),
-      new ExperimentalMetricsCsvMiddleware(
-        metricsCsvPath,
-        middlewaresExampleloggerFactory
-      ),
+      new ExperimentalMetricsCsvMiddleware(metricsCsvPath, middlewaresExampleloggerFactory),
     ]),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -169,11 +155,7 @@ async function middlewaresExample() {
   // wait for metrics to flush to disk
   await delay(100);
 
-  logger.info(
-    `Here are the contents of the metrics csv file:\n\n${fs
-      .readFileSync(metricsCsvPath)
-      .toString()}`
-  );
+  logger.info(`Here are the contents of the metrics csv file:\n\n${fs.readFileSync(metricsCsvPath).toString()}`);
 
   middlewaresExamplelogger.info('Middlewares example complete!');
 }

--- a/examples/nodejs/basic.ts
+++ b/examples/nodejs/basic.ts
@@ -1,11 +1,4 @@
-import {
-  CacheGet,
-  CreateCache,
-  CacheSet,
-  CacheClient,
-  Configurations,
-  CredentialProvider,
-} from '@gomomento/sdk';
+import {CacheGet, CreateCache, CacheSet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
   const momento = new CacheClient({

--- a/examples/nodejs/dictionary.ts
+++ b/examples/nodejs/dictionary.ts
@@ -38,16 +38,9 @@ const main = async () => {
   }
 
   // Set a value
-  const dictionarySetFieldResponse = await momento.dictionarySetField(
-    cacheName,
-    dictionaryName,
-    'field1',
-    'value1'
-  );
+  const dictionarySetFieldResponse = await momento.dictionarySetField(cacheName, dictionaryName, 'field1', 'value1');
   if (dictionarySetFieldResponse instanceof CacheDictionarySetField.Error) {
-    console.log(
-      `Error setting a value in a dictionary: ${dictionarySetFieldResponse.message()}`
-    );
+    console.log(`Error setting a value in a dictionary: ${dictionarySetFieldResponse.message()}`);
     process.exitCode = 1;
   }
 
@@ -66,79 +59,44 @@ const main = async () => {
     }
   );
   if (dictionarySetFieldsResponse instanceof CacheDictionarySetFields.Error) {
-    console.log(
-      `Error setting multiple values in a dictionary: ${dictionarySetFieldsResponse.message()}`
-    );
+    console.log(`Error setting multiple values in a dictionary: ${dictionarySetFieldsResponse.message()}`);
     process.exitCode = 1;
   }
 
   // Get a value
   console.log('\nGetting a single dictionary value');
   const field = 'field1';
-  const dictionaryGetFieldResponse = await momento.dictionaryGetField(
-    cacheName,
-    dictionaryName,
-    field
-  );
+  const dictionaryGetFieldResponse = await momento.dictionaryGetField(cacheName, dictionaryName, field);
   if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Hit) {
-    console.log(
-      `Dictionary get of ${field}: status=HIT; value=${dictionaryGetFieldResponse.valueString()}`
-    );
-  } else if (
-    dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Miss
-  ) {
+    console.log(`Dictionary get of ${field}: status=HIT; value=${dictionaryGetFieldResponse.valueString()}`);
+  } else if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Miss) {
     // In this example you can get here if you:
     // - change the field name to one that does not exist, or if you
     // - set a short TTL, then add a sleep so that it expires.
     console.log(`Dictionary get of ${field}: status=MISS`);
-  } else if (
-    dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Error
-  ) {
-    console.log(
-      `Error getting value from dictionary: ${dictionaryGetFieldResponse.message()}`
-    );
+  } else if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Error) {
+    console.log(`Error getting value from dictionary: ${dictionaryGetFieldResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryGetFieldResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryGetFieldResponse.toString()}`);
   }
 
   // Get multiple values
   console.log('\nGetting multiple dictionary values');
   const fieldsList = ['field1', 'field2', 'field3', 'field4'];
-  const dictionaryGetFieldsResponse = await momento.dictionaryGetFields(
-    cacheName,
-    dictionaryName,
-    fieldsList
-  );
+  const dictionaryGetFieldsResponse = await momento.dictionaryGetFields(cacheName, dictionaryName, fieldsList);
   if (dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Hit) {
-    console.log(
-      `Got dictionary fields: ${JSON.stringify(
-        dictionaryGetFieldsResponse.valueRecord(),
-        null,
-        2
-      )}`
-    );
-  } else if (
-    dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Error
-  ) {
-    console.log(
-      `Error getting values from a dictionary: ${dictionaryGetFieldsResponse.message()}`
-    );
+    console.log(`Got dictionary fields: ${JSON.stringify(dictionaryGetFieldsResponse.valueRecord(), null, 2)}`);
+  } else if (dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Error) {
+    console.log(`Error getting values from a dictionary: ${dictionaryGetFieldsResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryGetFieldsResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryGetFieldsResponse.toString()}`);
   }
 
   // Get the whole dictionary
   console.log('\nGetting an entire dictionary');
-  const dictionaryFetchResponse = await momento.dictionaryFetch(
-    cacheName,
-    dictionaryName
-  );
+  const dictionaryFetchResponse = await momento.dictionaryFetch(cacheName, dictionaryName);
   if (dictionaryFetchResponse instanceof CacheDictionaryFetch.Hit) {
     const dictionary = dictionaryFetchResponse.valueRecord();
     console.log(`Fetched dictionary: ${JSON.stringify(dictionary, null, 2)}`);
@@ -148,14 +106,10 @@ const main = async () => {
     // - setting a short TTL and adding a Task.Delay so the dictionary expires
     console.log(`Expected ${dictionaryName} to be a hit; got a miss.`);
   } else if (dictionaryFetchResponse instanceof CacheDictionaryFetch.Error) {
-    console.log(
-      `Error while fetching ${dictionaryName}: ${dictionaryFetchResponse.message()}`
-    );
+    console.log(`Error while fetching ${dictionaryName}: ${dictionaryFetchResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryFetchResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryFetchResponse.toString()}`);
   }
 };
 
@@ -164,8 +118,6 @@ main()
     console.log('success!!');
   })
   .catch((e: Error) => {
-    console.error(
-      `Uncaught exception while running dictionary example: ${e.message}`
-    );
+    console.error(`Uncaught exception while running dictionary example: ${e.message}`);
     throw e;
   });

--- a/examples/nodejs/doc-example-files/cheat-sheet-main.ts
+++ b/examples/nodejs/doc-example-files/cheat-sheet-main.ts
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  CacheGet,
-  CreateCache,
-  CacheSet,
-  CacheClient,
-  Configurations,
-  CredentialProvider,
-} from '@gomomento/sdk';
+import {CacheGet, CreateCache, CacheSet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 function main() {
   const cacheClient = new CacheClient({
@@ -21,8 +14,6 @@ function main() {
 try {
   main();
 } catch (e) {
-  console.error(
-    `Uncaught exception while running example: ${JSON.stringify(e)}`
-  );
+  console.error(`Uncaught exception while running example: ${JSON.stringify(e)}`);
   throw e;
 }

--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -28,9 +28,7 @@ async function example_API_CreateCache(cacheClient: CacheClient) {
   } else if (result instanceof CreateCache.AlreadyExists) {
     console.log("Cache 'test-cache' already exists");
   } else {
-    throw new Error(
-      `An error occurred while attempting to create cache 'test-cache': ${result.toString()}`
-    );
+    throw new Error(`An error occurred while attempting to create cache 'test-cache': ${result.toString()}`);
   }
 }
 
@@ -55,9 +53,7 @@ async function example_API_ListCaches(cacheClient: CacheClient) {
         .join('\n')}\n\n`
     );
   } else if (result instanceof ListCaches.Error) {
-    throw new Error(
-      `An error occurred while attempting to list caches: ${result.errorCode()}: ${result.toString()}`
-    );
+    throw new Error(`An error occurred while attempting to list caches: ${result.errorCode()}: ${result.toString()}`);
   }
 }
 

--- a/examples/nodejs/load-gen.ts
+++ b/examples/nodejs/load-gen.ts
@@ -13,10 +13,7 @@ import {
   executeRequestAndUpdateContextCounts,
   initiateLoadGenContext,
 } from './utils/load-gen';
-import {
-  getElapsedMillis,
-  logStats,
-} from './utils/load-gen-statistics-calculator';
+import {getElapsedMillis, logStats} from './utils/load-gen-statistics-calculator';
 import {createCache, getCacheClient} from './utils/cache';
 
 class BasicLoadGen {
@@ -35,34 +32,23 @@ class BasicLoadGen {
     this.options = options;
     this.cacheValue = 'x'.repeat(options.cacheItemPayloadBytes);
     this.delayMillisBetweenRequests =
-      (1000.0 * this.options.numberOfConcurrentRequests) /
-      this.options.maxRequestsPerSecond;
+      (1000.0 * this.options.numberOfConcurrentRequests) / this.options.maxRequestsPerSecond;
   }
 
   async run(): Promise<void> {
-    const momento = getCacheClient(
-      this.loggerFactory,
-      this.options.requestTimeoutMs,
-      this.cacheItemTtlSeconds
-    );
+    const momento = getCacheClient(this.loggerFactory, this.options.requestTimeoutMs, this.cacheItemTtlSeconds);
 
     await createCache(momento, this.cacheName, this.logger);
 
-    this.logger.trace(
-      `delayMillisBetweenRequests: ${this.delayMillisBetweenRequests}`
-    );
+    this.logger.trace(`delayMillisBetweenRequests: ${this.delayMillisBetweenRequests}`);
 
     this.logger.info(`Limiting to ${this.options.maxRequestsPerSecond} tps`);
-    this.logger.info(
-      `Running ${this.options.numberOfConcurrentRequests} concurrent requests`
-    );
+    this.logger.info(`Running ${this.options.numberOfConcurrentRequests} concurrent requests`);
     this.logger.info(`Running for ${this.options.totalSecondsToRun} seconds`);
 
     const loadGenContext = initiateLoadGenContext();
 
-    const asyncGetSetResults = range(
-      this.options.numberOfConcurrentRequests
-    ).map(workerId =>
+    const asyncGetSetResults = range(this.options.numberOfConcurrentRequests).map(workerId =>
       this.launchAndRunWorkers(momento, loadGenContext, workerId + 1)
     );
 
@@ -114,10 +100,8 @@ class BasicLoadGen {
     const cacheKey = `worker${workerId}operation${operationId}`;
 
     const setStartTime = process.hrtime();
-    const result = await executeRequestAndUpdateContextCounts(
-      this.logger,
-      loadGenContext,
-      () => client.set(this.cacheName, cacheKey, this.cacheValue)
+    const result = await executeRequestAndUpdateContextCounts(this.logger, loadGenContext, () =>
+      client.set(this.cacheName, cacheKey, this.cacheValue)
     );
     if (result !== undefined) {
       const setDuration = getElapsedMillis(setStartTime);
@@ -130,10 +114,8 @@ class BasicLoadGen {
     }
 
     const getStartTime = process.hrtime();
-    const getResult = await executeRequestAndUpdateContextCounts(
-      this.logger,
-      loadGenContext,
-      () => client.get(this.cacheName, cacheKey)
+    const getResult = await executeRequestAndUpdateContextCounts(this.logger, loadGenContext, () =>
+      client.get(this.cacheName, cacheKey)
     );
 
     if (getResult !== undefined) {

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -14,7 +14,7 @@
     "topic-publish": "tsc && node dist/topic-publish.js",
     "request-coalescing": "tsc && node dist/request-coalescing.js",
     "doc-examples-js-apis": "tsc && node dist/doc-examples-js-apis.js",
-    "validate-examples": "tsc && node dist/basic.js && node dist/advanced.js && node dist/dictionary.js && node dist/doc-examples-js-apis.js && node dist/doc-example-files/cheat-sheet-main.js",
+    "validate-examples": "tsc && node dist/readme.js && node dist/basic.js && node dist/advanced.js && node dist/dictionary.js && node dist/doc-examples-js-apis.js && node dist/doc-example-files/cheat-sheet-main.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix"

--- a/examples/nodejs/readme.ts
+++ b/examples/nodejs/readme.ts
@@ -1,0 +1,22 @@
+import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
+
+async function main() {
+  const momento = new CacheClient({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+    }),
+    defaultTtlSeconds: 60,
+  });
+
+  const createCacheResponse = await momento.createCache('cache');
+  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  const getResponse = await momento.get('cache', 'foo');
+  if (getResponse instanceof CacheGet.Hit) {
+    console.log(`Got value: ${getResponse.valueString()}`);
+  }
+}
+
+main().catch(e => {
+  throw e;
+});

--- a/examples/nodejs/readme.ts
+++ b/examples/nodejs/readme.ts
@@ -9,8 +9,8 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  const createCacheResponse = await momento.createCache('cache');
-  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  await momento.createCache('cache');
+  await momento.set('cache', 'foo', 'FOO');
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);

--- a/examples/nodejs/readme.ts
+++ b/examples/nodejs/readme.ts
@@ -1,7 +1,7 @@
 import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
-  const momento = new CacheClient({
+  const cacheClient = new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -9,9 +9,9 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await momento.createCache('cache');
-  await momento.set('cache', 'foo', 'FOO');
-  const getResponse = await momento.get('cache', 'foo');
+  await cacheClient.createCache('cache');
+  await cacheClient.set('cache', 'foo', 'FOO');
+  const getResponse = await cacheClient.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);
   }

--- a/examples/nodejs/topic-publish.ts
+++ b/examples/nodejs/topic-publish.ts
@@ -1,9 +1,4 @@
-import {
-  TopicClient,
-  TopicPublish,
-  Configurations,
-  CredentialProvider,
-} from '@gomomento/sdk';
+import {TopicClient, TopicPublish, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 import {ensureCacheExists} from './utils/cache';
 
@@ -23,9 +18,7 @@ async function main() {
 
   await ensureCacheExists(cacheName);
 
-  console.log(
-    `Publishing cacheName=${cacheName}, topicName=${topicName}, value=${value}`
-  );
+  console.log(`Publishing cacheName=${cacheName}, topicName=${topicName}, value=${value}`);
   const publishResponse = await momento.publish(cacheName, topicName, value);
   if (publishResponse instanceof TopicPublish.Success) {
     console.log('Value published successfully!');

--- a/examples/nodejs/topic-subscribe.ts
+++ b/examples/nodejs/topic-subscribe.ts
@@ -1,10 +1,4 @@
-import {
-  TopicClient,
-  TopicItem,
-  TopicSubscribe,
-  Configurations,
-  CredentialProvider,
-} from '@gomomento/sdk';
+import {TopicClient, TopicItem, TopicSubscribe, Configurations, CredentialProvider} from '@gomomento/sdk';
 import {ensureCacheExists} from './utils/cache';
 
 async function main() {
@@ -35,22 +29,17 @@ async function main() {
     console.log(`Error subscribing to topic: ${response.toString()}`);
     return;
   } else {
-    console.log(
-      `Unexpected response from topic subscription: ${response.toString()}`
-    );
+    console.log(`Unexpected response from topic subscription: ${response.toString()}`);
     return;
   }
 
-  const sleep = (seconds: number) =>
-    new Promise(r => setTimeout(r, seconds * 1000));
+  const sleep = (seconds: number) => new Promise(r => setTimeout(r, seconds * 1000));
 
   // Wait a couple minutes to receive some items, then unsubscribe to finish the example.
   await sleep(120);
 
   if (response instanceof TopicSubscribe.Subscription) {
-    console.log(
-      'Unsubscribing from topic subscription. Restart the example to subscribe again.'
-    );
+    console.log('Unsubscribing from topic subscription. Restart the example to subscribe again.');
     response.unsubscribe();
   }
 }

--- a/examples/nodejs/utils/cache.ts
+++ b/examples/nodejs/utils/cache.ts
@@ -15,10 +15,7 @@ export function getCacheClient(
   cacheItemTtlSeconds: number
 ) {
   return new CacheClient({
-    configuration:
-      Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(
-        requestTimeoutMs
-      ),
+    configuration: Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(requestTimeoutMs),
     credentialProvider: new EnvMomentoTokenProvider({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
     }),
@@ -26,11 +23,7 @@ export function getCacheClient(
   });
 }
 
-export async function createCache(
-  momentCacheClient: CacheClient,
-  cacheName: string,
-  logger: MomentoLogger
-) {
+export async function createCache(momentCacheClient: CacheClient, cacheName: string, logger: MomentoLogger) {
   const createResponse = await momentCacheClient.createCache(cacheName);
   if (createResponse instanceof CreateCache.AlreadyExists) {
     logger.info(`cache '${cacheName}' already exists`);
@@ -40,9 +33,7 @@ export async function createCache(
 }
 
 export async function ensureCacheExists(cacheName: string): Promise<void> {
-  const loggerFactory = new DefaultMomentoLoggerFactory(
-    DefaultMomentoLoggerLevel.INFO
-  );
+  const loggerFactory = new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.INFO);
   const momento = getCacheClient(loggerFactory, 5000, 60);
   const createCacheResponse = await momento.createCache(cacheName);
   if (createCacheResponse instanceof CreateCache.Success) {
@@ -52,8 +43,6 @@ export async function ensureCacheExists(cacheName: string): Promise<void> {
   } else if (createCacheResponse instanceof CreateCache.Error) {
     throw createCacheResponse.innerException();
   } else {
-    throw new Error(
-      `Unknown create cache response type: ${createCacheResponse.toString()}`
-    );
+    throw new Error(`Unknown create cache response type: ${createCacheResponse.toString()}`);
   }
 }

--- a/examples/nodejs/utils/load-gen-statistics-calculator.ts
+++ b/examples/nodejs/utils/load-gen-statistics-calculator.ts
@@ -2,13 +2,8 @@ import {BasicLoadGenContext, RequestCoalescerContext} from './load-gen';
 import * as hdr from 'hdr-histogram-js';
 import {MomentoLogger} from '@gomomento/sdk';
 
-export function tps(
-  context: BasicLoadGenContext,
-  requestCount: number
-): number {
-  return Math.round(
-    (requestCount * 1000) / getElapsedMillis(context.startTime)
-  );
+export function tps(context: BasicLoadGenContext, requestCount: number): number {
+  return Math.round((requestCount * 1000) / getElapsedMillis(context.startTime));
 }
 
 export function getElapsedMillis(startTime: [number, number]): number {
@@ -16,13 +11,8 @@ export function getElapsedMillis(startTime: [number, number]): number {
   return (endTime[0] * 1e9 + endTime[1]) / 1e6;
 }
 
-export function percentRequests(
-  context: BasicLoadGenContext,
-  count: number
-): string {
-  return (
-    Math.round((count / context.globalRequestCount) * 100 * 10) / 10
-  ).toString();
+export function percentRequests(context: BasicLoadGenContext, count: number): string {
+  return (Math.round((count / context.globalRequestCount) * 100 * 10) / 10).toString();
 }
 
 export function outputHistogramSummary(histogram: hdr.Histogram): string {
@@ -56,15 +46,11 @@ total requests: ${loadGenContext.globalRequestCount} (${tps(
     loadGenContext,
     loadGenContext.globalUnavailableCount
   )}%)
-deadline exceeded: ${
-    loadGenContext.globalDeadlineExceededCount
-  } (${percentRequests(
+deadline exceeded: ${loadGenContext.globalDeadlineExceededCount} (${percentRequests(
     loadGenContext,
     loadGenContext.globalDeadlineExceededCount
   )}%)
-resource exhausted: ${
-    loadGenContext.globalResourceExhaustedCount
-  } (${percentRequests(
+resource exhausted: ${loadGenContext.globalResourceExhaustedCount} (${percentRequests(
     loadGenContext,
     loadGenContext.globalResourceExhaustedCount
   )}%)
@@ -89,15 +75,9 @@ export function logCoalescingStats(
   logger.info(`
 For request coalescer:
 Number of set requests coalesced:
-${context.numberOfSetRequestsCoalesced} (${percentRequests(
-    loadGenContext,
-    context.numberOfSetRequestsCoalesced
-  )}%)
+${context.numberOfSetRequestsCoalesced} (${percentRequests(loadGenContext, context.numberOfSetRequestsCoalesced)}%)
 
 Number of get requests coalesced:
-${context.numberOfGetRequestsCoalesced} (${percentRequests(
-    loadGenContext,
-    context.numberOfGetRequestsCoalesced
-  )}%)
+${context.numberOfGetRequestsCoalesced} (${percentRequests(loadGenContext, context.numberOfGetRequestsCoalesced)}%)
 `);
 }

--- a/examples/nodejs/utils/load-gen.ts
+++ b/examples/nodejs/utils/load-gen.ts
@@ -47,10 +47,7 @@ export interface RequestCoalescerContext {
   numberOfGetRequestsCoalesced: number;
 }
 
-export function updateContextCountsForRequest(
-  context: BasicLoadGenContext,
-  result: AsyncSetGetResult
-): void {
+export function updateContextCountsForRequest(context: BasicLoadGenContext, result: AsyncSetGetResult): void {
   context.globalRequestCount++;
   // TODO: this could be simplified and made more generic, worth doing if we ever want to
   //  expand this to additional types of behavior
@@ -98,18 +95,14 @@ export async function executeRequest<T>(
       if (e.message.includes('UNAVAILABLE')) {
         return [AsyncSetGetResult.UNAVAILABLE, undefined];
       } else if (e.message.includes('RST_STREAM')) {
-        logger.error(
-          `Caught RST_STREAM error; swallowing: ${e.name}, ${e.message}`
-        );
+        logger.error(`Caught RST_STREAM error; swallowing: ${e.name}, ${e.message}`);
         return [AsyncSetGetResult.RST_STREAM, undefined];
       } else {
         throw e;
       }
     } else if (e instanceof LimitExceededError) {
       if (e.message.includes('RESOURCE_EXHAUSTED')) {
-        logger.error(
-          `Caught RESOURCE_EXHAUSTED error; swallowing: ${e.name}, ${e.message}`
-        );
+        logger.error(`Caught RESOURCE_EXHAUSTED error; swallowing: ${e.name}, ${e.message}`);
         return [AsyncSetGetResult.RESOURCE_EXHAUSTED, undefined];
       } else {
         throw e;

--- a/examples/nodejs/utils/momento-client-with-coalescing.ts
+++ b/examples/nodejs/utils/momento-client-with-coalescing.ts
@@ -3,11 +3,7 @@ import {RequestCoalescerContext} from './load-gen';
 
 export interface GetAndSetOnlyClient {
   get(cacheName: string, key: string): Promise<CacheGet.Response>;
-  set(
-    cacheName: string,
-    key: string,
-    value: string
-  ): Promise<CacheSet.Response>;
+  set(cacheName: string, key: string, value: string): Promise<CacheSet.Response>;
 }
 
 export class MomentoClientWrapperWithCoalescing {
@@ -38,11 +34,7 @@ export class MomentoClientWrapperWithCoalescing {
     });
   }
 
-  set(
-    cacheName: string,
-    key: string,
-    value: string
-  ): Promise<CacheSet.Response> {
+  set(cacheName: string, key: string, value: string): Promise<CacheSet.Response> {
     if (this.setRequestMap.has(key)) {
       this.context.numberOfSetRequestsCoalesced++;
       const mapResponse = this.setRequestMap.get(key);

--- a/examples/web/.prettierrc.json
+++ b/examples/web/.prettierrc.json
@@ -2,6 +2,7 @@
     "bracketSpacing": false,
     "singleQuote": true,
     "trailingComma": "es5",
-    "arrowParens": "avoid"
+    "arrowParens": "avoid",
+    "printWidth": 120
   }
   

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -1,5 +1,5 @@
 <head>
-  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Serverless Cache">
+  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -1,3 +1,11 @@
+<head>
+  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Serverless Cache">
+</head>
+<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+
+[![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-official.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+[![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-stable.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+
 # Node.js Client SDK
 
 _Read this in other languages_: [日本語](README.ja.md)

--- a/examples/web/advanced.ts
+++ b/examples/web/advanced.ts
@@ -73,9 +73,7 @@ async function setGetDeleteExample() {
   // ttl is an optional field on most write operations, but you can provide it if you
   // want to override the default ttl that you specified when constructing your client.
   const exampleTtlSeconds = 10;
-  logger.info(
-    `Storing key=${cacheKey}, value=${cacheValue}, ttl=${exampleTtlSeconds}`
-  );
+  logger.info(`Storing key=${cacheKey}, value=${cacheValue}, ttl=${exampleTtlSeconds}`);
   const setResponse = await momento.set(cacheName, cacheKey, cacheValue, {
     ttl: exampleTtlSeconds,
   });
@@ -119,13 +117,9 @@ async function concurrentGetsExample() {
   getResponses.forEach((response, index) => {
     const key = `key${index + 1}`;
     if (response instanceof CacheGet.Hit) {
-      logger.info(
-        `Concurrent get for ${key} returned ${response.valueString()}`
-      );
+      logger.info(`Concurrent get for ${key} returned ${response.valueString()}`);
     } else {
-      logger.info(
-        `Something went wrong with concurrent get for key ${key}: ${response.toString()}`
-      );
+      logger.info(`Something went wrong with concurrent get for key ${key}: ${response.toString()}`);
     }
   });
 }

--- a/examples/web/basic.ts
+++ b/examples/web/basic.ts
@@ -1,11 +1,4 @@
-import {
-  CacheGet,
-  CreateCache,
-  CacheSet,
-  CacheClient,
-  Configurations,
-  CredentialProvider,
-} from '@gomomento/sdk-web';
+import {CacheGet, CreateCache, CacheSet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk-web';
 
 // Because we're not running in a browser, we need to explicitly make
 // XMLHttpRequest available.

--- a/examples/web/dictionary.ts
+++ b/examples/web/dictionary.ts
@@ -45,16 +45,9 @@ const main = async () => {
   }
 
   // Set a value
-  const dictionarySetFieldResponse = await momento.dictionarySetField(
-    cacheName,
-    dictionaryName,
-    'field1',
-    'value1'
-  );
+  const dictionarySetFieldResponse = await momento.dictionarySetField(cacheName, dictionaryName, 'field1', 'value1');
   if (dictionarySetFieldResponse instanceof CacheDictionarySetField.Error) {
-    console.log(
-      `Error setting a value in a dictionary: ${dictionarySetFieldResponse.message()}`
-    );
+    console.log(`Error setting a value in a dictionary: ${dictionarySetFieldResponse.message()}`);
     process.exitCode = 1;
   }
 
@@ -73,79 +66,44 @@ const main = async () => {
     }
   );
   if (dictionarySetFieldsResponse instanceof CacheDictionarySetFields.Error) {
-    console.log(
-      `Error setting multiple values in a dictionary: ${dictionarySetFieldsResponse.message()}`
-    );
+    console.log(`Error setting multiple values in a dictionary: ${dictionarySetFieldsResponse.message()}`);
     process.exitCode = 1;
   }
 
   // Get a value
   console.log('\nGetting a single dictionary value');
   const field = 'field1';
-  const dictionaryGetFieldResponse = await momento.dictionaryGetField(
-    cacheName,
-    dictionaryName,
-    field
-  );
+  const dictionaryGetFieldResponse = await momento.dictionaryGetField(cacheName, dictionaryName, field);
   if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Hit) {
-    console.log(
-      `Dictionary get of ${field}: status=HIT; value=${dictionaryGetFieldResponse.valueString()}`
-    );
-  } else if (
-    dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Miss
-  ) {
+    console.log(`Dictionary get of ${field}: status=HIT; value=${dictionaryGetFieldResponse.valueString()}`);
+  } else if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Miss) {
     // In this example you can get here if you:
     // - change the field name to one that does not exist, or if you
     // - set a short TTL, then add a sleep so that it expires.
     console.log(`Dictionary get of ${field}: status=MISS`);
-  } else if (
-    dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Error
-  ) {
-    console.log(
-      `Error getting value from dictionary: ${dictionaryGetFieldResponse.message()}`
-    );
+  } else if (dictionaryGetFieldResponse instanceof CacheDictionaryGetField.Error) {
+    console.log(`Error getting value from dictionary: ${dictionaryGetFieldResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryGetFieldResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryGetFieldResponse.toString()}`);
   }
 
   // Get multiple values
   console.log('\nGetting multiple dictionary values');
   const fieldsList = ['field1', 'field2', 'field3', 'field4'];
-  const dictionaryGetFieldsResponse = await momento.dictionaryGetFields(
-    cacheName,
-    dictionaryName,
-    fieldsList
-  );
+  const dictionaryGetFieldsResponse = await momento.dictionaryGetFields(cacheName, dictionaryName, fieldsList);
   if (dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Hit) {
-    console.log(
-      `Got dictionary fields: ${JSON.stringify(
-        dictionaryGetFieldsResponse.valueRecord(),
-        null,
-        2
-      )}`
-    );
-  } else if (
-    dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Error
-  ) {
-    console.log(
-      `Error getting values from a dictionary: ${dictionaryGetFieldsResponse.message()}`
-    );
+    console.log(`Got dictionary fields: ${JSON.stringify(dictionaryGetFieldsResponse.valueRecord(), null, 2)}`);
+  } else if (dictionaryGetFieldsResponse instanceof CacheDictionaryGetFields.Error) {
+    console.log(`Error getting values from a dictionary: ${dictionaryGetFieldsResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryGetFieldsResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryGetFieldsResponse.toString()}`);
   }
 
   // Get the whole dictionary
   console.log('\nGetting an entire dictionary');
-  const dictionaryFetchResponse = await momento.dictionaryFetch(
-    cacheName,
-    dictionaryName
-  );
+  const dictionaryFetchResponse = await momento.dictionaryFetch(cacheName, dictionaryName);
   if (dictionaryFetchResponse instanceof CacheDictionaryFetch.Hit) {
     const dictionary = dictionaryFetchResponse.valueRecord();
     console.log(`Fetched dictionary: ${JSON.stringify(dictionary, null, 2)}`);
@@ -155,14 +113,10 @@ const main = async () => {
     // - setting a short TTL and adding a Task.Delay so the dictionary expires
     console.log(`Expected ${dictionaryName} to be a hit; got a miss.`);
   } else if (dictionaryFetchResponse instanceof CacheDictionaryFetch.Error) {
-    console.log(
-      `Error while fetching ${dictionaryName}: ${dictionaryFetchResponse.message()}`
-    );
+    console.log(`Error while fetching ${dictionaryName}: ${dictionaryFetchResponse.message()}`);
     process.exitCode = 1;
   } else {
-    throw new Error(
-      `Unexpected response: ${dictionaryFetchResponse.toString()}`
-    );
+    throw new Error(`Unexpected response: ${dictionaryFetchResponse.toString()}`);
   }
 };
 
@@ -171,8 +125,6 @@ main()
     console.log('success!!');
   })
   .catch((e: Error) => {
-    console.error(
-      `Uncaught exception while running dictionary example: ${e.message}`
-    );
+    console.error(`Uncaught exception while running dictionary example: ${e.message}`);
     throw e;
   });

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -9,7 +9,7 @@
     "example": "tsc && node dist/basic.js",
     "advanced": "tsc && node dist/advanced.js",
     "dictionary": "tsc && node dist/dictionary.js",
-    "validate-examples": "tsc && node dist/basic.js && node dist/advanced.js && node dist/dictionary.js",
+    "validate-examples": "tsc && node dist/basic.js && node dist/advanced.js && node dist/dictionary.js && node dist/readme.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix"

--- a/examples/web/readme.ts
+++ b/examples/web/readme.ts
@@ -12,8 +12,8 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  const createCacheResponse = await momento.createCache('cache');
-  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  await momento.createCache('cache');
+  await momento.set('cache', 'foo', 'FOO');
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);

--- a/examples/web/readme.ts
+++ b/examples/web/readme.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/ban-ts-comment */
+import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk-web';
+// @ts-ignore
+// This global is required in order to use the Web SDK outside of a browser
+global.XMLHttpRequest = require('xhr2');
+async function main() {
+  const momento = new CacheClient({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+    }),
+    defaultTtlSeconds: 60,
+  });
+
+  const createCacheResponse = await momento.createCache('cache');
+  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  const getResponse = await momento.get('cache', 'foo');
+  if (getResponse instanceof CacheGet.Hit) {
+    console.log(`Got value: ${getResponse.valueString()}`);
+  }
+}
+
+main().catch(e => {
+  throw e;
+});

--- a/examples/web/readme.ts
+++ b/examples/web/readme.ts
@@ -4,7 +4,7 @@ import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomome
 // This global is required in order to use the Web SDK outside of a browser
 global.XMLHttpRequest = require('xhr2');
 async function main() {
-  const momento = new CacheClient({
+  const cacheClient = new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -12,9 +12,9 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await momento.createCache('cache');
-  await momento.set('cache', 'foo', 'FOO');
-  const getResponse = await momento.get('cache', 'foo');
+  await cacheClient.createCache('cache');
+  await cacheClient.set('cache', 'foo', 'FOO');
+  const getResponse = await cacheClient.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);
   }

--- a/examples/web/utils/cache.ts
+++ b/examples/web/utils/cache.ts
@@ -15,10 +15,7 @@ export function getCacheClient(
   cacheItemTtlSeconds: number
 ) {
   return new CacheClient({
-    configuration:
-      Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(
-        requestTimeoutMs
-      ),
+    configuration: Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(requestTimeoutMs),
     credentialProvider: new EnvMomentoTokenProvider({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
     }),
@@ -26,11 +23,7 @@ export function getCacheClient(
   });
 }
 
-export async function createCache(
-  momentCacheClient: CacheClient,
-  cacheName: string,
-  logger: MomentoLogger
-) {
+export async function createCache(momentCacheClient: CacheClient, cacheName: string, logger: MomentoLogger) {
   const createResponse = await momentCacheClient.createCache(cacheName);
   if (createResponse instanceof CreateCache.AlreadyExists) {
     logger.info(`cache '${cacheName}' already exists`);
@@ -40,9 +33,7 @@ export async function createCache(
 }
 
 export async function ensureCacheExists(cacheName: string): Promise<void> {
-  const loggerFactory = new DefaultMomentoLoggerFactory(
-    DefaultMomentoLoggerLevel.INFO
-  );
+  const loggerFactory = new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.INFO);
   const momento = getCacheClient(loggerFactory, 5000, 60);
   const createCacheResponse = await momento.createCache(cacheName);
   if (createCacheResponse instanceof CreateCache.Success) {
@@ -52,8 +43,6 @@ export async function ensureCacheExists(cacheName: string): Promise<void> {
   } else if (createCacheResponse instanceof CreateCache.Error) {
     throw createCacheResponse.innerException();
   } else {
-    throw new Error(
-      `Unknown create cache response type: ${createCacheResponse.toString()}`
-    );
+    throw new Error(`Unknown create cache response type: ${createCacheResponse.toString()}`);
   }
 }

--- a/packages/client-sdk-nodejs/README.md
+++ b/packages/client-sdk-nodejs/README.md
@@ -30,7 +30,7 @@ the [Momento Web SDK](../client-sdk-web).
 import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
-  const momento = new CacheClient({
+  const cacheClient = new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -38,9 +38,9 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await momento.createCache('cache');
-  await momento.set('cache', 'foo', 'FOO');
-  const getResponse = await momento.get('cache', 'foo');
+  await cacheClient.createCache('cache');
+  await cacheClient.set('cache', 'foo', 'FOO');
+  const getResponse = await cacheClient.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);
   }

--- a/packages/client-sdk-nodejs/README.md
+++ b/packages/client-sdk-nodejs/README.md
@@ -1,5 +1,5 @@
 <head>
-  <meta name="Momento Node.js Client Library Documentation" content="JavaScript client software development kit for Momento Serverless Cache">
+  <meta name="Momento Node.js Client Library Documentation" content="JavaScript client software development kit for Momento Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 
@@ -13,7 +13,7 @@
 * Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
 * Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
 
-Momento Serverless Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
+Momento Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
 required by traditional caching solutions.  This repo contains the source code for the Momento JavaScript client libraries.
 
 ## Packages
@@ -38,8 +38,8 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  const createCacheResponse = await momento.createCache('cache');
-  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  await momento.createCache('cache');
+  await momento.set('cache', 'foo', 'FOO');
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);

--- a/packages/client-sdk-nodejs/README.md
+++ b/packages/client-sdk-nodejs/README.md
@@ -1,12 +1,12 @@
 <head>
-  <meta name="Momento JavaScript Client Library Documentation" content="JavaScript client software development kit for Momento Serverless Cache">
+  <meta name="Momento Node.js Client Library Documentation" content="JavaScript client software development kit for Momento Serverless Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 
 [![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-official.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
 [![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-stable.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
 
-# Momento JavaScript Client Libraries
+# Momento Node.js Client Library
 
 * Website: [https://www.gomomento.com/](https://www.gomomento.com/)
 * Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
@@ -18,13 +18,11 @@ required by traditional caching solutions.  This repo contains the source code f
 
 ## Packages
 
-There are two different JavaScript SDKs available for Momento on npmjs.  The API is identical in both SDKs, but each
-is best suited for a particular environment:
+The node.js SDK is available on npmjs: [`@gomomento/sdk`](https://www.npmjs.com/package/@gomomento/sdk).
 
-* [`@gomomento/sdk`](https://www.npmjs.com/package/@gomomento/sdk): the Momento node.js SDK, for use in server-side applications
-  and other node.js environments where performance considerations are key.
-* [`@gomomento/sdk-web`](https://www.npmjs.com/package/@gomomento/sdk-web): the Momento web SDK, for use in browsers or
-  other non-node.js JavaScript environments.  More portable but less performant for server-side use cases.
+The node.js SDK is the best choice for server-side JavaScript applications or environments where performance considerations
+are key.  If you are writing a browser application or other JavaScript code that will run outside of node.js, check out
+the [Momento Web SDK](../client-sdk-web).
 
 ## Usage
 
@@ -59,10 +57,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available for both the node.js and web SDKs:
-
-* [Node.js SDK examples](./examples/nodejs)
-* [Web SDK examples](./examples/web)
+Working example projects, with all required build configuration files, are available in the [examples](../../examples/nodejs) subdirectory.
 
 ## Developing
 

--- a/packages/client-sdk-web/README.md
+++ b/packages/client-sdk-web/README.md
@@ -1,12 +1,12 @@
 <head>
-  <meta name="Momento JavaScript Client Library Documentation" content="JavaScript client software development kit for Momento Serverless Cache">
+  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Serverless Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 
 [![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-official.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
 [![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-stable.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
 
-# Momento JavaScript Client Libraries
+# Momento JavaScript Web Client Library
 
 * Website: [https://www.gomomento.com/](https://www.gomomento.com/)
 * Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
@@ -18,19 +18,19 @@ required by traditional caching solutions.  This repo contains the source code f
 
 ## Packages
 
-There are two different JavaScript SDKs available for Momento on npmjs.  The API is identical in both SDKs, but each
-is best suited for a particular environment:
+The JavaScript Web SDK is available on npmjs: [`@gomomento/sdk-web`](https://www.npmjs.com/package/@gomomento/sdk-web).
 
-* [`@gomomento/sdk`](https://www.npmjs.com/package/@gomomento/sdk): the Momento node.js SDK, for use in server-side applications
-  and other node.js environments where performance considerations are key.
-* [`@gomomento/sdk-web`](https://www.npmjs.com/package/@gomomento/sdk-web): the Momento web SDK, for use in browsers or
-  other non-node.js JavaScript environments.  More portable but less performant for server-side use cases.
+The web SDK is the best choice for client-side JavaScript applications, such as code that will run in a browser.  For
+node.js server-side applications, check out the [Momento Node.js SDK](../client-sdk-nodejs).
 
 ## Usage
 
 ```javascript
-import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
-
+/* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/ban-ts-comment */
+import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk-web';
+// @ts-ignore
+// This global is required in order to use the Web SDK outside of a browser
+global.XMLHttpRequest = require('xhr2');
 async function main() {
   const momento = new CacheClient({
     configuration: Configurations.Laptop.v1(),
@@ -59,10 +59,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available for both the node.js and web SDKs:
-
-* [Node.js SDK examples](./examples/nodejs)
-* [Web SDK examples](./examples/web)
+Working example projects, with all required build configuration files, are available in the [examples](../../examples/web) subdirectory.
 
 ## Developing
 

--- a/packages/client-sdk-web/README.md
+++ b/packages/client-sdk-web/README.md
@@ -1,5 +1,5 @@
 <head>
-  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Serverless Cache">
+  <meta name="Momento Web Client Library Documentation" content="JavaScript web client software development kit for Momento Cache">
 </head>
 <img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
 
@@ -13,7 +13,7 @@
 * Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
 * Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
 
-Momento Serverless Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
+Momento Cache is a fast, simple, pay-as-you-go caching solution without any of the operational overhead
 required by traditional caching solutions.  This repo contains the source code for the Momento JavaScript client libraries.
 
 ## Packages
@@ -40,8 +40,8 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  const createCacheResponse = await momento.createCache('cache');
-  const setResponse = await momento.set('cache', 'foo', 'FOO');
+  await momento.createCache('cache');
+  await momento.set('cache', 'foo', 'FOO');
   const getResponse = await momento.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);

--- a/packages/client-sdk-web/README.md
+++ b/packages/client-sdk-web/README.md
@@ -32,7 +32,7 @@ import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomome
 // This global is required in order to use the Web SDK outside of a browser
 global.XMLHttpRequest = require('xhr2');
 async function main() {
-  const momento = new CacheClient({
+  const cacheClient = new CacheClient({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -40,9 +40,9 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await momento.createCache('cache');
-  await momento.set('cache', 'foo', 'FOO');
-  const getResponse = await momento.get('cache', 'foo');
+  await cacheClient.createCache('cache');
+  await cacheClient.set('cache', 'foo', 'FOO');
+  const getResponse = await cacheClient.get('cache', 'foo');
   if (getResponse instanceof CacheGet.Hit) {
     console.log(`Got value: ${getResponse.valueString()}`);
   }


### PR DESCRIPTION
 chore: update READMEs for new repository layout

This commit contains several changes:

* Adds READMEs for the package/client-sdk-nodejs and package/client-sdk-web
  directories, which are necessary for npm.js.
* Makes the top-level README a lot less verbose, with the intent
  of moving most of the content to the docs website.
* Adds a more succinct example, `readme.ts`, for inclusion in the READMEs
  (the template generator will need an update before this can be slurped
  in, so it's just hard-coded copy/paste for now.)
* Relaxes the line length restrictions in prettier config, to make all of
  the examples a bit more compact.