### PR TITLE
fix: remove TEST_CACHE_NAME from release job

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: macos-latest
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: js-integration-test-ci
     needs: release
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
The tests don't need a hard-coded cache name and they don't work
well with one anymore; this commit removes the TEST_CACHE_NAME
env var from the release job.
