### PR TITLE
chore: export `ICacheClient` from SDKs

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -61,6 +61,7 @@ import * as GenerateAuthToken from '@gomomento/sdk-core/dist/src/messages/respon
 import * as RefreshAuthToken from '@gomomento/sdk-core/dist/src/messages/responses/refresh-auth-token';
 
 import {
+  ICacheClient,
   SubscribeCallOptions,
   CacheInfo,
   CollectionTtl,
@@ -148,6 +149,7 @@ export {ExperimentalMetricsCsvMiddleware} from './config/middleware/experimental
 export {ExampleAsyncMiddleware} from './config/middleware/example-async-middleware';
 
 export {
+  ICacheClient,
   CollectionTtl,
   ItemType,
   SortedSetOrder,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -60,6 +60,7 @@ import * as GenerateAuthToken from '@gomomento/sdk-core/dist/src/messages/respon
 import * as RefreshAuthToken from '@gomomento/sdk-core/dist/src/messages/responses/refresh-auth-token';
 
 import {
+  ICacheClient,
   SubscribeCallOptions,
   CacheInfo,
   CollectionTtl,
@@ -103,6 +104,7 @@ export {
 } from './config/logging/default-momento-logger';
 
 export {
+  ICacheClient,
   CollectionTtl,
   ItemType,
   SortedSetOrder,


### PR DESCRIPTION
Allow consumers of the SDKs direct access to `ICacheClient` without
having to separately install `@gomomento/core`
