### PR TITLE
feat: Add ping api example for docs

### DIFF
--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -64,6 +64,7 @@ import {
   TopicPublish,
   TopicSubscribe,
 } from '@gomomento/sdk';
+import {InternalNodeGrpcPingClient} from '../../packages/client-sdk-nodejs/src/internal/ping-client';
 import {ExampleMetricMiddleware} from './doc-example-files/example-metric-middleware';
 
 function retrieveAuthTokenFromYourSecretsManager(): string {
@@ -864,6 +865,25 @@ async function example_API_TopicSubscribe(topicClient: TopicClient) {
   }
 }
 
+function example_API_InstantiatePingClient() {
+  new InternalNodeGrpcPingClient({
+    endpoint: 'some.url',
+    configuration: Configurations.Laptop.latest(),
+  });
+}
+
+async function example_API_Ping(pingClient: InternalNodeGrpcPingClient) {
+  await pingClient
+    .ping()
+    .then(() => {
+      console.log('pinged successfully!');
+    })
+    .catch(err => {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      console.log(`failed to ping: ${err}`);
+    });
+}
+
 async function main() {
   const originalAuthToken = process.env['MOMENTO_AUTH_TOKEN'];
   process.env['MOMENTO_AUTH_TOKEN'] = retrieveAuthTokenFromYourSecretsManager();
@@ -957,6 +977,13 @@ async function main() {
   });
   await example_API_TopicPublish(topicClient);
   await example_API_TopicSubscribe(topicClient);
+
+  example_API_InstantiatePingClient();
+  const pingClient = new InternalNodeGrpcPingClient({
+    endpoint: 'bad.url',
+    configuration: Configurations.Laptop.latest(),
+  });
+  await example_API_Ping(pingClient);
 }
 
 main().catch(e => {

--- a/examples/nodejs/doc-examples-js-apis.ts
+++ b/examples/nodejs/doc-examples-js-apis.ts
@@ -835,11 +835,26 @@ async function example_API_TopicSubscribe(topicClient: TopicClient) {
       return;
     },
     onItem: () => {
+      console.log("Publishing values to the topic 'test-topic'!");
       return;
     },
   });
   if (result instanceof TopicSubscribe.Subscription) {
     console.log("Successfully subscribed to topic 'test-topic'");
+
+    // Wait for stream to start.
+    setTimeout(() => {
+      console.log('Waiting for the stream to start');
+    }, 2000);
+
+    // Publish a value
+    await topicClient.publish('test-cache', 'test-topic', 'test-value');
+
+    // Wait for published values to be received.
+    setTimeout(() => {
+      console.log('Waiting for the published values');
+    }, 2000);
+
     // Need to close the stream before the example ends or else the example will hang.
     result.unsubscribe();
   } else if (result instanceof TopicSubscribe.Error) {


### PR DESCRIPTION
## PR Description:
This commit adds the ping api example

## Testing:
Locally tested via command:
`MOMENTO_AUTH_TOKEN=<MOMENTO_AUTH_TOKEN> npm run doc-examples-js-apis`

## Result:
