### PR TITLE
chore: Allow Web SDK integration tests to be run against localhost

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,6 @@ jobs:
     runs-on: macos-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: js-integration-test-ci
 
     steps:
       - name: Setup repo

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -44,7 +44,7 @@ export class InternalWebGrpcAuthClient<
     this.clientMetadataProvider = new ClientMetadataProvider({});
     this.authClient = new auth.AuthClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://${getWebControlEndpoint(this.creds)}`,
+      getWebControlEndpoint(this.creds),
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/control-client.ts
+++ b/packages/client-sdk-web/src/internal/control-client.ts
@@ -54,7 +54,7 @@ export class ControlClient<
     });
     this.clientWrapper = new control.ScsControlClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://${getWebControlEndpoint(props.credentialProvider)}`,
+      getWebControlEndpoint(props.credentialProvider),
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -156,7 +156,7 @@ export class DataClient<
     });
     this.clientWrapper = new cache.ScsClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://${getWebCacheEndpoint(props.credentialProvider)}`,
+      getWebCacheEndpoint(props.credentialProvider),
       null,
       {}
     );

--- a/packages/client-sdk-web/src/internal/ping-client.ts
+++ b/packages/client-sdk-web/src/internal/ping-client.ts
@@ -26,12 +26,7 @@ export class PingClient<
   constructor(props: PingClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
     this.clientMetadataProvider = new ClientMetadataProvider({});
-    this.clientWrapper = new ping.PingClient(
-      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://${props.endpoint}`,
-      null,
-      {}
-    );
+    this.clientWrapper = new ping.PingClient(props.endpoint, null, {});
   }
 
   public async ping(): Promise<void> {

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -54,7 +54,7 @@ export class PubsubClient<
 
     this.client = new pubsub.PubsubClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
-      `https://${getWebCacheEndpoint(props.credentialProvider)}`,
+      getWebCacheEndpoint(props.credentialProvider),
       null,
       {}
     );

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -23,7 +23,7 @@ export function getWebControlEndpoint(
   if (credentialProvider.isControlEndpointOverridden()) {
     return withProtocolPrefix(credentialProvider.getControlEndpoint());
   }
-  return withProtocolPrefix(`${credentialProvider.getControlEndpoint()}`);
+  return withProtocolPrefix(`web.${credentialProvider.getControlEndpoint()}`);
 }
 
 export function getWebCacheEndpoint(
@@ -32,7 +32,7 @@ export function getWebCacheEndpoint(
   if (credentialProvider.isCacheEndpointOverridden()) {
     return withProtocolPrefix(credentialProvider.getCacheEndpoint());
   }
-  return withProtocolPrefix(`${credentialProvider.getCacheEndpoint()}`);
+  return withProtocolPrefix(`web.${credentialProvider.getCacheEndpoint()}`);
 }
 
 function withProtocolPrefix(endpoint: string): string {

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -20,11 +20,24 @@ export function createCallMetadata(
 export function getWebControlEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  return `web.${credentialProvider.getControlEndpoint()}`;
+  if (credentialProvider.isControlEndpointOverridden()) {
+    return withProtocolPrefix(credentialProvider.getControlEndpoint());
+  }
+  return withProtocolPrefix(`${credentialProvider.getControlEndpoint()}`);
 }
 
 export function getWebCacheEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  return `web.${credentialProvider.getCacheEndpoint()}`;
+  if (credentialProvider.isCacheEndpointOverridden()) {
+    return withProtocolPrefix(credentialProvider.getCacheEndpoint());
+  }
+  return withProtocolPrefix(`${credentialProvider.getCacheEndpoint()}`);
+}
+
+function withProtocolPrefix(endpoint: string): string {
+  if (endpoint.match(/^http(?:s)?:\/\//)) {
+    return endpoint;
+  }
+  return `https://${endpoint}`;
 }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -1,6 +1,8 @@
 import {
   deleteCacheIfExists,
   testCacheName,
+  isLocalhostDevelopmentMode,
+  createCacheIfNotExists,
 } from '@gomomento/common-integration-tests';
 import {
   CreateCache,
@@ -18,13 +20,28 @@ import {
 import {ITopicClient} from '@gomomento/sdk-core/dist/src/clients/ITopicClient';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 
-const credsProvider = CredentialProvider.fromEnvironmentVariable({
-  environmentVariableName: 'TEST_AUTH_TOKEN',
-});
+let _credsProvider: CredentialProvider | undefined = undefined;
+
+function credsProvider(): CredentialProvider {
+  if (_credsProvider === undefined) {
+    if (isLocalhostDevelopmentMode()) {
+      _credsProvider = CredentialProvider.fromEnvironmentVariable({
+        environmentVariableName: 'TEST_AUTH_TOKEN',
+        controlEndpoint: 'https://no-controlplane-requests-allowed:9001',
+        cacheEndpoint: 'https://localhost:9001',
+      });
+    } else {
+      _credsProvider = CredentialProvider.fromEnvironmentVariable({
+        environmentVariableName: 'TEST_AUTH_TOKEN',
+      });
+    }
+  }
+  return _credsProvider;
+}
 
 export const IntegrationTestCacheClientProps: CacheClientProps = {
   configuration: Configurations.Laptop.latest(),
-  credentialProvider: credsProvider,
+  credentialProvider: credsProvider(),
   defaultTtlSeconds: 1111,
 };
 
@@ -35,7 +52,7 @@ function momentoClientForTesting(): CacheClient {
 function momentoTopicClientForTesting(): TopicClient {
   return new TopicClient({
     configuration: TopicConfigurations.Default.latest(),
-    credentialProvider: credsProvider,
+    credentialProvider: credsProvider(),
   });
 }
 
@@ -49,10 +66,7 @@ export function SetupIntegrationTest(): {
     // Use a fresh client to avoid test interference with setup.
     const momento = momentoClientForTesting();
     await deleteCacheIfExists(momento, cacheName);
-    const createResponse = await momento.createCache(cacheName);
-    if (createResponse instanceof CreateCache.Error) {
-      throw createResponse.innerException();
-    }
+    await createCacheIfNotExists(momento, cacheName);
   });
 
   afterAll(async () => {
@@ -112,8 +126,8 @@ export function SetupAuthClientIntegrationTest(): {
         environmentVariableName: 'TEST_SESSION_TOKEN',
         // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
         // steal them from the auth-token-based creds provider.
-        cacheEndpoint: credsProvider.getCacheEndpoint(),
-        controlEndpoint: credsProvider.getControlEndpoint(),
+        cacheEndpoint: credsProvider().getCacheEndpoint(),
+        controlEndpoint: credsProvider().getControlEndpoint(),
       }),
     }),
     legacyTokenAuthClient: new AuthClient({

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -125,7 +125,7 @@ export function SetupAuthClientIntegrationTest(): {
       credentialProvider: CredentialProvider.fromEnvironmentVariable({
         environmentVariableName: 'TEST_SESSION_TOKEN',
         // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
-        // steal them from the auth-token-based creds provider.
+        // steal them from the auth-token-based creds provider.`
         cacheEndpoint: credsProvider().getCacheEndpoint(),
         controlEndpoint: credsProvider().getControlEndpoint(),
       }),

--- a/packages/client-sdk-web/test/integration/internal/ping.test.ts
+++ b/packages/client-sdk-web/test/integration/internal/ping.test.ts
@@ -1,8 +1,8 @@
 import {CredentialProvider} from '@gomomento/sdk-core';
-import {CacheClient, Configurations} from '../../src';
-import {PingClient} from '../../src/internal/ping-client';
+import {CacheClient, Configurations} from '../../../src';
+import {PingClient} from '../../../src/internal/ping-client';
 import {expectWithMessage} from '@gomomento/common-integration-tests';
-import {CacheClientProps} from '../../src/cache-client-props';
+import {CacheClientProps} from '../../../src/cache-client-props';
 
 describe('ping service', () => {
   it('ping should work', async () => {
@@ -21,7 +21,7 @@ describe('ping service', () => {
     const consoleErr = console.error;
     console.error = jest.fn();
     const pingClient = new PingClient({
-      endpoint: 'bad.url',
+      endpoint: 'https://not_a_valid_dns_name',
       configuration: Configurations.Laptop.latest(),
     });
     try {

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -1,0 +1,140 @@
+import {
+  Base64DecodedV1Token,
+  encodeToBase64,
+} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {CredentialProvider} from '@gomomento/sdk-core';
+import {
+  getWebCacheEndpoint,
+  getWebControlEndpoint,
+} from '../../../src/utils/web-client-utils';
+
+// These tokens have valid syntax, but they don't actually have valid credentials.  Just used for unit testing.
+const fakeTestLegacyToken =
+  'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJmb29Abm90LmEuZG9tYWluIiwiY3AiOiJjb250cm9sLXBsYW5lLWVuZHBvaW50Lm5vdC5hLmRvbWFpbiIsImMiOiJjYWNoZS1lbmRwb2ludC5ub3QuYS5kb21haW4ifQo.rtxfu4miBHQ1uptWJ2x3UiAwwJYcMeYIkkpXxUno_wIavg4h6YJStcbxk32NDBbmJkJS7mUw6MsvJNWaxfdPOw';
+const fakeTestV1ApiKey =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2NzgzMDU4MTIsImV4cCI6NDg2NTUxNTQxMiwiYXVkIjoiIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.8Iy8q84Lsr-D3YCo_HP4d-xjHdT8UCIuvAYcxhFMyz8';
+const decodedV1Token: Base64DecodedV1Token = {
+  api_key: fakeTestV1ApiKey,
+  endpoint: 'test.momentohq.com',
+};
+const base64EncodedFakeV1AuthToken = encodeToBase64(
+  JSON.stringify(decodedV1Token)
+);
+
+describe('getWebControlEndpoint', () => {
+  it('adds "https://web." prefix to endpoints that were parsed from legacy tokens', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: fakeTestLegacyToken,
+    });
+    const webControlEndpoint = getWebControlEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual(
+      'https://web.control-plane-endpoint.not.a.domain'
+    );
+  });
+  it('adds "https://web." prefix to endpoints that were parsed from v1 tokens', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+    });
+    const webControlEndpoint = getWebControlEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual(
+      'https://web.control.test.momentohq.com'
+    );
+  });
+
+  it('adds https protocol, but does not add web prefix for overridden endpoints', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+      controlEndpoint: 'some-control-endpoint',
+      cacheEndpoint: 'some-cache-endpoint',
+    });
+    const webControlEndpoint = getWebControlEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual('https://some-control-endpoint');
+  });
+  it('works with overridden endpoints that already have the protocol', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+      controlEndpoint: 'https://some-control-endpoint',
+      cacheEndpoint: 'https://some-cache-endpoint',
+    });
+    const webControlEndpoint = getWebControlEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual('https://some-control-endpoint');
+  });
+  describe('leaves port intact for overridden endpoints', () => {
+    it("with overrides that don't contain protocol", () => {
+      const credProvider = CredentialProvider.fromString({
+        authToken: base64EncodedFakeV1AuthToken,
+        controlEndpoint: 'some-control-endpoint:9001',
+        cacheEndpoint: 'some-cache-endpoint:9001',
+      });
+      const webControlEndpoint = getWebControlEndpoint(credProvider);
+      expect(webControlEndpoint).toEqual('https://some-control-endpoint:9001');
+    });
+    it('with overrides that do contain protocol', () => {
+      const credProvider = CredentialProvider.fromString({
+        authToken: base64EncodedFakeV1AuthToken,
+        controlEndpoint: 'https://some-control-endpoint:9001',
+        cacheEndpoint: 'https://some-cache-endpoint:9001',
+      });
+      const webControlEndpoint = getWebControlEndpoint(credProvider);
+      expect(webControlEndpoint).toEqual('https://some-control-endpoint:9001');
+    });
+  });
+});
+
+describe('getWebCacheEndpoint', () => {
+  it('adds "https://web." prefix to endpoints that were parsed from legacy tokens', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: fakeTestLegacyToken,
+    });
+    const webControlEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual(
+      'https://web.cache-endpoint.not.a.domain'
+    );
+  });
+  it('adds "https://web." prefix to endpoints that were parsed from v1 tokens', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+    });
+    const webControlEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual('https://web.cache.test.momentohq.com');
+  });
+
+  it('adds https protocol, but does not add web prefix for overridden endpoints', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+      controlEndpoint: 'some-control-endpoint',
+      cacheEndpoint: 'some-cache-endpoint',
+    });
+    const webControlEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual('https://some-cache-endpoint');
+  });
+  it('works with overridden endpoints that already have the protocol', () => {
+    const credProvider = CredentialProvider.fromString({
+      authToken: base64EncodedFakeV1AuthToken,
+      controlEndpoint: 'https://some-control-endpoint',
+      cacheEndpoint: 'https://some-cache-endpoint',
+    });
+    const webControlEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webControlEndpoint).toEqual('https://some-cache-endpoint');
+  });
+  describe('leaves port intact for overridden endpoints', () => {
+    it("with overrides that don't contain protocol", () => {
+      const credProvider = CredentialProvider.fromString({
+        authToken: base64EncodedFakeV1AuthToken,
+        controlEndpoint: 'some-control-endpoint:9001',
+        cacheEndpoint: 'some-cache-endpoint:9001',
+      });
+      const webControlEndpoint = getWebCacheEndpoint(credProvider);
+      expect(webControlEndpoint).toEqual('https://some-cache-endpoint:9001');
+    });
+    it('with overrides that do contain protocol', () => {
+      const credProvider = CredentialProvider.fromString({
+        authToken: base64EncodedFakeV1AuthToken,
+        controlEndpoint: 'https://some-control-endpoint:9001',
+        cacheEndpoint: 'https://some-cache-endpoint:9001',
+      });
+      const webControlEndpoint = getWebCacheEndpoint(credProvider);
+      expect(webControlEndpoint).toEqual('https://some-cache-endpoint:9001');
+    });
+  });
+});

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -104,9 +104,7 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
     super();
     const decodedToken = decodeAuthToken(props.authToken);
     this.authToken = decodedToken.authToken;
