### PR TITLE
feat: create new TopicConfiguration class for configuring TopicClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "client-sdk-nodejs",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/packages/client-sdk-nodejs/src/config/configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/configuration.ts
@@ -23,7 +23,7 @@ export interface ConfigurationProps {
 }
 
 /**
- * Configuration options for Momento Simple Cache client.
+ * Configuration options for Momento CacheClient.
  *
  * @export
  * @interface Configuration

--- a/packages/client-sdk-nodejs/src/config/topic-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configuration.ts
@@ -1,0 +1,33 @@
+import {MomentoLoggerFactory} from '../';
+
+export interface TopicConfigurationProps {
+  /**
+   * Configures logging verbosity and format
+   */
+  loggerFactory: MomentoLoggerFactory;
+}
+
+/**
+ * Configuration options for Momento TopicClient
+ *
+ * @export
+ * @interface TopicConfiguration
+ */
+export interface TopicConfiguration {
+  /**
+   * @returns {MomentoLoggerFactory} the current configuration options for logging verbosity and format
+   */
+  getLoggerFactory(): MomentoLoggerFactory;
+}
+
+export class TopicClientConfiguration implements TopicConfiguration {
+  private readonly loggerFactory: MomentoLoggerFactory;
+
+  constructor(props: TopicConfigurationProps) {
+    this.loggerFactory = props.loggerFactory;
+  }
+
+  getLoggerFactory(): MomentoLoggerFactory {
+    return this.loggerFactory;
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -1,0 +1,30 @@
+import {MomentoLoggerFactory} from '@gomomento/sdk-core';
+import {DefaultMomentoLoggerFactory} from './logging/default-momento-logger';
+import {
+  TopicClientConfiguration,
+  TopicConfiguration,
+} from './topic-configuration';
+
+const defaultLoggerFactory: MomentoLoggerFactory =
+  new DefaultMomentoLoggerFactory();
+
+/**
+ * Default config provides defaults suitable for most environments; prioritizes success of publishing and receiving messages.
+ * @export
+ * @class Default
+ */
+export class Default extends TopicClientConfiguration {
+  /**
+   * Provides the latest recommended configuration for a default environment.  NOTE: this configuration may
+   * change in future releases to take advantage of improvements we identify for default configurations.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {TopicConfiguration}
+   */
+  static latest(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): TopicConfiguration {
+    return new TopicClientConfiguration({
+      loggerFactory: loggerFactory,
+    });
+  }
+}

--- a/packages/client-sdk-nodejs/src/internal/control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/control-client.ts
@@ -61,7 +61,10 @@ export class ControlClient {
           props.credentialProvider.getControlEndpoint(),
           ChannelCredentials.createSsl()
         ),
-      configuration: props.configuration,
+      loggerFactory: props.configuration.getLoggerFactory(),
+      maxIdleMillis: props.configuration
+        .getTransportStrategy()
+        .getMaxIdleMillis(),
     });
   }
 

--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -130,7 +130,10 @@ export class DataClient implements IDataClient {
             'grpc.use_local_subchannel_pool': 1,
           }
         ),
-      configuration: this.configuration,
+      loggerFactory: this.configuration.getLoggerFactory(),
+      maxIdleMillis: this.configuration
+        .getTransportStrategy()
+        .getMaxIdleMillis(),
     });
 
     this.textEncoder = new TextEncoder();

--- a/packages/client-sdk-nodejs/src/internal/grpc/idle-grpc-client-wrapper.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/idle-grpc-client-wrapper.ts
@@ -1,10 +1,10 @@
 import {CloseableGrpcClient, GrpcClientWrapper} from './grpc-client-wrapper';
