### PR TITLE
feat: add a configuration for lambda

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -33,15 +33,10 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       credentialProvider: props.credentialProvider,
     });
 
-    // For high load, we get better performance with multiple clients.  Here we
-    // are setting a default, hard-coded value for the number of clients to use,
-    // because we haven't yet designed the API for users to use to configure
-    // tunables:
-    // https://github.com/momentohq/dev-eco-issue-tracker/issues/85
-    // The choice of 6 as the initial value is a rough guess at a reasonable
-    // default for the short-term, based on load testing results captured in:
-    // https://github.com/momentohq/oncall-tracker/issues/186
-    const numClients = 6;
+    const numClients = props.configuration
+      .getTransportStrategy()
+      .getGrpcConfig()
+      .getNumClients();
     const dataClients = range(numClients).map(() => new DataClient(props));
     super(controlClient, dataClients);
 

--- a/packages/client-sdk-nodejs/src/config/configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/configurations.ts
@@ -59,6 +59,7 @@ export class Laptop extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
@@ -99,6 +100,7 @@ class InRegionDefault extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
@@ -140,12 +142,54 @@ class InRegionLowLatency extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
       maxIdleMillis: defaultMaxIdleMillis,
     });
     return new InRegionDefault({
+      loggerFactory: loggerFactory,
+      retryStrategy: defaultRetryStrategy(loggerFactory),
+      transportStrategy: transportStrategy,
+      middlewares: defaultMiddlewares,
+    });
+  }
+}
+
+class InRegionLambda extends CacheConfiguration {
+  /**
+   * Provides the latest recommended configuration for a in-region lambda environment.  NOTE: this configuration may
+   * change in future releases to take advantage of improvements we identify for default configurations.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {CacheConfiguration}
+   */
+  static latest(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): CacheConfiguration {
+    return InRegionLambda.v1(loggerFactory);
+  }
+
+  /**
+   * Provides v1 recommended configuration for an in-region lambda environment.  This configuration is guaranteed not
+   * to change in future releases of the Momento node.js SDK.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {CacheConfiguration}
+   */
+  static v1(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): CacheConfiguration {
+    const deadlineMillis = 1100;
+    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      numClients: 1,
+    });
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: defaultMaxIdleMillis,
+    });
+    return new InRegionLambda({
       loggerFactory: loggerFactory,
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
@@ -175,4 +219,9 @@ export class InRegion {
    * @type {InRegionLowLatency}
    */
   static LowLatency = InRegionLowLatency;
+
+  /**
+   * This config prioritizes quick setup time and consistent latency for use in lambdas.
+   */
+  static Lambda = InRegionLambda;
 }

--- a/packages/client-sdk-nodejs/src/config/configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/configurations.ts
@@ -59,13 +59,41 @@ export class Laptop extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
-      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
       maxIdleMillis: defaultMaxIdleMillis,
     });
     return new Laptop({
+      loggerFactory: loggerFactory,
+      retryStrategy: defaultRetryStrategy(loggerFactory),
+      transportStrategy: transportStrategy,
+      middlewares: defaultMiddlewares,
+    });
+  }
+}
+
+export class Lambda extends CacheConfiguration {
+  /**
+   * Provides the latest recommended configuration for a lambda environment.  NOTE: this configuration may
+   * change in future releases to take advantage of improvements we identify for default configurations.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {CacheConfiguration}
+   */
+  static latest(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): CacheConfiguration {
+    const deadlineMillis = 1100;
+    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
+      deadlineMillis: deadlineMillis,
+      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      numClients: 1,
+    });
+    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
+      grpcConfiguration: grpcConfig,
+      maxIdleMillis: defaultMaxIdleMillis,
+    });
+    return new Lambda({
       loggerFactory: loggerFactory,
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
@@ -100,7 +128,6 @@ class InRegionDefault extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
-      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
@@ -142,54 +169,12 @@ class InRegionLowLatency extends CacheConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
-      numClients: 6,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,
       maxIdleMillis: defaultMaxIdleMillis,
     });
     return new InRegionDefault({
-      loggerFactory: loggerFactory,
-      retryStrategy: defaultRetryStrategy(loggerFactory),
-      transportStrategy: transportStrategy,
-      middlewares: defaultMiddlewares,
-    });
-  }
-}
-
-class InRegionLambda extends CacheConfiguration {
-  /**
-   * Provides the latest recommended configuration for a in-region lambda environment.  NOTE: this configuration may
-   * change in future releases to take advantage of improvements we identify for default configurations.
-   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {CacheConfiguration}
-   */
-  static latest(
-    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): CacheConfiguration {
-    return InRegionLambda.v1(loggerFactory);
-  }
-
-  /**
-   * Provides v1 recommended configuration for an in-region lambda environment.  This configuration is guaranteed not
-   * to change in future releases of the Momento node.js SDK.
-   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
-   * @returns {CacheConfiguration}
-   */
-  static v1(
-    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
-  ): CacheConfiguration {
-    const deadlineMillis = 1100;
-    const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
-      deadlineMillis: deadlineMillis,
-      maxSessionMemoryMb: defaultMaxSessionMemoryMb,
-      numClients: 1,
-    });
-    const transportStrategy: TransportStrategy = new StaticTransportStrategy({
-      grpcConfiguration: grpcConfig,
-      maxIdleMillis: defaultMaxIdleMillis,
-    });
-    return new InRegionLambda({
       loggerFactory: loggerFactory,
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
@@ -219,9 +204,4 @@ export class InRegion {
    * @type {InRegionLowLatency}
    */
   static LowLatency = InRegionLowLatency;
-
-  /**
-   * This config prioritizes quick setup time and consistent latency for use in lambdas.
-   */
-  static Lambda = InRegionLambda;
 }

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -14,7 +14,7 @@ export interface GrpcConfigurationProps {
    * The number of internal clients a cache client will create to communicate with Momento. More of them allows
    * more concurrent requests, at the cost of more open connections and the latency of setting up each client.
    */
-  numClients: number;
+  numClients?: number;
 }
 
 /**

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -9,6 +9,12 @@ export interface GrpcConfigurationProps {
    * more than this amount will return a ResourceExhausted error.
    */
   maxSessionMemoryMb: number;
+
+  /**
+   * The number of internal clients a cache client will create to communicate with Momento. More of them allows
+   * more concurrent requests, at the cost of more open connections and the latency of setting up each client.
+   */
+  numClients: number;
 }
 
 /**
@@ -42,4 +48,17 @@ export interface GrpcConfiguration {
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified maximum memory
    */
   withMaxSessionMemoryMb(maxSessionMemoryMb: number): GrpcConfiguration;
+
+  /**
+   * @returns {number} the number of internal clients a cache client will create to communicate with Momento. More of
+   * them will allow for more concurrent requests.
+   */
+  getNumClients(): number;
+
+  /**
+   * Copy constructor for overriding the number of clients to create
+   * @param {number} numClients the number of internal clients to create
+   * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified number of clients
+   */
+  withNumClients(numClients: number): GrpcConfiguration;
 }

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -65,7 +65,12 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
   constructor(props: GrpcConfigurationProps) {
     this.deadlineMillis = props.deadlineMillis;
     this.maxSessionMemoryMb = props.maxSessionMemoryMb;
-    this.numClients = props.numClients;
+    if (props.numClients !== undefined && props.numClients !== null) {
+      this.numClients = props.numClients;
+    } else {
+      // This is the previously hardcoded value and a safe default for most environments.
+      this.numClients = 6;
+    }
   }
 
   getDeadlineMillis(): number {

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -61,9 +61,11 @@ export interface TransportStrategyProps {
 export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly deadlineMillis: number;
   private readonly maxSessionMemoryMb: number;
+  private readonly numClients: number;
   constructor(props: GrpcConfigurationProps) {
     this.deadlineMillis = props.deadlineMillis;
     this.maxSessionMemoryMb = props.maxSessionMemoryMb;
+    this.numClients = props.numClients;
   }
 
   getDeadlineMillis(): number {
@@ -78,6 +80,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     return new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: this.maxSessionMemoryMb,
+      numClients: this.numClients,
     });
   }
 
