### PR TITLE
chore: updating contributing guide to run examples with local SDK changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,13 @@ The easiest way to do your initial build of all the packages is to run:
 ./scripts/build-all-packages.sh
 ```
 
-From that point you can change directories into any of the `package` subdirs to work on an individual package. Take a look at the `scripts` section of the `package.json` in each package directory to see what build commands are available. They all support `npm run build` to compile the code. 
+From that point you can change directories into any of the `package` subdirs to work on an individual package. Take a look at the `scripts` section of the `package.json` in each package directory to see what build commands are available. They all support `npm run build` to compile the code.
 
 ## Running tests
 
 Most packages.json files have script targets like `unit-test` and `integration-test` that show how the tests will get run in CI. You can use these as an example to set up a command to run the tests you want to run locally. Most will require a little tweaking in order to run just the things you're interested in and deal with other constraints.
 
-For example you will probably need to limit Jest `maxWorkers` to avoid throttling errors due to concurrency, and you will want to skip the auth tests unless you have a session token, etc. So here is an example command you might use to run all of the integration tests other than the auth tests:
+For example, you will probably need to limit Jest `maxWorkers` to avoid throttling errors due to concurrency, and you will want to skip the auth tests unless you have a session token, etc. So here is an example command you might use to run all the integration tests other than the auth tests:
 
 ```
 TEST_AUTH_TOKEN=<your_token_here> npx jest integration --maxWorkers 1 --testPathIgnorePatterns auth-client-test.ts
