### PR TITLE
feat: allow configurable token vending machine (permission scope and expiry)

### DIFF
--- a/examples/nodejs/token-vending-machine/README.md
+++ b/examples/nodejs/token-vending-machine/README.md
@@ -23,11 +23,18 @@ The primary use for the Token Vending Machine is to provide temporary, restricte
 
 ## Configuring the Token Vending Machine App
 
-Before you deploy the token vending machine, you will need to configure the scope of permissions and the expiry date for the tokens that it will vend.
+Before you deploy the token vending machine, you will need to configure the scope of permissions and the expiry duration for the tokens that it will vend. For example, you can restrict the permissions for these browser tokens so that they have read-only access or read-write access, and you can also restrict them to specific caches or topics.
 
 These two required variables live in the [lambda/config.ts](./lambda/config.ts) file.
 
 ## Deploying the Token Vending Machine App
+
+First make sure to start Docker and install the dependencies in the `lambda` directory, which is where the AWS Lambda code lives.
+
+```bash
+cd lambda
+npm install
+```
 
 The source code for the CDK application lives in the `infrastructure` directory.
 To build and deploy it you will first need to install the dependencies:

--- a/examples/nodejs/token-vending-machine/README.md
+++ b/examples/nodejs/token-vending-machine/README.md
@@ -21,6 +21,12 @@ This repo contains an example Token Vending Machine application, built using AWS
 
 The primary use for the Token Vending Machine is to provide temporary, restricted scope Momento Auth tokens. These tokens can be used by browsers that are running apps written against the [Momento Web SDK](https://github.com/momentohq/client-sdk-javascript/tree/main/packages/client-sdk-web). For example, you can create a browser-based chat application that allows pub/sub communication between your users via [Momento Topics](https://docs.momentohq.com/introduction/momento-topics); each browser will need a Momento auth token in order to communicate with the Momento Topics server, and the Token Vending Machine can provide those tokens.
 
+## Configuring the Token Vending Machine App
+
+Before you deploy the token vending machine, you will need to configure the scope of permissions and the expiry date for the tokens that it will vend.
+
+These two required variables live in the [lambda/config.ts](./lambda/config.ts) file.
+
 ## Deploying the Token Vending Machine App
 
 The source code for the CDK application lives in the `infrastructure` directory.

--- a/examples/nodejs/token-vending-machine/lambda/config.ts
+++ b/examples/nodejs/token-vending-machine/lambda/config.ts
@@ -1,4 +1,4 @@
-import {AllDataReadWrite, ExpiresIn, TokenScope} from '@gomomento/sdk';
+import {AllDataReadWrite, TopicRole, CacheRole, ExpiresIn, TokenScope, AllTopics, AllCaches} from '@gomomento/sdk';
 
 /**
  * Set the scope of permissions for your tokens. 
@@ -7,7 +7,8 @@ import {AllDataReadWrite, ExpiresIn, TokenScope} from '@gomomento/sdk';
  *    export const tokenPermissions: TokenScope =  AllDataReadWrite;
  * 
  * You may also provide a bespoke list of permissions for each cache and topic that you have:
- *    export const tokenPermissions: TokenScope =  [
+ *    export const tokenPermissions: TokenScope =  {
+ *      permissions: [
  *        {
  *          role: CacheRole.ReadWrite | CacheRole.ReadOnly, 
  *          cache: AllCaches | "your-cache-name"
@@ -17,11 +18,23 @@ import {AllDataReadWrite, ExpiresIn, TokenScope} from '@gomomento/sdk';
  *          cache: AllCaches | "your-cache-name",
  *          topic: AllTopics | "your-topic-name"
  *        }
- *    ];
+ *      ]
+ *    };
  * 
  * More information here: https://github.com/momentohq/client-sdk-javascript/blob/62a34741059cb08c8dfff4e7011be29facab8d80/packages/core/src/auth/tokens/token-scope.ts
  */
-export const tokenPermissions: TokenScope = AllDataReadWrite;
+export const tokenPermissions: TokenScope = {
+  permissions: [
+    {
+      role: CacheRole.ReadWrite,
+      cache: "default-cache"
+    },
+    {
+      role: TopicRole.PublishSubscribe, 
+      cache: "default-cache",
+      topic: AllTopics
+    }
+]};
 
 /**
  * Set the TTL for your tokens in terms of seconds, minutes, hours,  

--- a/examples/nodejs/token-vending-machine/lambda/config.ts
+++ b/examples/nodejs/token-vending-machine/lambda/config.ts
@@ -1,0 +1,31 @@
+import {AllDataReadWrite, ExpiresIn, TokenScope} from '@gomomento/sdk';
+
+/**
+ * Set the scope of permissions for your tokens. 
+ * 
+ * AllDataReadWrite provides read and write permissions to all of your caches:
+ *    export const tokenPermissions: TokenScope =  AllDataReadWrite;
+ * 
+ * You may also provide a bespoke list of permissions for each cache and topic that you have:
+ *    export const tokenPermissions: TokenScope =  [
+ *        {
+ *          role: CacheRole.ReadWrite | CacheRole.ReadOnly, 
+ *          cache: AllCaches | "your-cache-name"
+ *        },
+ *        {
+ *          role: TopicRole.PublishSubscribe | TopicRole.SubscribeOnly, 
+ *          cache: AllCaches | "your-cache-name",
+ *          topic: AllTopics | "your-topic-name"
+ *        }
+ *    ];
+ * 
+ * More information here: https://github.com/momentohq/client-sdk-javascript/blob/62a34741059cb08c8dfff4e7011be29facab8d80/packages/core/src/auth/tokens/token-scope.ts
+ */
+export const tokenPermissions: TokenScope = AllDataReadWrite;
+
+/**
+ * Set the TTL for your tokens in terms of seconds, minutes, hours,  
+ * days, or using epoch format. You may also set tokens to never expire.
+ * More information here: https://github.com/momentohq/client-sdk-javascript/blob/62a34741059cb08c8dfff4e7011be29facab8d80/packages/core/src/utils/expiration.ts#L17
+ */
+export const tokenExpiresIn: ExpiresIn = ExpiresIn.hours(1);

--- a/examples/nodejs/token-vending-machine/lambda/config.ts
+++ b/examples/nodejs/token-vending-machine/lambda/config.ts
@@ -21,7 +21,7 @@ import {AllDataReadWrite, TopicRole, CacheRole, ExpiresIn, TokenScope, AllTopics
  *      ]
  *    };
  * 
