### PR TITLE
feat: add logging implementation of experimental metrics middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -1,0 +1,47 @@
+import {MomentoLogger, MomentoLoggerFactory} from '../../';
+import {
+  ExperimentalMetricsMiddleware,
+  ExperimentalMetricsMiddlewareRequestHandler,
+  ExperimentalRequestMetrics,
+} from './impl/experimental-metrics-middleware';
+
+class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMetricsMiddlewareRequestHandler {
+  constructor(parent: ExperimentalMetricsMiddleware, logger: MomentoLogger) {
+    super(parent, logger);
+  }
+
+  emitMetrics(metrics: ExperimentalRequestMetrics): Promise<void> {
+    this.logger.info(JSON.stringify(metrics));
+    return Promise.resolve();
+  }
+}
+
+/**
+ * This middleware enables per-request client-side metrics.  Metrics for each
+ * request will be written to a CSV file; this file can be analyzed or shared
+ * with Momento to diagnose performance issues.
+ *
+ * The metrics format is currently considered experimental; in a future release,
+ * once the format is considered stable, this class will be renamed to remove
+ * the Experimental prefix.
+ *
+ * WARNING: enabling this middleware may have minor performance implications,
+ * so enable with caution.
+ *
+ * WARNING: depending on your request volume, the CSV file size may grow quickly;
+ * neither sampling nor file compression / rotation are included at this time
+ * (though they may be added in the future).
+ *
+ * See `advanced.ts` in the examples directory for an example of how to set up
+ * your {Configuration} to enable this middleware.
+ */
+export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMiddleware {
+  static numActiveRequests = 0;
+
+  constructor(loggerFactory: MomentoLoggerFactory) {
+    super(
+      loggerFactory,
+      (p, l) => new ExperimentalMetricsLoggingMiddlewareRequestHandler(p, l)
+    );
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -18,7 +18,7 @@ class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMet
 
 /**
  * This middleware enables per-request client-side metrics.  Metrics for each
- * request will be written to a CSV file; this file can be analyzed or shared
+ * request will be written to logs; the log data can be analyzed or shared
  * with Momento to diagnose performance issues.
  *
  * The metrics format is currently considered experimental; in a future release,
@@ -28,9 +28,10 @@ class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMet
  * WARNING: enabling this middleware may have minor performance implications,
  * so enable with caution.
  *
- * WARNING: depending on your request volume, the CSV file size may grow quickly;
- * neither sampling nor file compression / rotation are included at this time
- * (though they may be added in the future).
+ * WARNING: depending on your request volume, this middleware will produce a high
+ * volume of log output. If you are writing logs directly to local disk, be aware
+ * of disk usage and make sure you have log rotation / compression enabled via a
+ * tool such as `logrotate`.
  *
  * See `advanced.ts` in the examples directory for an example of how to set up
  * your {Configuration} to enable this middleware.

--- a/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
@@ -1,0 +1,204 @@
+import {Middleware, MiddlewareRequestHandler} from '../middleware';
+import {Metadata, StatusObject} from '@grpc/grpc-js';
+import {Message} from 'google-protobuf';
+import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
+
+const FIELD_NAMES: Array<string> = [
+  'numActiveRequestsAtStart',
+  'numActiveRequestsAtFinish',
+  'requestType',
+  'status',
+  'startTime',
+  'requestBodyTime',
+  'endTime',
+  'duration',
+  'requestSize',
+  'responseSize',
+];
+
+export interface ExperimentalRequestMetrics {
+  /**
+   * number of requests active at the start of the request
+   */
+  numActiveRequestsAtStart: number;
+  /**
+   * number of requests active at the finish of the request (including the request itself)
+   */
+  numActiveRequestsAtFinish: number;
+  /**
+   * The generated grpc object type of the request
+   */
+  requestType: string;
+  /**
+   * The grpc status code of the response
+   */
+  status: number;
+  /**
+   * The time the request started (millis since epoch)
+   */
+  startTime: number;
+  /**
+   * The time the body of the request was available to the grpc library (millis since epoch)
+   */
+  requestBodyTime: number;
+  /**
+   * The time the request completed (millis since epoch)
+   */
+  endTime: number;
+  /**
+   * The duration of the request (in millis)
+   */
+  duration: number;
+  /**
+   * The size of the request body in bytes
+   */
+  requestSize: number;
+  /**
+   * The size of the response body in bytes
+   */
+  responseSize: number;
+}
+
+export abstract class ExperimentalMetricsMiddlewareRequestHandler
+  implements MiddlewareRequestHandler
+{
+  private readonly parent: ExperimentalMetricsMiddleware;
+  protected readonly logger: MomentoLogger;
+
+  private readonly numActiveRequestsAtStart: number;
+  private readonly startTime: number;
+  private requestBodyTime: number;
+  private requestType: string;
+  private requestSize: number;
+  private responseStatusCode: number;
+  private responseSize: number;
+
+  private receivedResponseBody: boolean;
+  private receivedResponseStatus: boolean;
+
+  constructor(parent: ExperimentalMetricsMiddleware, logger: MomentoLogger) {
+    this.parent = parent;
+    this.logger = logger;
+
+    this.numActiveRequestsAtStart = parent.incrementActiveRequestCount();
+    this.startTime = new Date().getTime();
+
+    this.receivedResponseBody = false;
+    this.receivedResponseStatus = false;
+  }
+
+  abstract emitMetrics(metrics: ExperimentalRequestMetrics): Promise<void>;
+
+  onRequestBody(request: Message): Promise<Message> {
+    this.requestSize = request.serializeBinary().length;
+    this.requestType = request.constructor.name;
+    this.requestBodyTime = new Date().getTime();
+    return Promise.resolve(request);
+  }
+
+  onRequestMetadata(metadata: Metadata): Promise<Metadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseBody(response: Message | null): Promise<Message | null> {
+    if (response !== null) {
+      this.responseSize = response.serializeBinary().length;
+    } else {
+      this.responseSize = 0;
+    }
+    this.receivedResponseBody = true;
+    if (this.done()) this.recordMetrics();
+    return Promise.resolve(response);
+  }
+
+  onResponseMetadata(metadata: Metadata): Promise<Metadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseStatus(status: StatusObject): Promise<StatusObject> {
+    this.receivedResponseStatus = true;
+    this.responseStatusCode = status.code;
+    if (this.done()) this.recordMetrics();
+    return Promise.resolve(status);
+  }
+
+  private done(): boolean {
+    return this.receivedResponseBody && this.receivedResponseStatus;
+  }
+
+  private recordMetrics(): void {
+    const endTime = new Date().getTime();
+    const metrics: ExperimentalRequestMetrics = {
+      numActiveRequestsAtStart: this.numActiveRequestsAtStart,
+      numActiveRequestsAtFinish: this.parent.activeRequestCount(),
+      requestType: this.requestType,
+      status: this.responseStatusCode,
+      startTime: this.startTime,
+      requestBodyTime: this.requestBodyTime,
+      endTime: endTime,
+      duration: endTime - this.startTime,
+      requestSize: this.requestSize,
+      responseSize: this.responseSize,
+    };
+    this.emitMetrics(metrics).catch(e =>
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      this.logger.error(`An error occurred when trying to emit metrics: ${e}`)
+    );
+    this.parent.decrementActiveRequestCount();
+  }
+}
+
+/**
+ * This middleware enables per-request client-side metrics.  This is an abstract
+ * class that does not route the metrics to a specific destination; concrete subclasses
+ * may store the metrics as they see fit.
+ *
+ * The metrics format is currently considered experimental; in a future release,
+ * once the format is considered stable, this class will be renamed to remove
+ * the Experimental prefix.
+ *
+ * WARNING: enabling this middleware may have minor performance implications,
+ * so enable with caution.
+ *
+ * See `advanced.ts` in the examples directory for an example of how to set up
+ * your {Configuration} to enable this middleware.
+ */
+export abstract class ExperimentalMetricsMiddleware implements Middleware {
+  private numActiveRequests = 0;
+  private readonly logger: MomentoLogger;
+  private readonly requestHandlerFactoryFn: (
+    parent: ExperimentalMetricsMiddleware,
+    logger: MomentoLogger
+  ) => MiddlewareRequestHandler;
+
+  constructor(
+    loggerFactory: MomentoLoggerFactory,
+    requestHandlerFactoryFn: (
+      parent: ExperimentalMetricsMiddleware,
+      logger: MomentoLogger
+    ) => MiddlewareRequestHandler
+  ) {
+    this.logger = loggerFactory.getLogger(this);
+    this.requestHandlerFactoryFn = requestHandlerFactoryFn;
+  }
+
+  fieldNames(): Array<string> {
+    return FIELD_NAMES;
+  }
+
+  incrementActiveRequestCount(): number {
+    return ++this.numActiveRequests;
+  }
+
+  activeRequestCount(): number {
+    return this.numActiveRequests;
+  }
+
+  decrementActiveRequestCount(): void {
+    --this.numActiveRequests;
+  }
+
+  onNewRequest(): MiddlewareRequestHandler {
+    return this.requestHandlerFactoryFn(this, this.logger);
+  }
+}

--- a/packages/client-sdk-nodejs/src/internal/middleware/in-flight-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/internal/middleware/in-flight-request-count-middleware.ts
@@ -1,0 +1,72 @@
+import {
+  Middleware,
+  MiddlewareRequestHandler,
+} from '../../config/middleware/middleware';
+import {Metadata, StatusObject} from '@grpc/grpc-js';
+import {Message} from 'google-protobuf';
+import {MomentoLogger, MomentoLoggerFactory} from '../../';
+
+class InFlightRequestCountMiddlewareRequestHandler
+  implements MiddlewareRequestHandler
+{
+  private readonly logger: MomentoLogger;
+  private readonly inFlightRequestsAtStart: number;
+
+  private receivedResponseBody: boolean;
+  private receivedResponseStatus: boolean;
+
+  constructor(logger: MomentoLogger) {
+    this.logger = logger;
+    this.inFlightRequestsAtStart =
+      ++InFlightRequestCountMiddleware.numActiveRequests;
+  }
+
+  onRequestBody(request: Message): Promise<Message> {
+    return Promise.resolve(request);
+  }
+
+  onRequestMetadata(metadata: Metadata): Promise<Metadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseBody(response: Message | null): Promise<Message | null> {
+    this.receivedResponseBody = true;
+    if (this.done()) this.logStatusInformation();
+    return Promise.resolve(response);
+  }
+
+  onResponseMetadata(metadata: Metadata): Promise<Metadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseStatus(status: StatusObject): Promise<StatusObject> {
+    this.receivedResponseStatus = true;
+    if (this.done()) this.logStatusInformation();
+    return Promise.resolve(status);
+  }
+
+  private done(): boolean {
+    return this.receivedResponseBody && this.receivedResponseStatus;
+  }
+
+  private logStatusInformation(): void {
+    const inFlightRequestsAtEnd =
+      --InFlightRequestCountMiddleware.numActiveRequests;
+    this.logger.debug(
+      `Request completed; in-flight requests at start: ${this.inFlightRequestsAtStart}, in-flight requests at completion: ${inFlightRequestsAtEnd}`
+    );
+  }
+}
+
+export class InFlightRequestCountMiddleware implements Middleware {
+  static numActiveRequests = 0;
+  private readonly logger: MomentoLogger;
+
+  constructor(loggerFactory: MomentoLoggerFactory) {
+    this.logger = loggerFactory.getLogger(this);
+  }
+
+  onNewRequest(): MiddlewareRequestHandler {
+    return new InFlightRequestCountMiddlewareRequestHandler(this.logger);
+  }
+}


### PR DESCRIPTION
This commit refactors the "Experimental Metrics CSV" middleware to
be an abstract class that is destination-agnostic. This will allow
us to provide implementations of it that write to other targets
besides CSV. Also included in this PR is an implementation that
writes the metrics to the logger, which is a slightly more scalable
destination for most of our users to consider enabling.
