### PR TITLE
fix: allow for grpc web pubsub client to reconnect streams on network…

### DIFF
--- a/scripts/build-nodejs-sdk.sh
+++ b/scripts/build-nodejs-sdk.sh
@@ -6,4 +6,5 @@ set -e
 echo "dev building nodejs sdk"
 
 ./scripts/build-package.sh "core"
+./scripts/build-package.sh "common-integration-tests"
 ./scripts/build-package.sh "client-sdk-nodejs"

--- a/scripts/build-web-sdk.sh
+++ b/scripts/build-web-sdk.sh
@@ -6,4 +6,5 @@ set -e
 echo "dev building web sdk"
 
 ./scripts/build-package.sh "core"
+./scripts/build-package.sh "common-integration-tests"
 ./scripts/build-package.sh "client-sdk-web"


### PR DESCRIPTION
… errors

Inside of a browser, we were seeing that our topic client was not attempting to resubscribe during/after a brief network outage. This pr addresses this by making sure that we are checking for the correct grpc error message from grpc web, and makes sure that we correctly set the `firstMessage` option to be true _only_ when the user is subscribing to a new stream, and not on reconnection attempts