-import {Configuration} from '../../config/configuration';
-import {MomentoLogger} from '../../';
+import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
 
 export interface IdleGrpcClientWrapperProps<T extends CloseableGrpcClient> {
   clientFactoryFn: () => T;
-  configuration: Configuration;
+  loggerFactory: MomentoLoggerFactory;
+  maxIdleMillis: number;
 }
 
 /**
@@ -35,12 +35,10 @@ export class IdleGrpcClientWrapper<T extends CloseableGrpcClient>
   private lastAccessTime: number;
 
   constructor(props: IdleGrpcClientWrapperProps<T>) {
-    this.logger = props.configuration.getLoggerFactory().getLogger(this);
+    this.logger = props.loggerFactory.getLogger(this);
     this.clientFactoryFn = props.clientFactoryFn;
     this.client = this.clientFactoryFn();
-    this.maxIdleMillis = props.configuration
-      .getTransportStrategy()
-      .getMaxIdleMillis();
+    this.maxIdleMillis = props.maxIdleMillis;
     this.lastAccessTime = Date.now();
   }
 

--- a/packages/client-sdk-nodejs/src/internal/ping-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/ping-client.ts
@@ -36,7 +36,10 @@ export class InternalNodeGrpcPingClient {
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
         new grpcPing.PingClient(props.endpoint, ChannelCredentials.createSsl()),
-      configuration: props.configuration,
+      loggerFactory: props.configuration.getLoggerFactory(),
+      maxIdleMillis: props.configuration
+        .getTransportStrategy()
+        .getMaxIdleMillis(),
     });
   }
 

--- a/packages/client-sdk-nodejs/src/topic-client-props.ts
+++ b/packages/client-sdk-nodejs/src/topic-client-props.ts
@@ -1,11 +1,11 @@
 import {CredentialProvider} from '.';
-import {Configuration} from './config/configuration';
+import {TopicConfiguration} from './config/topic-configuration';
 
 export interface TopicClientProps {
   /**
    * Configuration settings for the topic client
    */
-  configuration: Configuration;
+  configuration: TopicConfiguration;
   /**
    * controls how the client will get authentication information for connecting to the Momento service
    */

--- a/packages/client-sdk-web/src/config/topic-configuration.ts
+++ b/packages/client-sdk-web/src/config/topic-configuration.ts
@@ -1,0 +1,33 @@
+import {MomentoLoggerFactory} from '../';
+
+export interface TopicConfigurationProps {
+  /**
+   * Configures logging verbosity and format
+   */
+  loggerFactory: MomentoLoggerFactory;
+}
+
+/**
+ * Configuration options for Momento TopicClient
+ *
+ * @export
+ * @interface TopicConfiguration
+ */
+export interface TopicConfiguration {
+  /**
+   * @returns {MomentoLoggerFactory} the current configuration options for logging verbosity and format
+   */
+  getLoggerFactory(): MomentoLoggerFactory;
+}
+
+export class TopicClientConfiguration implements TopicConfiguration {
+  private readonly loggerFactory: MomentoLoggerFactory;
+
+  constructor(props: TopicConfigurationProps) {
+    this.loggerFactory = props.loggerFactory;
+  }
+
+  getLoggerFactory(): MomentoLoggerFactory {
+    return this.loggerFactory;
+  }
+}

--- a/packages/client-sdk-web/src/config/topic-configurations.ts
+++ b/packages/client-sdk-web/src/config/topic-configurations.ts
@@ -1,0 +1,30 @@
+import {MomentoLoggerFactory} from '@gomomento/sdk-core';
+import {DefaultMomentoLoggerFactory} from './logging/default-momento-logger';
+import {
+  TopicClientConfiguration,
+  TopicConfiguration,
+} from './topic-configuration';
+
+const defaultLoggerFactory: MomentoLoggerFactory =
+  new DefaultMomentoLoggerFactory();
+
+/**
+ * Default config provides defaults suitable for most environments; prioritizes success of publishing and receiving messages.
+ * @export
+ * @class Default
+ */
+export class Default extends TopicClientConfiguration {
+  /**
+   * Provides the latest recommended configuration for a default environment.  NOTE: this configuration may
+   * change in future releases to take advantage of improvements we identify for default configurations.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {TopicConfiguration}
+   */
+  static latest(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): TopicConfiguration {
+    return new TopicClientConfiguration({
+      loggerFactory: loggerFactory,
+    });
+  }
+}

--- a/packages/client-sdk-web/src/topic-client-props.ts
+++ b/packages/client-sdk-web/src/topic-client-props.ts
@@ -1,11 +1,11 @@
 import {CredentialProvider} from '.';
-import {Configuration} from './config/configuration';
+import {TopicConfiguration} from './config/topic-configuration';
 
 export interface TopicClientProps {
   /**
    * Configuration settings for the topic client
    */
-  configuration: Configuration;
+  configuration: TopicConfiguration;
   /**
    * controls how the client will get authentication information for connecting to the Momento service
    */


### PR DESCRIPTION
Prior to this commit, the TopicClient was using a CacheClient
Configuration object for configuration. There are many settings
on the CacheClient configuration that aren't relevant for Topics,
and soon the reverse will likely be true as well. This commit changes
the TopicClient constructor to take a new TopicConfiguration object
which will give us the ability to define the configuration API for the
two clients independently going forward.
