### PR TITLE
feat: update all examples to use the cacheclient factory

### DIFF
--- a/examples/nodejs/access-control/access-control.ts
+++ b/examples/nodejs/access-control/access-control.ts
@@ -92,7 +92,7 @@ async function main() {
   const mainAuthClient = new AuthClient({
     credentialProvider: mainCredsProvider,
   });
-  const mainCacheClient = new CacheClient({
+  const mainCacheClient = await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: mainCredsProvider,
     defaultTtlSeconds: 60,
@@ -112,7 +112,7 @@ async function main() {
       TokenScopes.cacheReadOnly(CACHE_OPEN_DOOR),
       tokenValidForSeconds
     );
-    const scopedTokenCacheClient = new CacheClient({
+    const scopedTokenCacheClient = await CacheClient.create({
       configuration: Configurations.Laptop.v1(),
       credentialProvider: CredentialProvider.fromString({authToken: scopedToken}),
       defaultTtlSeconds: 600,

--- a/examples/nodejs/access-control/package-lock.json
+++ b/examples/nodejs/access-control/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.31.0"
+        "@gomomento/sdk": "1.32.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -2893,12 +2893,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -2906,9 +2906,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/access-control/package-lock.json
+++ b/examples/nodejs/access-control/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.28.0"
+        "@gomomento/sdk": "1.31.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -55,22 +55,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "license": "Apache-2.0",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -79,9 +80,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -91,8 +92,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "license": "Apache-2.0",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -103,7 +105,8 @@
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.8",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -170,23 +173,28 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -194,27 +202,33 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -228,7 +242,8 @@
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "16.18.38",
@@ -749,7 +764,8 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -851,7 +867,8 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/es-abstract": {
       "version": "1.21.2",
@@ -939,7 +956,8 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "engines": {
         "node": ">=6"
       }
@@ -1502,7 +1520,8 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1615,7 +1634,8 @@
     },
     "node_modules/google-protobuf": {
       "version": "3.21.2",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -1864,7 +1884,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
@@ -2052,7 +2073,8 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2061,7 +2083,8 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2282,8 +2305,9 @@
     },
     "node_modules/protobufjs": {
       "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2304,7 +2328,8 @@
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.2.3",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -2362,7 +2387,8 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2505,7 +2531,8 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2778,7 +2805,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2798,7 +2826,8 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "engines": {
         "node": ">=10"
       }
@@ -2810,7 +2839,8 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2826,7 +2856,8 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -2853,36 +2884,40 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.68.0",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.17",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -2890,6 +2925,8 @@
     },
     "@grpc/proto-loader": {
       "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -2932,41 +2969,63 @@
       }
     },
     "@protobufjs/aspromise": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "@protobufjs/codegen": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "@protobufjs/eventemitter": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
       }
     },
     "@protobufjs/float": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@types/google-protobuf": {
-      "version": "3.15.6"
+      "version": "3.15.6",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "@types/json-schema": {
       "version": "7.0.12",
@@ -2977,7 +3036,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
       "version": "16.18.38"
@@ -3244,6 +3305,8 @@
     },
     "cliui": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3306,7 +3369,9 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "es-abstract": {
       "version": "1.21.2",
@@ -3374,7 +3439,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -3741,7 +3808,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.2.1",
@@ -3807,7 +3876,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.21.2"
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "gopd": {
       "version": "1.0.1",
@@ -3942,7 +4013,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -4053,14 +4126,18 @@
       }
     },
     "lodash.camelcase": {
-      "version": "4.3.0"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
     },
     "long": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -4190,6 +4267,8 @@
     },
     "protobufjs": {
       "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4206,7 +4285,9 @@
       },
       "dependencies": {
         "long": {
-          "version": "5.2.3"
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         }
       }
     },
