### PR TITLE
feat: implementation for sorted set length and sorted set length by score

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -49,6 +49,8 @@ import * as CacheSortedSetGetScores from '@gomomento/sdk-core/dist/src/messages/
 import * as CacheSortedSetIncrementScore from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-increment-score';
 import * as CacheSortedSetRemoveElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-remove-element';
 import * as CacheSortedSetRemoveElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-remove-elements';
+import * as CacheSortedSetLength from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-length';
+import * as CacheSortedSetLengthByScore from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-length-by-score';
 import * as CacheItemGetType from '@gomomento/sdk-core/dist/src/messages/responses/cache-item-get-type';
 import * as CacheItemGetTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-item-get-ttl';
 
@@ -222,6 +224,8 @@ export {
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CacheItemGetType,
   CacheItemGetTtl,
   // TopicClient

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.62.1",
+        "@gomomento/generated-types-webtext": "0.68.0",
         "@gomomento/sdk-core": "file:../core",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -820,9 +820,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.62.1.tgz",
-      "integrity": "sha512-4NFP8eoHHGY+oDP5WX9Vd7/Yv3DjqmjqyFacLoT5QNIRqZ/EY6MQl2A4V+nR6udQIxitPooLCXb96paIsNiraw=="
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.68.0.tgz",
+      "integrity": "sha512-OEvSB2SlAzrG0hDGFEeIk1uIPyhCfpXpKLM+5nhOuzarox3ndrN8TwBLjbAaO6bi/une+DU+2NYE/miGfXazLw=="
     },
     "node_modules/@gomomento/sdk-core": {
       "resolved": "../core",
@@ -7723,9 +7723,9 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.62.1.tgz",
-      "integrity": "sha512-4NFP8eoHHGY+oDP5WX9Vd7/Yv3DjqmjqyFacLoT5QNIRqZ/EY6MQl2A4V+nR6udQIxitPooLCXb96paIsNiraw=="
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.68.0.tgz",
+      "integrity": "sha512-OEvSB2SlAzrG0hDGFEeIk1uIPyhCfpXpKLM+5nhOuzarox3ndrN8TwBLjbAaO6bi/une+DU+2NYE/miGfXazLw=="
     },
     "@gomomento/sdk-core": {
       "version": "file:../core",

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@gomomento/sdk-core": "file:../core",
-    "@gomomento/generated-types-webtext": "0.62.1",
+    "@gomomento/generated-types-webtext": "0.68.0",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",
     "jwt-decode": "3.1.2"

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -49,6 +49,8 @@ import * as CacheSortedSetGetScores from '@gomomento/sdk-core/dist/src/messages/
 import * as CacheSortedSetIncrementScore from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-increment-score';
 import * as CacheSortedSetRemoveElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-remove-element';
 import * as CacheSortedSetRemoveElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-remove-elements';
+import * as CacheSortedSetLength from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-length';
+import * as CacheSortedSetLengthByScore from '@gomomento/sdk-core/dist/src/messages/responses/cache-sorted-set-length-by-score';
 import * as CacheItemGetType from '@gomomento/sdk-core/dist/src/messages/responses/cache-item-get-type';
 import * as CacheItemGetTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-item-get-ttl';
 
@@ -169,6 +171,8 @@ export {
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CacheItemGetType,
   CacheItemGetTtl,
   TopicConfigurations,

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -10,6 +10,8 @@ import {
   CacheSortedSetPutElements,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CollectionTtl,
   MomentoErrorCode,
   SortedSetOrder,
@@ -1993,6 +1995,307 @@ export function runSortedSetTests(
           {value: uint8ArrayForTest('foo'), score: 42},
           {value: uint8ArrayForTest('bar'), score: 84},
         ]);
+      });
+    });
+
+    describe('#sortedSetLength', () => {
+      const responder = (props: ValidateSortedSetProps) => {
+        return Momento.sortedSetLength(props.cacheName, props.sortedSetName);
+      };
+
+      itBehavesLikeItValidates(responder);
+      itBehavesLikeItMissesWhenSortedSetDoesNotExist(responder);
+
+      it('returns the length if the sorted set exists', async () => {
+        const sortedSetName = v4();
+        const setValues = {foo: 42, bar: 84, baz: 90210};
+        const numElements = Object.keys(setValues).length;
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const result = await Momento.sortedSetLength(
+          IntegrationTestCacheName,
+          sortedSetName
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLength.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLength.Hit).length()).toEqual(
+          numElements
+        );
+      });
+    });
+
+    describe('#sortedSetLengthByScore', () => {
+      const responder = (props: ValidateSortedSetProps) => {
+        return Momento.sortedSetLength(props.cacheName, props.sortedSetName);
+      };
+
+      itBehavesLikeItValidates(responder);
+      itBehavesLikeItMissesWhenSortedSetDoesNotExist(responder);
+
+      it('gets the length when each score has only one element', async () => {
+        const sortedSetName = v4();
+        const setValues = {foo: 42, bar: 84, baz: 90210};
+        const numElements = Object.keys(setValues).length;
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(
+          numElements
+        );
+      });
+
+      it('gets the length when only one score has multiple elements', async () => {
+        const sortedSetName = v4();
+        const setValues = {foo: 42, bar: 42, baz: 42};
+        const numElements = Object.keys(setValues).length;
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(
+          numElements
+        );
+      });
+
+      it('gets the length when multiple scores have varying number of elements', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        const numElements = Object.keys(setValues).length;
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(
+          numElements
+        );
+      });
+
+      it('gets the length for scores above an inclusive lower bound', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const lowerBound = 42;
+        const inclusiveLowerBound = true;
+        const upperBound = undefined;
+        const inclusiveUpperBound = undefined;
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          lowerBound,
+          inclusiveLowerBound,
+          upperBound,
+          inclusiveUpperBound
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(7);
+      });
+
+      it('gets the length for scores above an exclusive lower bound', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const lowerBound = 42;
+        const inclusiveLowerBound = false;
+        const upperBound = undefined;
+        const inclusiveUpperBound = undefined;
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          lowerBound,
+          inclusiveLowerBound,
+          upperBound,
+          inclusiveUpperBound
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(4);
+      });
+
+      it('gets the length for scores below an inclusive upper bound', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const lowerBound = undefined;
+        const inclusiveLowerBound = undefined;
+        const upperBound = 555;
+        const inclusiveUpperBound = true;
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          lowerBound,
+          inclusiveLowerBound,
+          upperBound,
+          inclusiveUpperBound
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(9);
+      });
+
+      it('gets the length for scores below an exclusive upper bound', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const lowerBound = undefined;
+        const inclusiveLowerBound = undefined;
+        const upperBound = 555;
+        const inclusiveUpperBound = false;
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          lowerBound,
+          inclusiveLowerBound,
+          upperBound,
+          inclusiveUpperBound
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(5);
+      });
+
+      it('gets the length for scores within exclusive lower and upper bound', async () => {
+        const sortedSetName = v4();
+        const setValues = {
+          foo: 42,
+          bar: 42,
+          baz: 42,
+          apple: 1,
+          banana: 1,
+          water: 555,
+          air: 555,
+          earth: 555,
+          fire: 555,
+        };
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          setValues
+        );
+
+        const lowerBound = 1;
+        const inclusiveLowerBound = false;
+        const upperBound = 555;
+        const inclusiveUpperBound = false;
+        const result = await Momento.sortedSetLengthByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          lowerBound,
+          inclusiveLowerBound,
+          upperBound,
+          inclusiveUpperBound
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetLengthByScore.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        expect((result as CacheSortedSetLengthByScore.Hit).length()).toEqual(3);
       });
     });
 

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -34,6 +34,8 @@ import {
   CacheSortedSetGetScores,
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CacheItemGetType,
   CacheItemGetTtl,
 } from '../index';
