### PR TITLE
feat: bump grpc js to version 1.8.17

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.62.1",
+        "@gomomento/generated-types": "0.68.0",
         "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.8.14",
+        "@grpc/grpc-js": "1.8.17",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -43,7 +43,6 @@
       }
     },
     "../common-integration-tests": {
-      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -77,7 +76,6 @@
       }
     },
     "../core": {
-      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -829,11 +827,11 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.62.1.tgz",
-      "integrity": "sha512-EpF8X/+oTJQiXbHB8MDRSLlKaeBs9t0nw3nz2HdQ72oXDLsaVuJT3I/g3l6ZGlvVcInT+qUyg7cKPENtTHE4gg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
+      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.14",
+        "@grpc/grpc-js": "1.8.17",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2"
       }
@@ -843,9 +841,9 @@
       "link": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -2453,9 +2451,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.444",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.444.tgz",
-      "integrity": "sha512-/AjkL4syRvOpowXWy3N4OHmVbFdWQpfSKHh0sCVYipDeEAtMce3rLjMJi/27Ia9jNIbw6P1JuPN32pSWybXXEQ==",
+      "version": "1.4.447",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.447.tgz",
+      "integrity": "sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3156,9 +3154,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6194,9 +6192,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
-      "integrity": "sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -6205,7 +6203,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": "^7.5.3",
         "yargs-parser": "^21.0.1"
       },
       "bin": {

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -50,9 +50,9 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.62.1",
+    "@gomomento/generated-types": "0.68.0",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.8.14",
+    "@grpc/grpc-js": "1.8.17",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"
   },


### PR DESCRIPTION
bumping from 1.8.14 -> 1.8.17

Features/fixes that come with this upgrade
- Ensure status and error events are consistently emitted 
- Fix a memory leak that could result from a specific pattern of recursive function 
- Fix missing transport trace 
- Disallow pick_first LB policy as the direct child of an outlier_detection LB policy

