### PR TITLE
feat: publish web SDK as 1.x

### DIFF
--- a/scripts/publish-all-packages.sh
+++ b/scripts/publish-all-packages.sh
@@ -27,11 +27,4 @@ pushd ${ROOT_DIR}/packages/common-integration-tests
   npm pack
 popd
 ${ROOT_DIR}/scripts/publish-package.sh "client-sdk-nodejs" "${VERSION}" "${CORE_VERSION}"
-
-# We plan to version the web SDK along with the node.js SDK and core library for the time
-# being, just to keep things simple.
-# Until we are ready for a 1.x release of the web sdk, we use this silly hack to replace
-# the leading `1.` in the version number with a `0.`, to make it clear that we are pre-`1.0`.
-# We will remove this line when we are ready to officially release the web sdk.
-WEB_SDK_VERSION=$(echo ${VERSION} |sed "s/^1\./0\./")
-${ROOT_DIR}/scripts/publish-package.sh "client-sdk-web" "${WEB_SDK_VERSION}" "${CORE_VERSION}"
+${ROOT_DIR}/scripts/publish-package.sh "client-sdk-web" "${VERSION}" "${CORE_VERSION}"


### PR DESCRIPTION
This commit removes the version number manipulation, so we will now begin publishing the web SDK using 1.x version numbers.