### PR TITLE
chore: export ICacheClient from core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,7 @@ export {
 } from './config/logging/noop-momento-logger';
 
 export {
+  ICacheClient,
   SetOptions,
   SetIfNotExistsOptions,
   IncrementOptions,


### PR DESCRIPTION
Some libraries require unit tests (mocks) in addition to integration tests. 
Therefore our integrations need to use dependency injection on the interface
`ICacheClient` so we can mock out `CacheClient` in the tests.

Currently we are not exporting `ICacheClient` from the Node.js or web
SDKs. Left alone we would have to separately install `@gomomento/core` to
access `ICacheClient`, which is less than desirable. After this PR I
will follow up to re-export `ICacheClient` from the SDKs.
