### PR TITLE
fix: make protobuf types a regular dependency

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -12,12 +12,12 @@
         "@gomomento/generated-types": "0.69.0",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
-        "@types/google-protobuf": "3.15.6",
         "@types/jest": "^27.0.2",
         "@types/node": "14.18.3",
         "@types/uuid": "^8.3.1",
@@ -1468,8 +1468,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
-      "dev": true
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -7926,8 +7925,7 @@
     "@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
-      "dev": true
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.6",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -28,7 +28,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
-    "@types/google-protobuf": "3.15.6",
     "@types/jest": "^27.0.2",
     "@types/node": "14.18.3",
     "@types/uuid": "^8.3.1",
@@ -53,6 +52,7 @@
     "@gomomento/generated-types": "0.69.0",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
+    "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"
   },


### PR DESCRIPTION
Prior to this commit, the @types/google-protobuf dep was a dev
dependency rather than a regular dependency.

This meant that when we published the SDK, it wasn't treated as
a required dependency for end users. This is problematic because
our middleware API includes the protobuf `Message` type.

I'm not sure what changed recently; possibly something in the
upstream grpc-js library, but for whatever reason this started
causing build failures in the example projects when trying to
build them against 1.30.0. They were failing with an error
about missing the type definition for `Message`.

This commit makes the types dependency a first-class dep. We
will need to be a little careful about this, it's not ideal to
be exposing types from an upstream dependency in our API signatures
and at some point we might want to create our own wrapper type
that basically redefines the relevant parts of the protobuf
Message type, but this should get the builds working for now.
