### PR TITLE
feat: add event loop lag to metrics middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-csv-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-csv-middleware.ts
@@ -33,6 +33,7 @@ class ExperimentalMetricsCsvMiddlewareRequestHandler extends ExperimentalMetrics
       metrics.requestSize,
       metrics.responseSize,
       metrics.connectionID,
+      metrics.eventLoopDelay,
     ].join(',');
     try {
       await fs.promises.appendFile(this.csvPath, `${csvRow}\n`);


### PR DESCRIPTION
Add the event loop delay at the start of a Momento call to the metrics middleware. It measures this by calling setTimeout with no delay that executes a function that subtracts the start time of the call from the current time. If there is no lag, it executes immediately and there is no difference. I didn't use the node performance measurement APIs because its event loop delay is a histogram that measures on a regular interval, and that doesn't fit well with per-request metrics.