@@ -101,3 +101,72 @@ e.g. to re-build and run the integration tests, and filter to only the dictionar
 export TEST_AUTH_TOKEN=<YOUR_AUTH_TOKEN>
 npm run build-and-run-tests -- dictionary
 ```
+
+## Testing local changes to the NodeJS SDK
+
+There are cases where you might want to run the examples with changes that you made to the SDK. One common use-case is
+running the [load generator](examples/nodejs/load-gen) for any new configurations, interceptors, or other network related
+changes.
+
+### Laptop/VM
+
+To test any existing or new example from your Laptop or a virtual machine, go to the example directory where it's `package.json` resides
+and install the local version of your SDK through `npm`. For instance, if you want to run the basic example with your changes to the SDK,
+the commands will look like:
+
+```bash
+./scripts/build-nodejs-sdk.sh
+cd examples/nodejs/cache
+npm install ../../../packages/client-sdk-nodejs
+```
+
+Notice that the `package.json` file in the `cache` directory now would link `@gomomento/sdk` dependency to the local
+version in the filesystem:
+
+`"@gomomento/sdk": "file:../../../packages/client-sdk-nodejs"`
+
+Running the examples after this will pick up the local changes made to the SDK. Note that you have to build the SDK each
+time you make a change through `./scripts/build-nodejs-sdk.sh`. If you have not made changes to `packages/core` or
+`packages/common-integration-tests` (local dependencies of the SDK), you can save some time building only the SDK through
+`./scripts/build-package.sh "client-sdk-nodejs"`.
+
+
+### AWS Lambda
+
+To run any existing or new example with your local changes to the SDK on an AWS Lambda environment, we need to follow some
+extra steps. AWS Lambda deployment will fail if we try to follow the same approach as we did on Laptop/VM above. Hence, we
+need to create a tarball of the SDK and point the examples to the tarball as the dependency instead of the SDK directory,
+or it's `npmjs` version.
+
+Since the `packages/client-sdk-nodejs` package takes a local dependency on `packages/core`, directly
+pointing the tarball for the SDK fails as well. In theory, creating a tarball of the `packages/core` package and using that for the SDK
+dependency, and then using the SDK dependency tarball for the examples dependency should work, but it doesn't as the Lambda
+build gets resolution errors.
+
+The steps that worked for one of the contributors was to remove the local `packages/core` directory altogether and use
+the `@gomomento/sdk-core` live `npmjs` [version](https://www.npmjs.com/package/@gomomento/sdk-core) instead.
+For instance, if you want to deploy the lambda `examples/nodejs/lambda-examples/simple-get` to your AWS account with your
+local changes to the SDK, the steps will look like:
+
+1. `rm -rf packages/core` Remove local core directory
+2. `cd packages/common-integration-tests` - Since this package also takes a local dependency on core, we need to do some
+   steps here as well.
+3. Update `package.json` `dependencies` section for `@gomomento/sdk-core` to `1.31.0` (or the latest version available at
+   [npmjs](https://www.npmjs.com/package/@gomomento/sdk-core) or what your IDE suggests.)
+   `"@gomomento/sdk-core": "1.31.0"`
+4. `npm install`
+5. `../../scripts/build-package-lambda.sh "common-integration-tests"`
+6. `cd ../client-sdk-nodejs` - Now we will repeat the same steps for the SDK package
+7. Update `package.json` `dependencies` section for `@gomomento/sdk-core` to `1.31.0` (or the latest version available at
+   [npmjs](https://www.npmjs.com/package/@gomomento/sdk-core) or what your IDE suggests.)
+   `"@gomomento/sdk-core": "1.31.0",`
+8. `npm install`
+9. `../../scripts/build-package-lambda.sh "client-sdk-nodejs"`
+10. `npm pack` - This will create the required tarball for AWS Lambda to successfully deploy our local changes to the SDK,
+    and you should see a file called `gomomento-sdk-0.0.1.tgz` created in the current `packages/client-sdk-nodejs` directory
+11. `cd ../../examples/nodejs/lambda-examples/simple-get/lambda/simple-get` - Now we go to our lambda example directory which
+    has its own `package.json` and update the SDK dependency to the local tarball
+  - `npm install ../../../../../../packages/client-sdk-nodejs/gomomento-sdk-0.0.1.tgz`
+12. Follow steps to deploy your lambda detailed on the [README](examples/nodejs/lambda-examples/simple-get) for that example.
+
+Note that you need to follow steps 9, 10, and 12 again for any further changes to the SDK after this deployment.

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -22,7 +22,8 @@
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix",
     "watch": "tsc -w",
-    "build": "cd ../core && npm run build && cd - && rm -rf dist && tsc && mkdir -p dist/src/internal/vendor && cp -r ../client-sdk-nodejs/src/internal/vendor/printf dist/src/internal/vendor/printf"
+    "build": "cd ../core && npm run build && cd - && rm -rf dist && tsc && mkdir -p dist/src/internal/vendor && cp -r ../client-sdk-nodejs/src/internal/vendor/printf dist/src/internal/vendor/printf",
+    "build-without-local-core": "rm -rf dist && tsc && mkdir -p dist/src/internal/vendor && cp -r ../client-sdk-nodejs/src/internal/vendor/printf dist/src/internal/vendor/printf"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/common-integration-tests/package.json
+++ b/packages/common-integration-tests/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix",
     "watch": "tsc -w",
-    "build": "tsc"
+    "build": "tsc",
+    "build-without-local-core": "tsc"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/scripts/build-nodejs-sdk-for-lambda.sh
+++ b/scripts/build-nodejs-sdk-for-lambda.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -x
+set -e
+
+echo "dev building nodejs sdk for aws lambda"
+
+./scripts/build-package-lambda.sh "common-integration-tests"
+./scripts/build-package-lambda.sh "client-sdk-nodejs"

--- a/scripts/build-package-lambda.sh
+++ b/scripts/build-package-lambda.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -x
+set -e
+
+ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )
+
+echo "building package: ${1}"
+
+pushd ${ROOT_DIR}/packages/${1}
+    npm ci
+    npm run format
+    npm run build-without-local-core
+    npm run lint
+popd


### PR DESCRIPTION
Updated ```CONTRIBUTING.MD``` to assist with testing out local SDK changes through examples on ec2/laptop/lambda. Was writing this while waiting for lambda runs to not forget about it later :)