@@ -267,6 +269,18 @@ export interface ICacheClient extends IControlClient, IPingClient {
     sortedSetName: string,
     values: string[] | Uint8Array[]
   ): Promise<CacheSortedSetRemoveElement.Response>;
+  sortedSetLength(
+    cacheName: string,
+    sortedSetName: string
+  ): Promise<CacheSortedSetLength.Response>;
+  sortedSetLengthByScore(
+    cacheName: string,
+    sortedSetName: string,
+    minScore?: number,
+    minScoreInclusive?: boolean,
+    maxScore?: number,
+    maxScoreInclusive?: boolean
+  ): Promise<CacheSortedSetLengthByScore.Response>;
   itemGetType(
     cacheName: string,
     key: string | Uint8Array

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,8 @@ import * as CacheSortedSetGetScores from './messages/responses/cache-sorted-set-
 import * as CacheSortedSetIncrementScore from './messages/responses/cache-sorted-set-increment-score';
 import * as CacheSortedSetRemoveElement from './messages/responses/cache-sorted-set-remove-element';
 import * as CacheSortedSetRemoveElements from './messages/responses/cache-sorted-set-remove-elements';
+import * as CacheSortedSetLength from './messages/responses/cache-sorted-set-length';
+import * as CacheSortedSetLengthByScore from './messages/responses/cache-sorted-set-length-by-score';
 import * as CacheItemGetType from './messages/responses/cache-item-get-type';
 import * as CacheItemGetTtl from './messages/responses/cache-item-get-ttl';
 
@@ -173,6 +175,8 @@ export {
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CacheItemGetType,
   CacheItemGetTtl,
   CacheInfo,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -42,6 +42,8 @@ import {
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   SortedSetOrder,
   CacheItemGetTtl,
   CacheItemGetType,
@@ -1145,6 +1147,55 @@ export abstract class AbstractCacheClient implements ICacheClient {
       cacheName,
       sortedSetName,
       values
+    );
+  }
+
+  /**
+   * Fetch length (number of items) of sorted set
+   * @param {string} cacheName - The cache containing the sorted set.
+   * @param {string} sortedSetName - The sorted set to remove from.
+   * @returns {Promise<CacheSortedSetLength.Response>}
+   * {@link CacheSortedSetLength.Hit} containing the length if the sorted set exists.
+   * {@link CacheSortedSetLength.Miss} if the sorted set does not exist.
+   * {@link CacheSortedSetLength.Error} on failure.
+   */
+  public async sortedSetLength(
+    cacheName: string,
+    sortedSetName: string
+  ): Promise<CacheSortedSetLength.Response> {
+    const client = this.getNextDataClient();
+    return await client.sortedSetLength(cacheName, sortedSetName);
+  }
+
+  /**
+   * Fetch length (number of items) of sorted set by score
+   * @param {string} cacheName - The cache containing the sorted set.
+   * @param {string} sortedSetName - The sorted set to remove from.
+   * @param {number} minScore - The lower bound on the score range to search in.
+   * @param {boolean} minScoreInclusive - Whether the lower bound is inclusive or exclusive.
+   * @param {number} maxScore - The upper bound on the score range to search in.
+   * @param {boolean} maxScoreInclusive - Whether the upper bound is inclusive or exclusive.
+   * @returns {Promise<CacheSortedSetLengthByScore.Response>}
+   * {@link CacheSortedSetLengthByScore.Hit} containing the length if the sorted set exists.
+   * {@link CacheSortedSetLengthByScore.Miss} if the sorted set does not exist.
+   * {@link CacheSortedSetLengthByScore.Error} on failure.
+   */
+  public async sortedSetLengthByScore(
+    cacheName: string,
+    sortedSetName: string,
+    minScore?: number,
+    minScoreInclusive?: boolean,
+    maxScore?: number,
+    maxScoreInclusive?: boolean
+  ): Promise<CacheSortedSetLengthByScore.Response> {
+    const client = this.getNextDataClient();
+    return await client.sortedSetLengthByScore(
+      cacheName,
+      sortedSetName,
+      minScore,
+      minScoreInclusive,
+      maxScore,
+      maxScoreInclusive
     );
   }
 

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -32,6 +32,8 @@ import {
   CacheSortedSetGetScores,
   CacheSortedSetIncrementScore,
   CacheSortedSetRemoveElement,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CollectionTtl,
   SortedSetOrder,
   CacheItemGetType,
@@ -239,6 +241,18 @@ export interface IDataClient {
     sortedSetName: string,
     values: string[] | Uint8Array[]
   ): Promise<CacheSortedSetRemoveElement.Response>;
+  sortedSetLength(
+    cacheName: string,
+    sortedSetName: string
+  ): Promise<CacheSortedSetLength.Response>;
+  sortedSetLengthByScore(
+    cacheName: string,
+    sortedSetName: string,
+    minScore?: number,
+    minScoreInclusive?: boolean,
+    maxScore?: number,
+    maxScoreInclusive?: boolean
+  ): Promise<CacheSortedSetLengthByScore.Response>;
   itemGetType(
     cacheName: string,
     key: string | Uint8Array

--- a/packages/core/src/messages/responses/cache-sorted-set-length-by-score.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-length-by-score.ts
@@ -1,0 +1,80 @@
+import {SdkError} from '../../errors';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseHit,
+  ResponseMiss,
+} from './response-base';
+
+/**
+ * Parent response type for a sorted set length request.  The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Hit}
+ * - {Miss}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof CacheSortedSetLengthByScore.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `CacheSortedSetLengthByScore.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {}
+
+class _Hit extends Response {
+  private readonly _length: number;
+  constructor(length: number) {
+    super();
+    this._length = length;
+  }
+
+  /**
+   * Returns the length of the sorted set
+   * @returns {number}
+   */
+  public length(): number {
+    return this._length;
+  }
+
+  public override toString(): string {
+    return `${super.toString()}: length ${this._length}`;
+  }
+}
+
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+
+/**
+ * Indicates that the requested data was not available in the cache.
+ */
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the sorted set length request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}

--- a/packages/core/src/messages/responses/cache-sorted-set-length.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-length.ts
@@ -1,0 +1,80 @@
+import {SdkError} from '../../errors';
+import {
+  ResponseBase,
+  ResponseError,
+  ResponseHit,
+  ResponseMiss,
+} from './response-base';
+
+/**
+ * Parent response type for a sorted set length request.  The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Hit}
+ * - {Miss}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof CacheSortedSetLength.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `CacheSortedSetLength.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {}
+
+class _Hit extends Response {
+  private readonly _length: number;
+  constructor(length: number) {
+    super();
+    this._length = length;
+  }
+
+  /**
+   * Returns the length of the sorted set
+   * @returns {number}
+   */
+  public length(): number {
+    return this._length;
+  }
+
+  public override toString(): string {
+    return `${super.toString()}: length ${this._length}`;
+  }
+}
+
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Hit extends ResponseHit(_Hit) {}
+
+class _Miss extends Response {}
+
+/**
+ * Indicates that the requested data was not available in the cache.
+ */
+export class Miss extends ResponseMiss(_Miss) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the sorted set length request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}


### PR DESCRIPTION
Addresses #581 by exposing the SortedSetLength and SortedSetLengthByScore endpoints for the Node.js and Web JavaScript SDKs