### PR TITLE
feat: Don't leak grpc-js/protobuf objects through middleware API

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/example-async-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/example-async-middleware.ts
@@ -1,7 +1,11 @@
-import {Middleware, MiddlewareRequestHandler} from './middleware';
+import {
+  Middleware,
+  MiddlewareMessage,
+  MiddlewareMetadata,
+  MiddlewareRequestHandler,
+  MiddlewareStatus,
+} from './middleware';
 
-import {Metadata, StatusObject} from '@grpc/grpc-js';
-import {Message} from 'google-protobuf';
 import {MomentoLogger, MomentoLoggerFactory} from '../..';
 
 class ExampleAsyncMiddlewareRequestHandler implements MiddlewareRequestHandler {
@@ -11,14 +15,16 @@ class ExampleAsyncMiddlewareRequestHandler implements MiddlewareRequestHandler {
     this.logger = logger;
   }
 
-  async onRequestMetadata(metadata: Metadata): Promise<Metadata> {
+  async onRequestMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
     this.logger.info('ExampleAsyncMiddleware.onRequestMetadata enter');
     await delay(500);
     this.logger.info('ExampleAsyncMiddleware.onRequestMetadata exit');
     return metadata;
   }
 
-  async onRequestBody(request: Message): Promise<Message> {
+  async onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
     this.logger.info('ExampleAsyncMiddleware.onRequestBody enter');
     await delay(500);
     this.logger.info('ExampleAsyncMiddleware.onRequestBody exit');
@@ -26,14 +32,18 @@ class ExampleAsyncMiddlewareRequestHandler implements MiddlewareRequestHandler {
     return request;
   }
 
-  async onResponseMetadata(metadata: Metadata): Promise<Metadata> {
+  async onResponseMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
     this.logger.info('ExampleAsyncMiddleware.onResponseMetadata enter');
     await delay(500);
     this.logger.info('ExampleAsyncMiddleware.onResponseMetadata exit');
     return metadata;
   }
 
-  async onResponseBody(response: Message | null): Promise<Message | null> {
+  async onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null> {
     this.logger.info('ExampleAsyncMiddleware.onResponseBody enter');
     await delay(500);
     this.logger.info('ExampleAsyncMiddleware.onResponseBody exit');
@@ -41,7 +51,7 @@ class ExampleAsyncMiddlewareRequestHandler implements MiddlewareRequestHandler {
     return response;
   }
 
-  async onResponseStatus(status: StatusObject): Promise<StatusObject> {
+  async onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus> {
     this.logger.info('ExampleAsyncMiddleware.onResponseStatus enter');
     await delay(500);
     this.logger.info('ExampleAsyncMiddleware.onResponseStatus exit');

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-request-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-request-logging-middleware.ts
@@ -1,6 +1,10 @@
-import {Middleware, MiddlewareRequestHandler} from './middleware';
-import {Metadata, StatusObject} from '@grpc/grpc-js';
-import {Message} from 'google-protobuf';
+import {
+  Middleware,
+  MiddlewareMessage,
+  MiddlewareMetadata,
+  MiddlewareRequestHandler,
+  MiddlewareStatus,
+} from './middleware';
 import {MomentoLogger, MomentoLoggerFactory} from '../../';
 
 class ExperimentalLoggingMiddlewareRequestHandler
@@ -13,51 +17,54 @@ class ExperimentalLoggingMiddlewareRequestHandler
     this.requestId = requestId;
   }
 
-  onRequestMetadata(metadata: Metadata): Promise<Metadata> {
+  onRequestMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata> {
     this.logger.debug(
       'Logging middleware: request %s onRequestMetadata: %s',
       this.requestId,
-      JSON.stringify(metadata.toJSON())
+      metadata.toJsonString()
     );
     return Promise.resolve(metadata);
   }
-  onRequestBody(request: Message): Promise<Message> {
+  onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
     this.logger.debug(
       'Logging middleware: request %s onRequestBody: request type: %s, request size: %s',
       this.requestId,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       request.constructor.name,
-      request.serializeBinary().length
+      request.messageLength()
     );
     return Promise.resolve(request);
   }
 
-  onResponseMetadata(metadata: Metadata): Promise<Metadata> {
+  onResponseMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
     this.logger.debug(
       'Logging middleware: request %s onResponseMetadata: %s',
       this.requestId,
-      JSON.stringify(metadata.toJSON())
+      metadata.toJsonString()
     );
     return Promise.resolve(metadata);
   }
 
-  onResponseBody(response: Message | null): Promise<Message | null> {
+  onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null> {
     this.logger.debug(
       'Logging middleware: request %s onResponseBody: response type: %s, response size: %s',
       this.requestId,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       response?.constructor?.name ?? 'null',
-      response?.serializeBinary()?.length ?? 0
+      response?.messageLength() ?? 0
     );
     return Promise.resolve(response);
   }
 
-  onResponseStatus(status: StatusObject): Promise<StatusObject> {
+  onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus> {
     this.logger.debug(
       'Logging middleware: request %s onResponseStatus: status code: %s',
       this.requestId,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      status.code
+      status.code()
     );
     return Promise.resolve(status);
   }

--- a/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
@@ -1,13 +1,47 @@
 import {Metadata, StatusObject} from '@grpc/grpc-js';
 import {Message} from 'google-protobuf';
 
-export interface MiddlewareRequestHandler {
-  onRequestMetadata(metadata: Metadata): Promise<Metadata>;
-  onRequestBody(request: Message): Promise<Message>;
+export class MiddlewareMetadata {
+  readonly _grpcMetadata: Metadata;
+  constructor(metadata: Metadata) {
+    this._grpcMetadata = metadata;
+  }
 
-  onResponseMetadata(metadata: Metadata): Promise<Metadata>;
-  onResponseBody(response: Message | null): Promise<Message | null>;
-  onResponseStatus(status: StatusObject): Promise<StatusObject>;
+  toJsonString(): string {
+    return JSON.stringify(this._grpcMetadata.toJSON());
+  }
+}
+export class MiddlewareStatus {
+  readonly _grpcStatus: StatusObject;
+  constructor(status: StatusObject) {
+    this._grpcStatus = status;
+  }
+
+  code() {
+    return this._grpcStatus.code;
+  }
+}
+
+export class MiddlewareMessage {
+  readonly _grpcMessage: Message;
+  constructor(message: Message) {
+    this._grpcMessage = message;
+  }
+
+  messageLength(): number {
+    return this._grpcMessage.serializeBinary().length;
+  }
+}
+
+export interface MiddlewareRequestHandler {
+  onRequestMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata>;
+  onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage>;
+
+  onResponseMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata>;
+  onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null>;
+  onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus>;
 }
 
 export interface MiddlewareRequestHandlerContext {

--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -48,12 +48,10 @@ export function middlewaresInterceptor(
             applyMiddlewareHandlers(
               'onResponseMetadata',
               reversedMiddlewareRequestHandlers,
-              (h: MiddlewareRequestHandler) => (m: Metadata) =>
-                h
-                  .onResponseMetadata(new MiddlewareMetadata(m))
-                  .then(m => m._grpcMetadata),
-              metadata,
-              next
+              (h: MiddlewareRequestHandler) => (m: MiddlewareMetadata) =>
+                h.onResponseMetadata(m),
+              new MiddlewareMetadata(metadata),
+              (metadata: MiddlewareMetadata) => next(metadata._grpcMetadata)
             );
           },
           onReceiveMessage: function (
@@ -66,12 +64,11 @@ export function middlewaresInterceptor(
             applyMiddlewareHandlers(
               'onResponseBody',
               reversedMiddlewareRequestHandlers,
-              (h: MiddlewareRequestHandler) => (request: Message) =>
-                h
-                  .onResponseBody(new MiddlewareMessage(request))
-                  .then(m => m?._grpcMessage),
-              message,
-              next
+              (h: MiddlewareRequestHandler) =>
+                (request: MiddlewareMessage | null) =>
+                  h.onResponseBody(request),
+              new MiddlewareMessage(message as Message),
+              (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
             );
           },
           onReceiveStatus: function (
@@ -81,12 +78,10 @@ export function middlewaresInterceptor(
             applyMiddlewareHandlers(
               'onResponseStatus',
               reversedMiddlewareRequestHandlers,
-              (h: MiddlewareRequestHandler) => (s: StatusObject) =>
-                h
-                  .onResponseStatus(new MiddlewareStatus(s))
-                  .then(s => s._grpcStatus),
-              status,
-              next
+              (h: MiddlewareRequestHandler) => (s: MiddlewareStatus) =>
+                h.onResponseStatus(s),
+              new MiddlewareStatus(status),
+              (s: MiddlewareStatus) => next(s._grpcStatus)
             );
           },
         };
@@ -94,12 +89,10 @@ export function middlewaresInterceptor(
         applyMiddlewareHandlers(
           'onRequestMetadata',
           middlewareRequestHandlers,
-          (h: MiddlewareRequestHandler) => (m: Metadata) =>
-            h
-              .onRequestMetadata(new MiddlewareMetadata(m))
-              .then(m => m._grpcMetadata),
-          metadata,
-          (m: Metadata) => next(m, newListener)
+          (h: MiddlewareRequestHandler) => (m: MiddlewareMetadata) =>
+            h.onRequestMetadata(m),
+          new MiddlewareMetadata(metadata),
+          (m: MiddlewareMetadata) => next(m._grpcMetadata, newListener)
         );
       },
       // unfortunately grpc uses `any` in their type defs for these
@@ -108,13 +101,10 @@ export function middlewaresInterceptor(
         applyMiddlewareHandlers(
           'onRequestBody',
           middlewareRequestHandlers,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (h: MiddlewareRequestHandler) => (request: any) =>
-            h
-              .onRequestBody(new MiddlewareMessage(request as Message))
-              .then(m => m._grpcMessage),
-          message,
-          next
+          (h: MiddlewareRequestHandler) => (request: MiddlewareMessage) =>
+            h.onRequestBody(request),
+          new MiddlewareMessage(message as Message),
+          (m: MiddlewareMessage) => next(m._grpcMessage)
         );
       },
     };

--- a/packages/client-sdk-nodejs/src/internal/middleware/in-flight-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/internal/middleware/in-flight-request-count-middleware.ts
@@ -1,9 +1,10 @@
 import {
   Middleware,
+  MiddlewareMessage,
+  MiddlewareMetadata,
   MiddlewareRequestHandler,
+  MiddlewareStatus,
 } from '../../config/middleware/middleware';
-import {Metadata, StatusObject} from '@grpc/grpc-js';
-import {Message} from 'google-protobuf';
 import {MomentoLogger, MomentoLoggerFactory} from '../../';
 
 class InFlightRequestCountMiddlewareRequestHandler
@@ -21,25 +22,29 @@ class InFlightRequestCountMiddlewareRequestHandler
       ++InFlightRequestCountMiddleware.numActiveRequests;
   }
 
-  onRequestBody(request: Message): Promise<Message> {
+  onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
     return Promise.resolve(request);
   }
 
-  onRequestMetadata(metadata: Metadata): Promise<Metadata> {
+  onRequestMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata> {
     return Promise.resolve(metadata);
   }
 
-  onResponseBody(response: Message | null): Promise<Message | null> {
+  onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null> {
     this.receivedResponseBody = true;
     if (this.done()) this.logStatusInformation();
     return Promise.resolve(response);
   }
 
-  onResponseMetadata(metadata: Metadata): Promise<Metadata> {
+  onResponseMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
     return Promise.resolve(metadata);
   }
 
-  onResponseStatus(status: StatusObject): Promise<StatusObject> {
+  onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus> {
     this.receivedResponseStatus = true;
     if (this.done()) this.logStatusInformation();
     return Promise.resolve(status);


### PR DESCRIPTION
This commit changes the middleware API signatures so that they
no longer directly reference objects from the grpc-js and protobuf
libraries.

Prior to this change, any project that included a custom middleware
implementation would need to be very careful to ensure that its
grpc-js and protobuf dependency versions exactly matched those
of the Momento SDK. And when the Momento SDK updates to new versions
of those deps, consuming projects would be forced to update accordingly.
Failure to do so would result in cryptic errors about object types
not being assignable.

Now we provide our own Middleware* classes that decorate the underlying
protobuf/grpc-js libs. This means that consuming projects with custom
middleware will only depend on our API, and our transitive deps will
be hidden from them.
