### PR TITLE
feat: export new TopicConfiguration namespaces from index

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -1,6 +1,7 @@
 import {CacheClient, SimpleCacheClient} from './cache-client';
 import {TopicClient} from './topic-client';
 import * as Configurations from './config/configurations';
+import * as TopicConfigurations from './config/topic-configurations';
 import {TopicClientProps} from './topic-client-props';
 
 // Cache Client Response Types
@@ -103,6 +104,10 @@ import {
 } from '@gomomento/sdk-core';
 
 import {Configuration, CacheConfiguration} from './config/configuration';
+import {
+  TopicConfiguration,
+  TopicClientConfiguration,
+} from './config/topic-configuration';
 
 export {
   DefaultMomentoLoggerFactory,
@@ -217,7 +222,10 @@ export {
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
   ItemGetType,
-  // TopicClient Response types
+  // TopicClient
+  TopicConfigurations,
+  TopicConfiguration,
+  TopicClientConfiguration,
   TopicClient,
   TopicClientProps,
   TopicItem,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -2,6 +2,7 @@ import {CacheClient} from './cache-client';
 import {AuthClient} from './auth-client';
 import {TopicClient} from './topic-client';
 import * as Configurations from './config/configurations';
+import * as TopicConfigurations from './config/topic-configurations';
 
 // Cache Client Response Types
 import * as CacheGet from '@gomomento/sdk-core/dist/src/messages/responses/cache-get';
@@ -97,6 +98,11 @@ import {
 
 import {Configuration} from './config/configuration';
 
+import {
+  TopicConfiguration,
+  TopicClientConfiguration,
+} from './config/topic-configuration';
+
 export {
   DefaultMomentoLoggerFactory,
   DefaultMomentoLogger,
@@ -163,6 +169,9 @@ export {
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
   ItemGetType,
+  TopicConfigurations,
+  TopicConfiguration,
+  TopicClientConfiguration,
   TopicClient,
   TopicItem,
   TopicPublish,


### PR DESCRIPTION
Prior to this commit we weren't exporting the topic config namespaces
from the index, so they weren't easy to use from outside of the SDK.