@@ -4232,7 +4313,9 @@
       "dev": true
     },
     "require-directory": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
     "resolve": {
       "version": "1.22.2",
@@ -4307,6 +4390,8 @@
     },
     "string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4474,6 +4559,8 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4485,7 +4572,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.8"
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -4493,6 +4582,8 @@
     },
     "yargs": {
       "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4504,7 +4595,9 @@
       }
     },
     "yargs-parser": {
-      "version": "21.1.1"
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     }
   }
 }

--- a/examples/nodejs/access-control/package.json
+++ b/examples/nodejs/access-control/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.28.0"
+    "@gomomento/sdk": "1.31.0"
   }
 }

--- a/examples/nodejs/access-control/package.json
+++ b/examples/nodejs/access-control/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.31.0"
+    "@gomomento/sdk": "1.32.0"
   }
 }

--- a/examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts
+++ b/examples/nodejs/aws/doc-example-files/doc-examples-js-aws-secrets.ts
@@ -31,7 +31,7 @@ async function example_API_retrieveAuthTokenFromSecretsManager(
   }
 
   // Gets a client connection object from Momento Cache and returns that for later use.
-  return new CacheClient({
+  return await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromString({authToken: secret}),
     defaultTtlSeconds: ttl,

--- a/examples/nodejs/aws/package-lock.json
+++ b/examples/nodejs/aws/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.370.0",
-        "@gomomento/sdk": "1.31.0"
+        "@gomomento/sdk": "1.32.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -799,12 +799,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -4942,12 +4942,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -4955,9 +4955,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/aws/package-lock.json
+++ b/examples/nodejs/aws/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.370.0",
-        "@gomomento/sdk": "1.27.2"
+        "@gomomento/sdk": "1.31.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -790,23 +790,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.27.2.tgz",
-      "integrity": "sha512-1RdVyvZQ3Dq8sOCQ6z3SyMPZcmgu3s9qOytxzLI1Ul7h+PUR0zLUrOCHA545ERFVIWMAhgFHayU8w88ddHrrXA==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.27.2",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.27.2.tgz",
-      "integrity": "sha512-W/Qg2AcBvbLQkw50ue11jheJC0SioEK76tT0v8gtTIC97zvAvbcSZAPnIs2QtZisTp1haSzOSaqAmM7V/GSdJw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -4933,40 +4933,40 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.27.2.tgz",
-      "integrity": "sha512-1RdVyvZQ3Dq8sOCQ6z3SyMPZcmgu3s9qOytxzLI1Ul7h+PUR0zLUrOCHA545ERFVIWMAhgFHayU8w88ddHrrXA==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.27.2",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.27.2.tgz",
-      "integrity": "sha512-W/Qg2AcBvbLQkw50ue11jheJC0SioEK76tT0v8gtTIC97zvAvbcSZAPnIs2QtZisTp1haSzOSaqAmM7V/GSdJw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"

--- a/examples/nodejs/aws/package.json
+++ b/examples/nodejs/aws/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.370.0",
-    "@gomomento/sdk": "1.31.0"
+    "@gomomento/sdk": "1.32.0"
   }
 }

--- a/examples/nodejs/aws/package.json
+++ b/examples/nodejs/aws/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.370.0",
-    "@gomomento/sdk": "1.27.2"
+    "@gomomento/sdk": "1.31.0"
   }
 }

--- a/examples/nodejs/cache/README.ja.md
+++ b/examples/nodejs/cache/README.ja.md
@@ -37,7 +37,7 @@ const authToken = process.env.MOMENTO_AUTH_TOKEN;
 
 //  Momentoをイニシャライズする
 const DEFAULT_TTL = 60; // デフォルトTTLは60秒
-const momento = new CacheClient(authToken, DEFAULT_TTL);
+const momento = await CacheClient.create(authToken, DEFAULT_TTL);
 
 // "myCache"という名のキャッシュを作成する
 const CACHE_NAME = "myCache";

--- a/examples/nodejs/cache/advanced.ts
+++ b/examples/nodejs/cache/advanced.ts
@@ -26,15 +26,16 @@ const cacheValue = 'value';
 const loggerFactory: MomentoLoggerFactory = new DefaultMomentoLoggerFactory();
 const logger = loggerFactory.getLogger('AdvancedExample');
 
