### PR TITLE
chore: add clientID to experimental requests logging middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -1,5 +1,5 @@
 process.env.GRPC_VERBOSITY = 'DEBUG';
-process.env.GRPC_TRACE = 'dns_resolver';
+process.env.GRPC_TRACE = 'dns_resolver,resolving_load_balancer,index';
 
 import {CacheClient, SimpleCacheClient} from './cache-client';
 import {TopicClient} from './topic-client';

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -1,5 +1,6 @@
 process.env.GRPC_VERBOSITY = 'DEBUG';
-process.env.GRPC_TRACE = 'dns_resolver,resolving_load_balancer,index';
+process.env.GRPC_TRACE =
+  'dns_resolver,resolving_load_balancer,connectivity_state,index';
 
 import {CacheClient, SimpleCacheClient} from './cache-client';
 import {TopicClient} from './topic-client';

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -1,3 +1,6 @@
+process.env.GRPC_VERBOSITY = 'DEBUG';
+process.env.GRPC_TRACE = 'dns_resolver';
+
 import {CacheClient, SimpleCacheClient} from './cache-client';
 import {TopicClient} from './topic-client';
 import * as Configurations from './config/configurations';


### PR DESCRIPTION
Only meant for testing/debugging purposes and not ready to be merged yet.

Added a hack so that we can see different clientIDs for different data clients on our ```ExperimentalMetricsLoggingMiddleware```