-    if (props.controlEndpoint !== undefined) {
-      this.controlEndpointOverridden = false;
-    }
+    this.controlEndpointOverridden = props.controlEndpoint !== undefined;
     const controlEndpoint =
       props.controlEndpoint ?? decodedToken.controlEndpoint;
     if (controlEndpoint === undefined) {
@@ -114,9 +112,7 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
         'Malformed token; unable to determine control endpoint.  Depending on the type of token you are using, you may need to specify the controlEndpoint explicitly.'
       );
     }
-    if (props.cacheEndpoint !== undefined) {
-      this.cacheEndpointOverridden = false;
-    }
+    this.cacheEndpointOverridden = props.cacheEndpoint !== undefined;
     const cacheEndpoint = props.cacheEndpoint ?? decodedToken.cacheEndpoint;
     if (cacheEndpoint === undefined) {
       throw new Error(

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -36,6 +36,16 @@ export abstract class CredentialProvider {
    */
   abstract getCacheEndpoint(): string;
 
+  /**
+   * @returns {boolean} true if the cache endpoint was manually overridden at construction time; false otherwise
+   */
+  abstract isCacheEndpointOverridden(): boolean;
+
+  /**
+   * @returns {boolean} true if the control endpoint was manually overridden at construction time; false otherwise
+   */
+  abstract isControlEndpointOverridden(): boolean;
+
   static fromEnvironmentVariable(
     props: EnvMomentoTokenProviderProps
   ): CredentialProvider {
@@ -55,6 +65,9 @@ abstract class CredentialProviderBase implements CredentialProvider {
   abstract getCacheEndpoint(): string;
 
   abstract getControlEndpoint(): string;
+
+  abstract isCacheEndpointOverridden(): boolean;
+  abstract isControlEndpointOverridden(): boolean;
 
   valueOf(): object {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -81,6 +94,8 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
   private readonly authToken: string;
   private readonly controlEndpoint: string;
   private readonly cacheEndpoint: string;
+  private readonly controlEndpointOverridden: boolean;
+  private readonly cacheEndpointOverridden: boolean;
 
   /**
    * @param {StringMomentoTokenProviderProps} props configuration options for the token provider
@@ -89,12 +104,18 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
     super();
     const decodedToken = decodeAuthToken(props.authToken);
     this.authToken = decodedToken.authToken;
+    if (props.controlEndpoint !== undefined) {
+      this.controlEndpointOverridden = false;
+    }
     const controlEndpoint =
       props.controlEndpoint ?? decodedToken.controlEndpoint;
     if (controlEndpoint === undefined) {
       throw new Error(
         'Malformed token; unable to determine control endpoint.  Depending on the type of token you are using, you may need to specify the controlEndpoint explicitly.'
       );
+    }
+    if (props.cacheEndpoint !== undefined) {
+      this.cacheEndpointOverridden = false;
     }
     const cacheEndpoint = props.cacheEndpoint ?? decodedToken.cacheEndpoint;
     if (cacheEndpoint === undefined) {
@@ -117,6 +138,14 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
 
   getControlEndpoint(): string {
     return this.controlEndpoint;
+  }
+
+  isControlEndpointOverridden(): boolean {
+    return this.controlEndpointOverridden;
+  }
+
+  isCacheEndpointOverridden(): boolean {
+    return this.cacheEndpointOverridden;
   }
 }
 

--- a/packages/core/test/unit/auth/credential-provider.test.ts
+++ b/packages/core/test/unit/auth/credential-provider.test.ts
@@ -51,6 +51,8 @@ describe('StringMomentoTokenProvider', () => {
     expect(legacyAuthProvider.getAuthToken()).toEqual(fakeTestLegacyToken);
     expect(legacyAuthProvider.getControlEndpoint()).toEqual('foo');
     expect(legacyAuthProvider.getCacheEndpoint()).toEqual(testCacheEndpoint);
+    expect(legacyAuthProvider.isCacheEndpointOverridden()).toEqual(false);
+    expect(legacyAuthProvider.isControlEndpointOverridden()).toEqual(true);
 
     const v1AuthProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
@@ -61,6 +63,8 @@ describe('StringMomentoTokenProvider', () => {
     expect(v1AuthProvider.getCacheEndpoint()).toEqual(
       `cache.${decodedV1Token.endpoint}`
     );
+    expect(v1AuthProvider.isCacheEndpointOverridden()).toEqual(false);
+    expect(v1AuthProvider.isControlEndpointOverridden()).toEqual(true);
   });
 
   it('supports overriding cache endpoint', () => {
@@ -73,6 +77,8 @@ describe('StringMomentoTokenProvider', () => {
       testControlEndpoint
     );
     expect(legacyAuthProvider.getCacheEndpoint()).toEqual('foo');
+    expect(legacyAuthProvider.isCacheEndpointOverridden()).toEqual(true);
+    expect(legacyAuthProvider.isControlEndpointOverridden()).toEqual(false);
 
     const v1AuthProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
@@ -83,6 +89,8 @@ describe('StringMomentoTokenProvider', () => {
       `control.${decodedV1Token.endpoint}`
     );
     expect(v1AuthProvider.getCacheEndpoint()).toEqual('foo');
+    expect(v1AuthProvider.isCacheEndpointOverridden()).toEqual(true);
+    expect(v1AuthProvider.isControlEndpointOverridden()).toEqual(false);
   });
 
   it('parses a session token with endpoint overrides', () => {

--- a/scripts/make-localhost-token-from-dev-token.sh
+++ b/scripts/make-localhost-token-from-dev-token.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+DEV_TOKEN=$1
+if [ "$DEV_TOKEN" == "" ]
+then
+  echo "Missing required argument: dev token"
+  echo "Usage: $0 <dev token>"
+  exit 1
+fi
+
+echo "{\"endpoint\":\"localhost\",\"api_key\":\"${DEV_TOKEN}\"}" |base64


### PR DESCRIPTION
This commit makes some refactors to the CredentialProvider, as well
as a few minor test changes, to allow the integration tests to be
run against localhost. Changes include:

* Keep track of whether the endpoints for CredentialProvider were
  overridden at construction time so that we can branch accordingly.
* Don't add `web` prefix if the endpoints were explicitly overridden.
* Add support for a `MOMENTO_SDK_TESTS_USE_LOCALHOST` in the integration
  tests; if provided it will override the endpoints to localhost, and
  cause most control plane operations to be skipped.
