### PR TITLE
chore: update fastly readme to explain secret store vs config store usage

### DIFF
--- a/examples/fastly-compute/README.md
+++ b/examples/fastly-compute/README.md
@@ -35,6 +35,8 @@ This example shows how to use the Momento HTTP API inside of a [Fastly Compute@E
 
   More information about the `fastly.toml` can be [found here](https://developer.fastly.com/reference/compute/fastly-toml/).
 
+  **Note**: for production environments, the Momento auth token should be saved in a [Fastly Secret Store](https://developer.fastly.com/reference/api/services/resources/secret-store/). However, this is a feature currently restricted to beta users, so this example saves the auth token in a [Config Store](https://developer.fastly.com/reference/api/services/resources/config-store/) instead.
+
 6. Start a local server to check that it's running at http://127.0.0.1:7676 
   ```
   fastly compute serve

--- a/examples/fastly-compute/src/index.ts
+++ b/examples/fastly-compute/src/index.ts
@@ -34,6 +34,7 @@ async function handleRequest(event: FetchEvent) {
   console.log('Connected to the Fastly Config Store');
 
   // Get all required information from the Config Store
+  // Note: for production environments, the Momento auth token should be saved in a Fastly Secret Store
   const authToken = secrets.get('MOMENTO_TOKEN');
   if (!authToken) {
     return new Response('Missing required env var MOMENTO_TOKEN', {


### PR DESCRIPTION
Follow up to #728 to emphasize that our example uses Config Stores because Secret Stores are currently restricted to Fastly beta users, but in production environments, Secret Stores should be used to hold auth tokens instead Config Stores.