### PR TITLE
feat: add list api examples for docs

### DIFF
--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -410,14 +410,14 @@ async function main() {
     defaultTtlSeconds: 60,
   });
 
-  await example_API_ErrorHandlingHitMiss(cacheClient);
-  await example_API_ErrorHandlingSuccess(cacheClient);
-
   await example_API_CreateCache(cacheClient);
   await example_API_DeleteCache(cacheClient);
   await example_API_CreateCache(cacheClient);
   await example_API_ListCaches(cacheClient);
   await example_API_FlushCache(cacheClient);
+
+  await example_API_ErrorHandlingHitMiss(cacheClient);
+  await example_API_ErrorHandlingSuccess(cacheClient);
 
   await example_API_Set(cacheClient);
   await example_API_Get(cacheClient);

--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -227,6 +227,7 @@ async function example_API_SetIfNotExists(cacheClient: CacheClient) {
 }
 
 async function example_API_ListFetch(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateBack('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listFetch('test-cache', 'test-list');
   if (result instanceof CacheListFetch.Hit) {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -37,6 +37,7 @@ import {
   CacheListPushFront,
   CacheListRemoveValue,
   CacheListRetain,
+  ItemType,
 } from '@gomomento/sdk';
 
 function retrieveAuthTokenFromYourSecretsManager(): string {
@@ -202,7 +203,7 @@ async function example_API_Increment(cacheClient: CacheClient) {
 async function example_API_ItemGetType(cacheClient: CacheClient) {
   const result = await cacheClient.itemGetType('test-cache', 'test-key');
   if (result instanceof ItemGetType.Hit) {
-    console.log(`Item type retrieved successfully: ${result.itemType()}`);
+    console.log(`Item type retrieved successfully: ${ItemType[result.itemType()]}`);
   } else if (result instanceof ItemGetType.Miss) {
     console.log("Key 'test-key' was not found in cache 'test-cache'");
   } else if (result instanceof ItemGetType.Error) {
@@ -228,7 +229,8 @@ async function example_API_SetIfNotExists(cacheClient: CacheClient) {
 async function example_API_ListFetch(cacheClient: CacheClient) {
   const result = await cacheClient.listFetch('test-cache', 'test-list');
   if (result instanceof CacheListFetch.Hit) {
-    console.log(`List fetched successfully: ${result.toString()}`);
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    console.log(`List fetched successfully: ${result.valueList()}`);
   } else if (result instanceof CacheListFetch.Miss) {
     console.log("List 'test-list' was not found in cache 'test-cache'");
   } else if (result instanceof CacheListFetch.Error) {
@@ -242,7 +244,7 @@ async function example_API_ListConcatenateBack(cacheClient: CacheClient) {
   await cacheClient.listConcatenateBack('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listConcatenateBack('test-cache', 'test-list', ['x', 'y', 'z']);
   if (result instanceof CacheListConcatenateBack.Success) {
-    console.log(`Values added successfully to the back of the list 'test-list': ${result.toString()}`);
+    console.log(`Values added successfully to the back of the list 'test-list'. Result - ${result.toString()}`);
   } else if (result instanceof CacheListConcatenateBack.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListConcatenateBack on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -254,7 +256,7 @@ async function example_API_ListConcatenateFront(cacheClient: CacheClient) {
   await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listConcatenateFront('test-cache', 'test-list', ['x', 'y', 'z']);
   if (result instanceof CacheListConcatenateFront.Success) {
-    console.log(`Values added successfully to the front of the list 'test-list': ${result.toString()}`);
+    console.log(`Values added successfully to the front of the list 'test-list'. Result - ${result.toString()}`);
   } else if (result instanceof CacheListConcatenateFront.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListConcatenateFront on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -308,7 +310,7 @@ async function example_API_ListPushBack(cacheClient: CacheClient) {
   await cacheClient.listConcatenateBack('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listPushBack('test-cache', 'test-list', 'x');
   if (result instanceof CacheListPushBack.Success) {
-    console.log(`Value 'x' added successfully to back of list 'test-list': ${result.toString()}`);
+    console.log("Value 'x' added successfully to back of list 'test-list'");
   } else if (result instanceof CacheListPushBack.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListPushBack on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -320,7 +322,7 @@ async function example_API_ListPushFront(cacheClient: CacheClient) {
   await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listPushFront('test-cache', 'test-list', 'x');
   if (result instanceof CacheListPushFront.Success) {
-    console.log(`Value 'x' added successfully to front of list 'test-list': ${result.toString()}`);
+    console.log("Value 'x' added successfully to front of list 'test-list'");
   } else if (result instanceof CacheListPushFront.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListPushFront on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -332,7 +334,7 @@ async function example_API_ListRemoveValue(cacheClient: CacheClient) {
   await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
   const result = await cacheClient.listRemoveValue('test-cache', 'test-list', 'b');
   if (result instanceof CacheListRemoveValue.Success) {
-    console.log(`Value 'b' removed successfully from list 'test-list': ${result.toString()}`);
+    console.log("Value 'b' removed successfully from list 'test-list'");
   } else if (result instanceof CacheListPushFront.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListRemoveValue on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -344,7 +346,7 @@ async function example_API_ListRetain(cacheClient: CacheClient) {
   await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c', 'd', 'e', 'f']);
   const result = await cacheClient.listRetain('test-cache', 'test-list', {startIndex: 1, endIndex: 4});
   if (result instanceof CacheListRetain.Success) {
-    console.log(`Retaining elements from index 1 to 4 from list 'test-list': ${result.toString()}`);
+    console.log("Retaining elements from index 1 to 4 from list 'test-list'");
   } else if (result instanceof CacheListRetain.Error) {
     throw new Error(
       `An error occurred while attempting to call cacheListRetain on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
@@ -411,13 +413,13 @@ async function main() {
   });
 
   await example_API_CreateCache(cacheClient);
+  await example_API_ErrorHandlingHitMiss(cacheClient);
+  await example_API_ErrorHandlingSuccess(cacheClient);
+
   await example_API_DeleteCache(cacheClient);
   await example_API_CreateCache(cacheClient);
   await example_API_ListCaches(cacheClient);
   await example_API_FlushCache(cacheClient);
-
-  await example_API_ErrorHandlingHitMiss(cacheClient);
-  await example_API_ErrorHandlingSuccess(cacheClient);
 
   await example_API_Set(cacheClient);
   await example_API_Get(cacheClient);

--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -27,6 +27,16 @@ import {
   CacheIncrement,
   ItemGetType,
   CacheSetIfNotExists,
+  CacheListFetch,
+  CacheListConcatenateBack,
+  CacheListConcatenateFront,
+  CacheListLength,
+  CacheListPopBack,
+  CacheListPopFront,
+  CacheListPushBack,
+  CacheListPushFront,
+  CacheListRemoveValue,
+  CacheListRetain,
 } from '@gomomento/sdk';
 
 function retrieveAuthTokenFromYourSecretsManager(): string {
@@ -215,6 +225,133 @@ async function example_API_SetIfNotExists(cacheClient: CacheClient) {
   }
 }
 
+async function example_API_ListFetch(cacheClient: CacheClient) {
+  const result = await cacheClient.listFetch('test-cache', 'test-list');
+  if (result instanceof CacheListFetch.Hit) {
+    console.log(`List fetched successfully: ${result.toString()}`);
+  } else if (result instanceof CacheListFetch.Miss) {
+    console.log("List 'test-list' was not found in cache 'test-cache'");
+  } else if (result instanceof CacheListFetch.Error) {
+    throw new Error(
+      `An error occurred while attempting to fetch the list 'test-list' from cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListConcatenateBack(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateBack('test-cache', 'test-list', ['a', 'b', 'c']);
+  const result = await cacheClient.listConcatenateBack('test-cache', 'test-list', ['x', 'y', 'z']);
+  if (result instanceof CacheListConcatenateBack.Success) {
+    console.log(`Values added successfully to the back of the list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListConcatenateBack.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListConcatenateBack on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListConcatenateFront(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
+  const result = await cacheClient.listConcatenateFront('test-cache', 'test-list', ['x', 'y', 'z']);
+  if (result instanceof CacheListConcatenateFront.Success) {
+    console.log(`Values added successfully to the front of the list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListConcatenateFront.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListConcatenateFront on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListLength(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateBack('test-cache', 'test-list', ['one', 'two', 'three']);
+  const result = await cacheClient.listLength('test-cache', 'test-list');
+  if (result instanceof CacheListLength.Hit) {
+    console.log(`Length of list 'test-list' is ${result.length()}`);
+  } else if (result instanceof CacheListLength.Miss) {
+    console.log("List 'test-list' was not found in cache 'test-cache'");
+  } else if (result instanceof CacheListLength.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListLength on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListPopBack(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateBack('test-cache', 'test-list', ['one', 'two', 'three']);
+  const result = await cacheClient.listPopBack('test-cache', 'test-list');
+  if (result instanceof CacheListPopBack.Hit) {
+    console.log(`Last value was removed successfully from list 'test-list': ${result.valueString()}`);
+  } else if (result instanceof CacheListPopBack.Miss) {
+    console.log("List 'test-list' was not found in cache 'test-cache'");
+  } else if (result instanceof CacheListPopBack.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListPopBack on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListPopFront(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateFront('test-cache', 'test-list', ['one', 'two', 'three']);
+  const result = await cacheClient.listPopFront('test-cache', 'test-list');
+  if (result instanceof CacheListPopFront.Hit) {
+    console.log(`First value was removed successfully from list 'test-list': ${result.valueString()}`);
+  } else if (result instanceof CacheListPopFront.Miss) {
+    console.log("List 'test-list' was not found in cache 'test-cache'");
+  } else if (result instanceof CacheListPopFront.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListPopFront on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListPushBack(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateBack('test-cache', 'test-list', ['a', 'b', 'c']);
+  const result = await cacheClient.listPushBack('test-cache', 'test-list', 'x');
+  if (result instanceof CacheListPushBack.Success) {
+    console.log(`Value 'x' added successfully to back of list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListPushBack.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListPushBack on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListPushFront(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
+  const result = await cacheClient.listPushFront('test-cache', 'test-list', 'x');
+  if (result instanceof CacheListPushFront.Success) {
+    console.log(`Value 'x' added successfully to front of list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListPushFront.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListPushFront on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListRemoveValue(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c']);
+  const result = await cacheClient.listRemoveValue('test-cache', 'test-list', 'b');
+  if (result instanceof CacheListRemoveValue.Success) {
+    console.log(`Value 'b' removed successfully from list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListPushFront.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListRemoveValue on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_ListRetain(cacheClient: CacheClient) {
+  await cacheClient.listConcatenateFront('test-cache', 'test-list', ['a', 'b', 'c', 'd', 'e', 'f']);
+  const result = await cacheClient.listRetain('test-cache', 'test-list', {startIndex: 1, endIndex: 4});
+  if (result instanceof CacheListRetain.Success) {
+    console.log(`Retaining elements from index 1 to 4 from list 'test-list': ${result.toString()}`);
+  } else if (result instanceof CacheListRetain.Error) {
+    throw new Error(
+      `An error occurred while attempting to call cacheListRetain on list 'test-list' in cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
 function example_API_InstantiateAuthClient() {
   new AuthClient({
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
@@ -288,6 +425,17 @@ async function main() {
   await example_API_Increment(cacheClient);
   await example_API_ItemGetType(cacheClient);
   await example_API_SetIfNotExists(cacheClient);
+
+  await example_API_ListFetch(cacheClient);
+  await example_API_ListConcatenateBack(cacheClient);
+  await example_API_ListConcatenateFront(cacheClient);
+  await example_API_ListLength(cacheClient);
+  await example_API_ListPopBack(cacheClient);
+  await example_API_ListPopFront(cacheClient);
+  await example_API_ListPushBack(cacheClient);
+  await example_API_ListPushFront(cacheClient);
+  await example_API_ListRemoveValue(cacheClient);
+  await example_API_ListRetain(cacheClient);
 
   example_API_InstantiateAuthClient();
   const authClient = new AuthClient({

--- a/scripts/build-nodejs-sdk.sh
+++ b/scripts/build-nodejs-sdk.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-echo "dev building web sdk"
+echo "dev building nodejs sdk"
 
 ./scripts/build-package.sh "core"
 ./scripts/build-package.sh "client-sdk-nodejs"


### PR DESCRIPTION
## PR Description:
Missing API list from public-dev-docs repo result:
`
SDK 'javascript' is missing 50 snippets and 0 files.
	Missing snippets: API_ConfigurationLambda,API_DictionaryFetch,API_DictionaryGetField,API_DictionaryGetFields,API_DictionaryIncrement,API_DictionaryRemoveField,API_DictionaryRemoveFields,API_DictionarySetField,API_DictionarySetFields,API_DictionaryLength,API_SetAddElement,API_SetAddElements,API_SetFetch,API_SetRemoveElement,API_SetRemoveElements,API_SetContainsElement,API_SetContainsElements,API_SetLength,API_TopicSubscribe,API_TopicPublish,API_InstantiateTopicClient,API_SortedSetPutElement,API_SortedSetPutElements,API_SortedSetFetchByRank,API_SortedSetFetchByScore,API_SortedSetGetScore,API_SortedSetGetScores,API_SortedSetRemoveElement,API_SortedSetRemoveElements,API_SortedSetGetRank,API_SortedSetIncrementScore,API_SortedSetLength,API_SortedSetLengthByScore,API_Ping,API_KeyExists,API_KeysExist,API_UpdateTtl,API_IncreaseTtl,API_DecreaseTtl,API_ItemGetTtl,API_ListFetch,API_ListConcatenateBack,API_ListConcatenateFront,API_ListLength,API_ListPopBack,API_ListPopFront,API_ListPushBack,API_ListPushFront,API_ListRemoveValue,API_ListRetain
`

This commit adds the examples for all list APIs:
- ListFetch
- ListConcatenateBack
- ListConcatenateFront
- ListLength
- ListPopBack
- ListPopFront
- ListPushBack
- ListPushFront
- ListRemoveValue
- ListRetain

## Testing
Output from ci jobs looks like:
<img width="747" alt="Screenshot 2023-05-30 at 6 03 53 PM" src="https://github.com/momentohq/client-sdk-javascript/assets/127137312/49b9a957-1a9d-40fb-afdd-ea9815c2f083">

