### PR TITLE
fix: remove TEST_CACHE_NAME from release job

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -11,7 +11,6 @@ jobs:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}
       TEST_LEGACY_AUTH_TOKEN: ${{ secrets.ALPHA_LEGACY_TEST_AUTH_TOKEN }}
-      TEST_CACHE_NAME: js-integration-test-ci
 
     steps:
       - name: Setup repo


### PR DESCRIPTION
The tests don't need a hard-coded cache name and they don't work
well with one anymore; this commit removes the TEST_CACHE_NAME
env var from the release job.