-const momento = new CacheClient({
-  configuration: Configurations.Laptop.v1(loggerFactory),
-  credentialProvider: CredentialProvider.fromEnvironmentVariable({
-    environmentVariableName: 'MOMENTO_AUTH_TOKEN',
-  }),
-  defaultTtlSeconds: 60,
-});
+let momento: CacheClient;
 
 async function main() {
+  momento = await CacheClient.create({
+    configuration: Configurations.Laptop.v1(loggerFactory),
+    credentialProvider: CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: 'MOMENTO_AUTH_TOKEN',
+    }),
+    defaultTtlSeconds: 60,
+  });
   await createCacheExample();
   await listCachesExample();
   await setGetDeleteExample();
@@ -132,7 +133,7 @@ async function middlewaresExample() {
 
   const metricsCsvPath = './advanced-middlewares-example-metrics.csv';
 
-  const middlewaresExampleClient = new CacheClient({
+  const middlewaresExampleClient = await CacheClient.create({
     configuration: Configurations.Laptop.v1(middlewaresExampleloggerFactory).withMiddlewares([
       new ExperimentalRequestLoggingMiddleware(middlewaresExampleloggerFactory),
       new ExperimentalMetricsCsvMiddleware(metricsCsvPath, middlewaresExampleloggerFactory),

--- a/examples/nodejs/cache/basic.ts
+++ b/examples/nodejs/cache/basic.ts
@@ -1,7 +1,7 @@
 import {CacheGet, CreateCache, CacheSet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
-  const momento = new CacheClient({
+  const momento = await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/examples/nodejs/cache/dictionary.ts
+++ b/examples/nodejs/cache/dictionary.ts
@@ -23,13 +23,15 @@ const credentialsProvider = new EnvMomentoTokenProvider({
 const loggerFactory: MomentoLoggerFactory = new DefaultMomentoLoggerFactory();
 
 const defaultTtl = 60;
-const momento = new CacheClient({
-  configuration: Configurations.Laptop.v1(loggerFactory),
-  credentialProvider: credentialsProvider,
-  defaultTtlSeconds: defaultTtl,
-});
+let momento: CacheClient;
 
 const main = async () => {
+  momento = await CacheClient.create({
+    configuration: Configurations.Laptop.v1(loggerFactory),
+    credentialProvider: credentialsProvider,
+    defaultTtlSeconds: defaultTtl,
+  });
+
   const createCacheResponse = await momento.createCache(cacheName);
   if (createCacheResponse instanceof CreateCache.AlreadyExists) {
     console.log('cache already exists');

--- a/examples/nodejs/cache/doc-example-files/cheat-sheet-main.ts
+++ b/examples/nodejs/cache/doc-example-files/cheat-sheet-main.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {CacheGet, CreateCache, CacheSet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
-function main() {
-  const cacheClient = new CacheClient({
+async function main() {
+  const cacheClient = await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -11,9 +11,7 @@ function main() {
   });
 }
 
-try {
-  main();
-} catch (e) {
+main().catch(e => {
   console.error(`Uncaught exception while running example: ${JSON.stringify(e)}`);
-  throw e;
-}
+  throw e; // Depending on the environment, this might not be necessary.
+});

--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -104,8 +104,8 @@ function example_API_ConfigurationInRegionLowLatency() {
   Configurations.InRegion.LowLatency.v1();
 }
 
-function example_API_InstantiateCacheClient() {
-  new CacheClient({
+async function example_API_InstantiateCacheClient() {
+  return await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -977,9 +977,9 @@ async function main() {
   example_API_ConfigurationInRegionDefaultLatest();
   example_API_ConfigurationInRegionLowLatency();
 
-  example_API_InstantiateCacheClient();
+  await example_API_InstantiateCacheClient();
 
-  const cacheClient = new CacheClient({
+  const cacheClient = await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.28.0"
+        "@gomomento/sdk": "1.31.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -153,23 +153,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -2986,40 +2986,40 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"

--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.31.0"
+        "@gomomento/sdk": "1.32.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -162,12 +162,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -2995,12 +2995,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3008,9 +3008,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -30,6 +30,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.28.0"
+    "@gomomento/sdk": "1.31.0"
   }
 }

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -30,6 +30,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.31.0"
+    "@gomomento/sdk": "1.32.0"
   }
 }

--- a/examples/nodejs/cache/readme.ts
+++ b/examples/nodejs/cache/readme.ts
@@ -1,7 +1,7 @@
 import {CacheGet, CacheClient, Configurations, CredentialProvider} from '@gomomento/sdk';
 
 async function main() {
-  const cacheClient = new CacheClient({
+  const cacheClient = await CacheClient.create({
     configuration: Configurations.Laptop.v1(),
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/handler.ts
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/handler.ts
@@ -52,7 +52,8 @@ async function getCacheClient(): Promise<CacheClient> {
   if (_cacheClient === undefined) {
     const momentoAuthToken = await getSecret(authTokenSecretName);
     console.log('Retrieved secret!');
-    _cacheClient = new CacheClient({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+    _cacheClient = await CacheClient.create({
       configuration: Configurations.InRegion.Default.v1().addMiddleware(
         new ExperimentalMetricsLoggingMiddleware(new DefaultMomentoLoggerFactory())
       ),

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/handler.ts
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/handler.ts
@@ -54,7 +54,7 @@ async function getCacheClient(): Promise<CacheClient> {
     console.log('Retrieved secret!');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
     _cacheClient = await CacheClient.create({
-      configuration: Configurations.InRegion.Default.v1().addMiddleware(
+      configuration: Configurations.Lambda.latest().addMiddleware(
         new ExperimentalMetricsLoggingMiddleware(new DefaultMomentoLoggerFactory())
       ),
       credentialProvider: CredentialProvider.fromString({authToken: momentoAuthToken}),

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "1.30.0",
+        "@gomomento/sdk": "1.31.0",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1069,13 +1069,14 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-RKE/7J+xxVGXM1BrlgCn0oyiagmyQP+/LYt0ZNW5UuSk/ntMP20yq25jgvr5fnTFKjsqHIRQv/qOVQodOF//GA==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.30.0",
+        "@gomomento/sdk-core": "1.31.0",
         "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -1084,9 +1085,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.30.0.tgz",
-      "integrity": "sha512-FueTI63ZamWrgfBKzK8LTX9FVxDs5z9Q0eZI0uwIo/S5l2YMVdoyfqzaIAdQnIpQL2I17aMpPHqwVQz87JZ5Wg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -1266,8 +1267,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
-      "dev": true
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -5342,21 +5342,22 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-RKE/7J+xxVGXM1BrlgCn0oyiagmyQP+/LYt0ZNW5UuSk/ntMP20yq25jgvr5fnTFKjsqHIRQv/qOVQodOF//GA==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.30.0",
+        "@gomomento/sdk-core": "1.31.0",
         "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.30.0.tgz",
-      "integrity": "sha512-FueTI63ZamWrgfBKzK8LTX9FVxDs5z9Q0eZI0uwIo/S5l2YMVdoyfqzaIAdQnIpQL2I17aMpPHqwVQz87JZ5Wg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -5506,8 +5507,7 @@
     "@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
-      "dev": true
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "@types/json-schema": {
       "version": "7.0.12",

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "1.31.0",
+        "@gomomento/sdk": "1.32.0",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1069,12 +1069,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -5342,12 +5342,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -5355,9 +5355,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "1.31.0",
+    "@gomomento/sdk": "1.32.0",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "1.30.0",
+    "@gomomento/sdk": "1.31.0",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.352.0",
         "@aws-sdk/client-secrets-manager": "^3.352.0",
-        "@gomomento/sdk": "^1.25.1",
+        "@gomomento/sdk": "^1.31.0",
         "aws-cdk-lib": "^2.85.0",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
@@ -657,23 +657,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.62.1.tgz",
-      "integrity": "sha512-EpF8X/+oTJQiXbHB8MDRSLlKaeBs9t0nw3nz2HdQ72oXDLsaVuJT3I/g3l6ZGlvVcInT+qUyg7cKPENtTHE4gg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.14",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.26.3.tgz",
-      "integrity": "sha512-JwKIVGyMdNVoYXnzG3XlEa2/J5iRAXPsX7OaYtwImLBTqP/48zStocC6NrPjCwLRx6qQo0XEc4Q/OAgyNETADw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.62.1",
-        "@gomomento/sdk-core": "1.26.3",
-        "@grpc/grpc-js": "1.8.14",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.26.3.tgz",
-      "integrity": "sha512-8C1G8/YPBtV4JFafnaMDeyhNJ8UK5wcJmbAwbuc81z841EH388W1f//dpFxL9+pd/jDb3OE7F8yyoW7XfLM1zg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -706,14 +706,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3177,54 +3177,54 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.62.1.tgz",
-      "integrity": "sha512-EpF8X/+oTJQiXbHB8MDRSLlKaeBs9t0nw3nz2HdQ72oXDLsaVuJT3I/g3l6ZGlvVcInT+qUyg7cKPENtTHE4gg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.14",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.26.3.tgz",
-      "integrity": "sha512-JwKIVGyMdNVoYXnzG3XlEa2/J5iRAXPsX7OaYtwImLBTqP/48zStocC6NrPjCwLRx6qQo0XEc4Q/OAgyNETADw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.62.1",
-        "@gomomento/sdk-core": "1.26.3",
-        "@grpc/grpc-js": "1.8.14",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.26.3.tgz",
-      "integrity": "sha512-8C1G8/YPBtV4JFafnaMDeyhNJ8UK5wcJmbAwbuc81z841EH388W1f//dpFxL9+pd/jDb3OE7F8yyoW7XfLM1zg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       }
     },

--- a/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.352.0",
         "@aws-sdk/client-secrets-manager": "^3.352.0",
-        "@gomomento/sdk": "^1.31.0",
+        "@gomomento/sdk": "^1.32.0",
         "aws-cdk-lib": "^2.85.0",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
@@ -666,12 +666,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3186,12 +3186,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3199,9 +3199,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/lambda-examples/topics-microservice/package.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.352.0",
     "@aws-sdk/client-secrets-manager": "^3.352.0",
-    "@gomomento/sdk": "^1.31.0",
+    "@gomomento/sdk": "^1.32.0",
     "aws-cdk-lib": "^2.85.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",

--- a/examples/nodejs/lambda-examples/topics-microservice/package.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.352.0",
     "@aws-sdk/client-secrets-manager": "^3.352.0",
-    "@gomomento/sdk": "^1.25.1",
+    "@gomomento/sdk": "^1.31.0",
     "aws-cdk-lib": "^2.85.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",

--- a/examples/nodejs/lambda-examples/topics-microservice/resources/libMomentoClient.ts
+++ b/examples/nodejs/lambda-examples/topics-microservice/resources/libMomentoClient.ts
@@ -56,7 +56,7 @@ export async function CreateCacheClient(
   // Call the Get Token function to get a Momento auth token from AWS Secrets Manager.
   const token: string = await GetToken(secretname, region);
   // Get a new cache connection with the token and set a default TTL for the connection.
-  return new CacheClient({
+  return await CacheClient.create({
     configuration: Configurations.Laptop.latest(),
     credentialProvider: CredentialProvider.fromString({ authToken : token }),
     defaultTtlSeconds: ttl,

--- a/examples/nodejs/lambda-examples/topics-microservice/resources/libMomentoClient.ts
+++ b/examples/nodejs/lambda-examples/topics-microservice/resources/libMomentoClient.ts
@@ -72,7 +72,7 @@ export async function CreateTopicClient(secretName: string, region: string): Pro
   const token: string = await GetToken(secretName, region);
   // Get a new cache connection with the token and set a default TTL for the connection.
   return new TopicClient({
-    configuration: Configurations.Laptop.latest(),
+    configuration: Configurations.Lambda.latest(),
     credentialProvider: CredentialProvider.fromString({ authToken : token }),
   });
 }

--- a/examples/nodejs/load-gen/README.ja.md
+++ b/examples/nodejs/load-gen/README.ja.md
@@ -37,7 +37,7 @@ const authToken = process.env.MOMENTO_AUTH_TOKEN;
 
 //  Momentoをイニシャライズする
 const DEFAULT_TTL = 60; // デフォルトTTLは60秒
-const momento = new CacheClient(authToken, DEFAULT_TTL);
+const momento = await CacheClient.create(authToken, DEFAULT_TTL);
 
 // "myCache"という名のキャッシュを作成する
 const CACHE_NAME = "myCache";

--- a/examples/nodejs/load-gen/load-gen.ts
+++ b/examples/nodejs/load-gen/load-gen.ts
@@ -36,7 +36,7 @@ class BasicLoadGen {
   }
 
   async run(): Promise<void> {
-    const momento = getCacheClient(this.loggerFactory, this.options.requestTimeoutMs, this.cacheItemTtlSeconds);
+    const momento = await getCacheClient(this.loggerFactory, this.options.requestTimeoutMs, this.cacheItemTtlSeconds);
 
     await createCache(momento, this.cacheName, this.logger);
 

--- a/examples/nodejs/load-gen/package-lock.json
+++ b/examples/nodejs/load-gen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.31.0",
+        "@gomomento/sdk": "1.32.0",
         "hdr-histogram-js": "3.0.0"
       },
       "devDependencies": {
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3131,12 +3131,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3144,9 +3144,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/load-gen/package-lock.json
+++ b/examples/nodejs/load-gen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.28.0",
+        "@gomomento/sdk": "1.31.0",
         "hdr-histogram-js": "3.0.0"
       },
       "devDependencies": {
@@ -54,23 +54,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -3122,40 +3122,40 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"

--- a/examples/nodejs/load-gen/package.json
+++ b/examples/nodejs/load-gen/package.json
@@ -27,7 +27,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.28.0",
+    "@gomomento/sdk": "1.31.0",
     "hdr-histogram-js": "3.0.0"
   }
 }

--- a/examples/nodejs/load-gen/package.json
+++ b/examples/nodejs/load-gen/package.json
@@ -27,7 +27,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.31.0",
+    "@gomomento/sdk": "1.32.0",
     "hdr-histogram-js": "3.0.0"
   }
 }

--- a/examples/nodejs/load-gen/request-coalescing.ts
+++ b/examples/nodejs/load-gen/request-coalescing.ts
@@ -43,7 +43,7 @@ class RequestCoalescerLoadGen {
   }
 
   async run(): Promise<void> {
-    const momento = getCacheClient(this.loggerFactory, this.options.requestTimeoutMs, this.cacheItemTtlSeconds);
+    const momento = await getCacheClient(this.loggerFactory, this.options.requestTimeoutMs, this.cacheItemTtlSeconds);
 
     await createCache(momento, this.cacheName, this.logger);
 

--- a/examples/nodejs/load-gen/utils/cache.ts
+++ b/examples/nodejs/load-gen/utils/cache.ts
@@ -13,8 +13,8 @@ export function getCacheClient(
   loggerFactory: MomentoLoggerFactory,
   requestTimeoutMs: number,
   cacheItemTtlSeconds: number
-) {
-  return new CacheClient({
+): Promise<CacheClient> {
+  return CacheClient.create({
     configuration: Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(requestTimeoutMs),
     credentialProvider: new EnvMomentoTokenProvider({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -34,7 +34,7 @@ export async function createCache(momentCacheClient: CacheClient, cacheName: str
 
 export async function ensureCacheExists(cacheName: string): Promise<void> {
   const loggerFactory = new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.INFO);
-  const momento = getCacheClient(loggerFactory, 5000, 60);
+  const momento = await getCacheClient(loggerFactory, 5000, 60);
   const createCacheResponse = await momento.createCache(cacheName);
   if (createCacheResponse instanceof CreateCache.Success) {
     console.log('Cache created successfully. Continuing.');

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.369.0",
-        "@gomomento/sdk": "^1.28.0",
+        "@gomomento/sdk": "^1.31.0",
         "mongodb": "^5.5.0"
       },
       "devDependencies": {
@@ -1249,23 +1249,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -8133,40 +8133,40 @@
       "dev": true
     },
     "@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "requires": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "requires": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.369.0",
-        "@gomomento/sdk": "^1.31.0",
+        "@gomomento/sdk": "^1.32.0",
         "mongodb": "^5.5.0"
       },
       "devDependencies": {
@@ -1258,12 +1258,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -8142,12 +8142,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -8155,9 +8155,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.369.0",
-    "@gomomento/sdk": "^1.31.0",
+    "@gomomento/sdk": "^1.32.0",
     "mongodb": "^5.5.0"
   },
   "devDependencies": {

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.369.0",
-    "@gomomento/sdk": "^1.28.0",
+    "@gomomento/sdk": "^1.31.0",
     "mongodb": "^5.5.0"
   },
   "devDependencies": {

--- a/examples/nodejs/mongodb-examples/simple-read-aside/src/lib/getClientFunctions.ts
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/src/lib/getClientFunctions.ts
@@ -52,7 +52,7 @@ export default async function CreateCacheClient(
   // Call the Get Token function to get a Momento auth token from AWS Secrets Manager.
   const token: string = await GetToken(tokenName);
   // Get a new cache connection with the token and set a default TTL for the connection.
-  return new CacheClient({
+  return await CacheClient.create({
       configuration: Configurations.Laptop.latest(),
       credentialProvider: CredentialProvider.fromString({ authToken : token }),
       defaultTtlSeconds: ttl,

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "1.28.0",
+        "@gomomento/sdk": "1.31.0",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1059,23 +1059,23 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.68.0.tgz",
-      "integrity": "sha512-2nBNCUQEREOglY/iGRh3AHZkEYUmxnQKD2N7eLDb+dApzQ8HKJ3kprIkEdcDNyfA/ZikpCWNIHRlOnXKV36uWg==",
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.69.0.tgz",
+      "integrity": "sha512-AFmMaPd/wYcUYR8dC0Qe4+vOkbJVGy4+BVO6ELLP7eA3RrPOgoRAFhr9yCjTaUHhcZmWeOjaSqufzd68Usl5Lg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-Xj9VckgHKpiJpsxa0Wstxw5GfsUh/aTtRSSTOUTDXlRR3ZucyQhXmIqpc8kJd6rINPkx9OFoCFjb8Xu0FPZhoQ==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
+      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
       "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "1.28.0",
-        "@grpc/grpc-js": "1.8.17",
+        "@gomomento/generated-types": "0.69.0",
+        "@gomomento/sdk-core": "1.31.0",
+        "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.28.0.tgz",
-      "integrity": "sha512-wYwGRUuq/6GoQNbO5nBMNzqwjkLTHAhLmwF/vMPnP4vZ68HbgzZfs5yJU0Tpj2TKOtwsxV+tWU+kD6pCpUuJlg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
+      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -1096,9 +1096,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "1.31.0",
+        "@gomomento/sdk": "1.32.0",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1068,12 +1068,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "1.28.0",
+    "@gomomento/sdk": "1.31.0",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "1.31.0",
+    "@gomomento/sdk": "1.32.0",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/topics/README.ja.md
+++ b/examples/nodejs/topics/README.ja.md
@@ -37,7 +37,7 @@ const authToken = process.env.MOMENTO_AUTH_TOKEN;
 
 //  Momentoをイニシャライズする
 const DEFAULT_TTL = 60; // デフォルトTTLは60秒
-const momento = new CacheClient(authToken, DEFAULT_TTL);
+const momento = await CacheClient.create(authToken, DEFAULT_TTL);
 
 // "myCache"という名のキャッシュを作成する
 const CACHE_NAME = "myCache";

--- a/examples/nodejs/topics/package-lock.json
+++ b/examples/nodejs/topics/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.31.0"
+        "@gomomento/sdk": "1.32.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -57,12 +57,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "dependencies": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3102,12 +3102,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.31.0.tgz",
-      "integrity": "sha512-GGb9udtWGNU5M7LIzbmn0br4aNPzZsPLHvavJiZ8AAjvx8oyt+JplQr4yVsnOBAkBrBxNa6j3tNutZzdERkI8w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.32.0.tgz",
+      "integrity": "sha512-+bA0qLBdKaVYAHvdUcgiCzd291zsZq1Dnmbh22YYNgn4d8l9GJskgKEAZS5WXOz6nuRfbanDiJodcOeW+76ZWw==",
       "requires": {
         "@gomomento/generated-types": "0.69.0",
-        "@gomomento/sdk-core": "1.31.0",
+        "@gomomento/sdk-core": "1.32.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3115,9 +3115,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.31.0.tgz",
-      "integrity": "sha512-REgg0nj9B5VM9wvfYVvlpbJuHd5Wy3DHIwPLtAqCXGXVReUdN8/5u/1estmLDOddfdeYfK+DsqYiBtLDtS3iMw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.32.0.tgz",
+      "integrity": "sha512-F2OKJF/Dv+zKE/w1hMvW0N+m3XOCqTuuSBVryik0WWzCI7bsqBT4/Ra1GxJiAb9S0vjFpRIxY/WCKwBiGMBUZA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/topics/package.json
+++ b/examples/nodejs/topics/package.json
@@ -27,6 +27,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.31.0"
+    "@gomomento/sdk": "1.32.0"
   }
 }

--- a/examples/nodejs/topics/utils/cache.ts
+++ b/examples/nodejs/topics/utils/cache.ts
@@ -9,12 +9,12 @@ import {
   MomentoLoggerFactory,
 } from '@gomomento/sdk';
 
-export function getCacheClient(
+export async function getCacheClient(
   loggerFactory: MomentoLoggerFactory,
   requestTimeoutMs: number,
   cacheItemTtlSeconds: number
 ) {
-  return new CacheClient({
+  return await CacheClient.create({
     configuration: Configurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(requestTimeoutMs),
     credentialProvider: new EnvMomentoTokenProvider({
       environmentVariableName: 'MOMENTO_AUTH_TOKEN',
@@ -34,7 +34,7 @@ export async function createCache(momentCacheClient: CacheClient, cacheName: str
 
 export async function ensureCacheExists(cacheName: string): Promise<void> {
   const loggerFactory = new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.INFO);
-  const momento = getCacheClient(loggerFactory, 5000, 60);
+  const momento = await getCacheClient(loggerFactory, 5000, 60);
   const createCacheResponse = await momento.createCache(cacheName);
   if (createCacheResponse instanceof CreateCache.Success) {
     console.log('Cache created successfully. Continuing.');


### PR DESCRIPTION
Bumped all examples to `1.31.0` and updated them to use the cache client factory instead of the constructor. Only the `observability` directory wasn't updated as it has an orthogonal blocker to bump up the SDK release version being tracked under https://github.com/momentohq/dev-eco-issue-tracker/issues/435.

### Testing 

- Ran `./scripts/build-all-examples.sh` and it succeeded
    - This was added here https://github.com/momentohq/client-sdk-javascript/pull/733
- I also tested the `public-dev-doc` repo by changing the SDK branch to the one on this PR and I saw the `cheat-sheet` and `develop` pages updated with the new signatures.