### PR TITLE
feat: make eager connections as default unless otherwise specified in factory methpds

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client-props.ts
+++ b/packages/client-sdk-nodejs/src/cache-client-props.ts
@@ -20,9 +20,11 @@ export interface EagerCacheClientProps extends CacheClientProps {
   /**
    * The time in seconds to wait for a client to establish a connection to Momento.
    *
-   * If present, the client will eagerly create its connection to Momento at construction. It will wait until the
-   * connection is established, or until the timout runs out. It the timeout runs out, the client will be valid to use,
-   * but it may still be connecting in the background.
+   * The behavior to establish an eager connection is enabled by default. If this value is set, the client will eagerly
+   * create its connection to Momento at construction. It will wait until the connection is established, or until the
+   * timeout runs out. It the timeout runs out, the client will be valid to use, but it may still be connecting in the background.
+   *
+   * Override this value to 0 if you want to disable eager connections.
    */
   eagerConnectTimeout?: number;
 }

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -12,6 +12,7 @@ import {range} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 import {AbstractCacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache/AbstractCacheClient';
 
+const EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS = 30;
 /**
  * Momento Cache Client.
  *
@@ -23,7 +24,6 @@ import {AbstractCacheClient} from '@gomomento/sdk-core/dist/src/internal/clients
 export class CacheClient extends AbstractCacheClient implements ICacheClient {
   private readonly logger: MomentoLogger;
   private readonly notYetAbstractedControlClient: ControlClient;
-
   /**
    * Creates an instance of CacheClient.
    * @param {CacheClientProps} props configuration and credentials for creating a CacheClient.
@@ -57,14 +57,15 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
    */
   static async create(props: EagerCacheClientProps): Promise<CacheClient> {
     const client = new CacheClient(props);
-    if (
-      props.eagerConnectTimeout !== null &&
+    const timeout =
       props.eagerConnectTimeout !== undefined
-    ) {
+        ? props.eagerConnectTimeout
+        : EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS;
+    // client need to explicitly set the value as 0 to disable eager connection.
+    if (props.eagerConnectTimeout !== 0) {
+      console.log(`timeout is  ${timeout}`);
       await Promise.all(
-        client.dataClients.map(dc =>
-          (dc as DataClient).connect(props.eagerConnectTimeout)
-        )
+        client.dataClients.map(dc => (dc as DataClient).connect(timeout))
       );
     }
     return client;

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -63,7 +63,6 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
         : EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS;
     // client need to explicitly set the value as 0 to disable eager connection.
     if (props.eagerConnectTimeout !== 0) {
-      console.log(`timeout is  ${timeout}`);
       await Promise.all(
         client.dataClients.map(dc => (dc as DataClient).connect(timeout))
       );


### PR DESCRIPTION
Make eager connections as default unless otherwise specified in factory methods. Only if a client specifies the value as 0 will the eager connection be turned off. The reason I chose 0 over `undefined` is `undefined` is our indicator that we need to use the default value of 30 seconds.  

I need this to be able to then cut a release and then change examples to use the new version to add stuff for some of the new config. I tested locally and it works fine!