### PR TITLE
chore: add chat examples build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,10 @@ jobs:
             npm ci
             npm run build
           popd
+          pushd examples/web/vite-chat-app
+            npm ci
+            npm run build
+          popd
 
       - name: Send CI failure mail
         if: ${{ steps.validation.outcome == 'failure' }}


### PR DESCRIPTION
A [previous PR](https://github.com/momentohq/client-sdk-javascript/pull/713) added building the nextjs chat app to the CI workflow. This commit adds the same for the vite chat app.