- * More information here: https://github.com/momentohq/client-sdk-javascript/blob/62a34741059cb08c8dfff4e7011be29facab8d80/packages/core/src/auth/tokens/token-scope.ts
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#tokenscope-objects
  */
 export const tokenPermissions: TokenScope = {
   permissions: [
@@ -39,6 +39,6 @@ export const tokenPermissions: TokenScope = {
 /**
  * Set the TTL for your tokens in terms of seconds, minutes, hours,  
  * days, or using epoch format. You may also set tokens to never expire.
- * More information here: https://github.com/momentohq/client-sdk-javascript/blob/62a34741059cb08c8dfff4e7011be29facab8d80/packages/core/src/utils/expiration.ts#L17
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#generateauthtoken-api
  */
 export const tokenExpiresIn: ExpiresIn = ExpiresIn.hours(1);

--- a/examples/nodejs/token-vending-machine/lambda/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "1.26.2",
+        "@gomomento/sdk": "1.28.0",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1308,23 +1308,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.62.1.tgz",
-      "integrity": "sha512-EpF8X/+oTJQiXbHB8MDRSLlKaeBs9t0nw3nz2HdQ72oXDLsaVuJT3I/g3l6ZGlvVcInT+qUyg7cKPENtTHE4gg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
+      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.14",
+        "@grpc/grpc-js": "1.8.17",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.26.2.tgz",
-      "integrity": "sha512-6XEGv26IxrY9eRsK1q1XjWFQg57rBNWZUenECP8Pc85BGNrgi8LfBWjDoPCtshGI1siR3BHpdp/+tHkzoM9nyQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
       "dependencies": {
-        "@gomomento/generated-types": "0.62.1",
-        "@gomomento/sdk-core": "1.26.2",
-        "@grpc/grpc-js": "1.8.14",
+        "@gomomento/generated-types": "0.68.0",
+        "@gomomento/sdk-core": "1.28.0",
+        "@grpc/grpc-js": "1.8.17",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -1333,9 +1333,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.26.2.tgz",
-      "integrity": "sha512-Ownbk2ZYIovH1y0IAkjwo/ynsTKRbktM6XwoY3rvEAp1n77AovT31q4ksm0j5hy4hyYJHcOmfx+bxn8z/Stq5g==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
+      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -1345,9 +1345,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -1357,14 +1357,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3924,9 +3924,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5842,54 +5842,54 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.62.1.tgz",
-      "integrity": "sha512-EpF8X/+oTJQiXbHB8MDRSLlKaeBs9t0nw3nz2HdQ72oXDLsaVuJT3I/g3l6ZGlvVcInT+qUyg7cKPENtTHE4gg==",
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
+      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.14",
+        "@grpc/grpc-js": "1.8.17",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.26.2.tgz",
-      "integrity": "sha512-6XEGv26IxrY9eRsK1q1XjWFQg57rBNWZUenECP8Pc85BGNrgi8LfBWjDoPCtshGI1siR3BHpdp/+tHkzoM9nyQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
       "requires": {
-        "@gomomento/generated-types": "0.62.1",
-        "@gomomento/sdk-core": "1.26.2",
-        "@grpc/grpc-js": "1.8.14",
+        "@gomomento/generated-types": "0.68.0",
+        "@gomomento/sdk-core": "1.28.0",
+        "@grpc/grpc-js": "1.8.17",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.26.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.26.2.tgz",
-      "integrity": "sha512-Ownbk2ZYIovH1y0IAkjwo/ynsTKRbktM6XwoY3rvEAp1n77AovT31q4ksm0j5hy4hyYJHcOmfx+bxn8z/Stq5g==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
+      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       }
     },
@@ -7715,9 +7715,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/examples/nodejs/token-vending-machine/lambda/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "1.26.2",
+    "@gomomento/sdk": "1.28.0",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/web/vite-chat-app/src/App.tsx
+++ b/examples/web/vite-chat-app/src/App.tsx
@@ -98,7 +98,7 @@ export default function Home() {
   return (
     <ChatRoom
       topicName={topic}
-      cacheName={import.meta.env.MOMENTO_CACHE_NAME}
+      cacheName={import.meta.env.VITE_MOMENTO_CACHE_NAME}
       username={username}
       onLeave={leaveChatRoom}
     />

--- a/examples/web/vite-chat-app/src/utils/momento-web.ts
+++ b/examples/web/vite-chat-app/src/utils/momento-web.ts
@@ -46,11 +46,11 @@ async function getNewWebClients(): Promise<MomentoClients> {
   const fetchResp = await fetch(import.meta.env.VITE_TOKEN_VENDING_MACHINE_URL, {
     cache: "no-store",
   });
-  const token = await fetchResp.text();
+  const token = await fetchResp.json();
   const topicClient = new TopicClient({
     configuration: Configurations.Browser.v1(),
     credentialProvider: CredentialProvider.fromString({
-      authToken: token,
+      authToken: token.authToken,
     }),
   });
   webTopicClient = topicClient;
@@ -90,8 +90,7 @@ export async function subscribeToTopic(
   ) => Promise<void>,
 ) {
   onErrorCb = onError;
-    onItemCb = onItem;
-    console.log("here", webTopicClient)
+  onItemCb = onItem;
   const topicClient = await getWebTopicClient();
   const resp = await topicClient.subscribe(cacheName, topicName, {
     onItem: onItemCb,


### PR DESCRIPTION
Addresses the first part of [#385](https://github.com/momentohq/dev-eco-issue-tracker/issues/385) by creating a new config file where users can specify token permissions and expiry before deploying the token vending machine. Instructions are in the README and examples are in the `config.ts` file.

The TVM CDK stack can be successfully deployed and a locally running vite-chat-app will get a new token from the API gateway endpoint. However, the app was expecting a string rather than a JSON object (which is what the TVM was providing) so I made a change there to accept JSON instead. The app was also using the wrong environment variable name for the cache name so I fixed that as well. I also had to include the CORS header in the Lambda response so that the app would connect to it.