@@ -85,6 +88,19 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     return new StaticGrpcConfiguration({
       deadlineMillis: this.deadlineMillis,
       maxSessionMemoryMb: maxSessionMemoryMb,
+      numClients: this.numClients,
+    });
+  }
+
+  getNumClients(): number {
+    return this.numClients;
+  }
+
+  withNumClients(numClients: number): GrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      deadlineMillis: this.deadlineMillis,
+      maxSessionMemoryMb: this.maxSessionMemoryMb,
+      numClients: numClients,
     });
   }
 }

--- a/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
@@ -16,7 +16,7 @@ describe('configuration.ts', () => {
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: 90210,
     maxSessionMemoryMb: 90211,
-    numClients: 6,
+    numClients: 2,
   });
   const testMaxIdleMillis = 90212;
   const testTransportStrategy = new StaticTransportStrategy({
@@ -53,7 +53,7 @@ describe('configuration.ts', () => {
     const newGrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: 5000,
       maxSessionMemoryMb: 5001,
-      numClients: 6,
+      numClients: 3,
     });
     const newMaxIdleMillis = 5002;
     const newTransportStrategy = new StaticTransportStrategy({
@@ -107,11 +107,6 @@ describe('configuration.ts', () => {
   it('should make v1 inregion low latency config available via latest alias', () => {
     expect(Configurations.InRegion.LowLatency.latest()).toEqual(
       Configurations.InRegion.LowLatency.v1()
-    );
-  });
-  it('should make v1 inregion lambda config available via latest alias', () => {
-    expect(Configurations.InRegion.Lambda.latest()).toEqual(
-      Configurations.InRegion.Lambda.v1()
     );
   });
 });

--- a/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
@@ -16,6 +16,7 @@ describe('configuration.ts', () => {
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: 90210,
     maxSessionMemoryMb: 90211,
+    numClients: 6,
   });
   const testMaxIdleMillis = 90212;
   const testTransportStrategy = new StaticTransportStrategy({
@@ -52,6 +53,7 @@ describe('configuration.ts', () => {
     const newGrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: 5000,
       maxSessionMemoryMb: 5001,
+      numClients: 6,
     });
     const newMaxIdleMillis = 5002;
     const newTransportStrategy = new StaticTransportStrategy({
@@ -77,6 +79,7 @@ describe('configuration.ts', () => {
       grpcConfiguration: new StaticGrpcConfiguration({
         deadlineMillis: newClientTimeoutMillis,
         maxSessionMemoryMb: testGrpcConfiguration.getMaxSessionMemoryMb(),
+        numClients: testGrpcConfiguration.getNumClients(),
       }),
       maxIdleMillis: testMaxIdleMillis,
     });
@@ -104,6 +107,11 @@ describe('configuration.ts', () => {
   it('should make v1 inregion low latency config available via latest alias', () => {
     expect(Configurations.InRegion.LowLatency.latest()).toEqual(
       Configurations.InRegion.LowLatency.v1()
+    );
+  });
+  it('should make v1 inregion lambda config available via latest alias', () => {
+    expect(Configurations.InRegion.Lambda.latest()).toEqual(
+      Configurations.InRegion.Lambda.v1()
     );
   });
 });

--- a/packages/client-sdk-nodejs/test/unit/config/transport/transport-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/config/transport/transport-strategy.test.ts
@@ -6,9 +6,11 @@ import {
 describe('StaticGrpcConfiguration', () => {
   const testDeadlineMillis = 90210;
   const testMaxSessionMemoryMb = 90211;
+  const testNumClients = 6;
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: testDeadlineMillis,
     maxSessionMemoryMb: testMaxSessionMemoryMb,
+    numClients: testNumClients,
   });
 
   it('should support overriding deadline millis', () => {
@@ -39,9 +41,11 @@ describe('StaticGrpcConfiguration', () => {
 describe('StaticTransportStrategy', () => {
   const testDeadlineMillis = 90210;
   const testMaxSessionMemoryMb = 90211;
+  const testNumClients = 6;
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: testDeadlineMillis,
     maxSessionMemoryMb: testMaxSessionMemoryMb,
+    numClients: testNumClients,
   });
 
   const testMaxIdleMillis = 90212;
@@ -56,6 +60,7 @@ describe('StaticTransportStrategy', () => {
     const newGrpcConfig = new StaticGrpcConfiguration({
       deadlineMillis: newDeadlineMillis,
       maxSessionMemoryMb: newMaxSessionMemoryMb,
+      numClients: testNumClients,
     });
     const strategyWithNewGrpcConfig =
       testTransportStrategy.withGrpcConfig(newGrpcConfig);
@@ -82,6 +87,7 @@ describe('StaticTransportStrategy', () => {
     const expectedGrpcConfig = new StaticGrpcConfiguration({
       deadlineMillis: newClientTimeout,
       maxSessionMemoryMb: testMaxSessionMemoryMb,
+      numClients: testNumClients,
     });
     const strategyWithNewClientTimeout =
       testTransportStrategy.withClientTimeoutMillis(newClientTimeout);

--- a/packages/client-sdk-nodejs/test/unit/config/transport/transport-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/config/transport/transport-strategy.test.ts
@@ -6,7 +6,7 @@ import {
 describe('StaticGrpcConfiguration', () => {
   const testDeadlineMillis = 90210;
   const testMaxSessionMemoryMb = 90211;
-  const testNumClients = 6;
+  const testNumClients = 4;
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: testDeadlineMillis,
     maxSessionMemoryMb: testMaxSessionMemoryMb,
@@ -36,12 +36,22 @@ describe('StaticGrpcConfiguration', () => {
       newMaxSessionMemory
     );
   });
+
+  it('should support overriding num clients', () => {
+    const newNumClients = 9;
+    const configWithNewDeadline =
+      testGrpcConfiguration.withNumClients(newNumClients);
+    expect(configWithNewDeadline.getNumClients()).toEqual(newNumClients);
+    expect(configWithNewDeadline.getMaxSessionMemoryMb()).toEqual(
+      testMaxSessionMemoryMb
+    );
+  });
 });
 
 describe('StaticTransportStrategy', () => {
   const testDeadlineMillis = 90210;
   const testMaxSessionMemoryMb = 90211;
-  const testNumClients = 6;
+  const testNumClients = 5;
   const testGrpcConfiguration = new StaticGrpcConfiguration({
     deadlineMillis: testDeadlineMillis,
     maxSessionMemoryMb: testMaxSessionMemoryMb,


### PR DESCRIPTION
Make the number of data clients a cache client creates configurable. 6 is likely too many for lambdas as the extra latency for the first 6 calls isn't worth it in a short-lived environment.

Create a new configuration, InRegion.Lambda, for use inside lambdas. It only creates 1 data client instead of 6.