### PR TITLE
fix: renamed aws secrets example to match docs snippetId used by the java example

### DIFF
--- a/examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts
+++ b/examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts
@@ -2,7 +2,7 @@ import {CacheClient, Configurations, CredentialProvider, CacheGet, CacheSet, Cre
 
 import {SecretsManagerClient, GetSecretValueCommand} from '@aws-sdk/client-secrets-manager';
 
-async function example_CreateCacheClientUsingAwsSecretsManager(
+async function example_API_retrieveAuthTokenFromSecretsManager(
   ttl = 600,
   secretName = 'MOMENTO_AUTH_TOKEN',
   regionName = 'us-west-2'
@@ -79,7 +79,7 @@ async function readFromCache(client: CacheClient, cacheName: string, key: string
 // Call the various functions
 async function main() {
   const CACHE_NAME = 'demo-cache2';
-  const cacheClient = await example_CreateCacheClientUsingAwsSecretsManager();
+  const cacheClient = await example_API_retrieveAuthTokenFromSecretsManager();
 
   await createCache(cacheClient, CACHE_NAME);
   await writeToCache(cacheClient, CACHE_NAME, 'code', '12345');


### PR DESCRIPTION
Addresses #612, creates the example in the JS SDK to pull into the [AWS Secrets doc page](https://docs.momentohq.com/develop/integrations/aws-secrets-manager#example-code-for-aws-secrets-manager).

This is a follow-up PR to #648 as I belatedly realized the docs repo expects [examples from different SDKs](https://github.com/momentohq/public-dev-docs/blob/92dd8e370fb778d997c848c17f3137f660e37fa4/plugins/example-code-snippets/src/inject-example-code-snippets.ts#L62C1-L73C3) to have the [same snippetId](https://github.com/momentohq/client-sdk-java/blob/82abae9f699097eaa649724b41257b48e4315ee8/examples/cache-with-aws/src/main/java/momento/client/example/doc_examples/DocExamplesJavaAPIs.java#L13C22-L13C69).

