### PR TITLE
feat: add value accessors on all relevant response classes

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -2514,7 +2514,9 @@ export class DataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return new CacheSortedSetIncrementScore.Error(
+        normalizeSdkError(err as Error)
+      );
     }
 
     this.logger.trace(
@@ -2570,7 +2572,9 @@ export class DataClient implements IDataClient {
               }
             } else {
               resolve(
-                new CacheDictionaryIncrement.Error(cacheServiceErrorMapper(err))
+                new CacheSortedSetIncrementScore.Error(
+                  cacheServiceErrorMapper(err)
+                )
               );
             }
           }

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -2361,7 +2361,7 @@ export class DataClient<
               );
             } else {
               resolve(
-                new CacheSortedSetFetch.Error(
+                new CacheSortedSetGetScores.Error(
                   new UnknownError('Unknown sorted set fetch hit response type')
                 )
               );
@@ -2456,7 +2456,9 @@ export class DataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return new CacheSortedSetIncrementScore.Error(
+        normalizeSdkError(err as Error)
+      );
     }
 
     this.logger.trace(
@@ -2513,7 +2515,9 @@ export class DataClient<
             }
           } else {
             resolve(
-              new CacheDictionaryIncrement.Error(cacheServiceErrorMapper(err))
+              new CacheSortedSetIncrementScore.Error(
+                cacheServiceErrorMapper(err)
+              )
             );
           }
         }

--- a/packages/common-integration-tests/package.json
+++ b/packages/common-integration-tests/package.json
@@ -21,6 +21,7 @@
     "format": "eslint . --ext .ts --fix",
     "watch": "tsc -w",
     "build": "tsc",
+    "build-with-deps": "cd ../core && npm run build && cd - && tsc",
     "build-without-local-core": "tsc"
   },
   "author": "",

--- a/packages/common-integration-tests/src/get-set-delete.ts
+++ b/packages/common-integration-tests/src/get-set-delete.ts
@@ -233,6 +233,37 @@ export function runGetSetDeleteTests(
       const getMiss = await Momento.get(IntegrationTestCacheName, cacheKey);
       expect(getMiss).toBeInstanceOf(CacheGet.Miss);
     });
+
+    it('should support accessing value for CacheGet.Hit without instanceof check', async () => {
+      const cacheKey = v4();
+      const cacheValue = v4();
+
+      const setResponse = await Momento.set(
+        IntegrationTestCacheName,
+        cacheKey,
+        cacheValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
+      let getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
+
+      expect(getResponse.value()).toEqual(cacheValue);
+
+      const hitResponse = getResponse as CacheGet.Hit;
+      expect(hitResponse.value()).toEqual(cacheValue);
+      expect(hitResponse.valueString()).toEqual(cacheValue);
+
+      getResponse = await Momento.get(IntegrationTestCacheName, v4());
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      }, `expected MISS but got ${getResponse.toString()}`);
+
+      expect(getResponse.value()).toEqual(undefined);
+    });
   });
 
   describe('#increment', () => {
@@ -242,81 +273,89 @@ export function runGetSetDeleteTests(
 
     it('increments from 0 to expected amount with string field', async () => {
       const field = v4();
-      let response = await Momento.increment(
+      let incrementResponse = await Momento.increment(
         IntegrationTestCacheName,
         field,
         1
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      let successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      let successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
-      response = await Momento.increment(IntegrationTestCacheName, field, 41);
+      incrementResponse = await Momento.increment(
+        IntegrationTestCacheName,
+        field,
+        41
+      );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
 
-      response = await Momento.increment(
+      incrementResponse = await Momento.increment(
         IntegrationTestCacheName,
         field,
         -1042
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
-      response = await Momento.get(IntegrationTestCacheName, field);
+      const getResponse = await Momento.get(IntegrationTestCacheName, field);
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheGet.Hit);
-      }, `expected HIT but got ${response.toString()}`);
-      const hitResponse = response as CacheGet.Hit;
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
+      const hitResponse = getResponse as CacheGet.Hit;
       expect(hitResponse.valueString()).toEqual('-1000');
     });
 
     it('increments from 0 to expected amount with Uint8Array field', async () => {
       const field = new TextEncoder().encode(v4());
-      let response = await Momento.increment(
+      let incrementResponse = await Momento.increment(
         IntegrationTestCacheName,
         field,
         1
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      let successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      let successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
-      response = await Momento.increment(IntegrationTestCacheName, field, 41);
+      incrementResponse = await Momento.increment(
+        IntegrationTestCacheName,
+        field,
+        41
+      );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
 
-      response = await Momento.increment(
+      incrementResponse = await Momento.increment(
         IntegrationTestCacheName,
         field,
         -1042
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheIncrement.Success);
-      }, `expected SUCCESS but got ${response.toString()}`);
-      successResponse = response as CacheIncrement.Success;
+        expect(incrementResponse).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+      successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
-      response = await Momento.get(IntegrationTestCacheName, field);
+      const getResponse = await Momento.get(IntegrationTestCacheName, field);
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(CacheGet.Hit);
-      }, `expected HIT but got ${response.toString()}`);
-      const hitResponse = response as CacheGet.Hit;
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
+      const hitResponse = getResponse as CacheGet.Hit;
       expect(hitResponse.valueString()).toEqual('-1000');
     });
 
@@ -380,6 +419,26 @@ export function runGetSetDeleteTests(
         expect(response).toBeInstanceOf(CacheIncrement.Success);
       }, `expected SUCCESS but got ${response.toString()}`);
       const successResponse = response as CacheIncrement.Success;
+      expect(successResponse.valueNumber()).toEqual(52);
+    });
+
+    it('should support accessing value for CacheIncrement.Success without instanceof check', async () => {
+      const field = v4();
+
+      await Momento.set(IntegrationTestCacheName, field, '10');
+      const response = await Momento.increment(
+        IntegrationTestCacheName,
+        field,
+        42
+      );
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(CacheIncrement.Success);
+      }, `expected SUCCESS but got ${response.toString()}`);
+
+      expect(response.value()).toEqual(52);
+
+      const successResponse = response as CacheIncrement.Success;
+      expect(successResponse.value()).toEqual(52);
       expect(successResponse.valueNumber()).toEqual(52);
     });
   });

--- a/packages/common-integration-tests/src/list.ts
+++ b/packages/common-integration-tests/src/list.ts
@@ -365,6 +365,37 @@ export function runListTests(
           'bar',
         ]);
       });
+
+      it('should support accessing value for CacheListFetch.Hit without instanceof check', async () => {
+        const listName = v4();
+
+        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
+          'foo',
+          'bar',
+        ]);
+
+        let fetchResponse = await Momento.listFetch(
+          IntegrationTestCacheName,
+          listName
+        );
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheListFetch.Hit);
+        }, `expected a HIT but got ${fetchResponse.toString()}`);
+
+        const expectedResult = ['foo', 'bar'];
+
+        expect(fetchResponse.value()).toEqual(expectedResult);
+
+        const hitResponse = fetchResponse as CacheListFetch.Hit;
+        expect(hitResponse.value()).toEqual(expectedResult);
+        expect(hitResponse.valueList()).toEqual(expectedResult);
+
+        fetchResponse = await Momento.listFetch(IntegrationTestCacheName, v4());
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheListFetch.Miss);
+        }, `expected a MISS but got ${fetchResponse.toString()}`);
+        expect(fetchResponse.value()).toEqual(undefined);
+      });
     });
 
     describe('#listLength', () => {
@@ -464,6 +495,35 @@ export function runListTests(
         }, `expected a HIT but got ${response.toString()}`);
         expect((response as CacheListPopBack.Hit).valueString()).toEqual('bar');
       });
+
+      it('should support accessing value for CacheListPopBack.Hit without instanceof check', async () => {
+        const listName = v4();
+
+        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
+          'foo',
+          'bar',
+        ]);
+
+        let popResponse = await Momento.listPopBack(
+          IntegrationTestCacheName,
+          listName
+        );
+        expectWithMessage(() => {
+          expect(popResponse).toBeInstanceOf(CacheListPopBack.Hit);
+        }, `expected a HIT but got ${popResponse.toString()}`);
+
+        expect(popResponse.value()).toEqual('bar');
+
+        const hitResponse = popResponse as CacheListPopBack.Hit;
+        expect(hitResponse.value()).toEqual('bar');
+        expect(hitResponse.valueString()).toEqual('bar');
+
+        popResponse = await Momento.listPopBack(IntegrationTestCacheName, v4());
+        expectWithMessage(() => {
+          expect(popResponse).toBeInstanceOf(CacheListPopBack.Miss);
+        }, `expected a MISS but got ${popResponse.toString()}`);
+        expect(popResponse.value()).toEqual(undefined);
+      });
     });
 
     describe('#listPopFront', () => {
@@ -517,6 +577,38 @@ export function runListTests(
           expect(response).toBeInstanceOf(CacheListPopFront.Hit);
         }, `expected a HIT but got ${response.toString()}`);
         expect((response as CacheListPopBack.Hit).valueString()).toEqual('foo');
+      });
+
+      it('should support accessing value for CacheListPopFront.Hit without instanceof check', async () => {
+        const listName = v4();
+
+        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
+          'foo',
+          'bar',
+        ]);
+
+        let popResponse = await Momento.listPopFront(
+          IntegrationTestCacheName,
+          listName
+        );
+        expectWithMessage(() => {
+          expect(popResponse).toBeInstanceOf(CacheListPopFront.Hit);
+        }, `expected a HIT but got ${popResponse.toString()}`);
+
+        expect(popResponse.value()).toEqual('foo');
+
+        const hitResponse = popResponse as CacheListPopBack.Hit;
+        expect(hitResponse.value()).toEqual('foo');
+        expect(hitResponse.valueString()).toEqual('foo');
+
+        popResponse = await Momento.listPopFront(
+          IntegrationTestCacheName,
+          v4()
+        );
+        expectWithMessage(() => {
+          expect(popResponse).toBeInstanceOf(CacheListPopFront.Miss);
+        }, `expected a MISS but got ${popResponse.toString()}`);
+        expect(popResponse.value()).toEqual(undefined);
       });
     });
 

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -547,7 +547,7 @@ export function runSetTests(
     });
   });
 
-  describe('#fetch', () => {
+  describe('#setFetch', () => {
     it('should succeed for string arrays happy path', async () => {
       const setName = v4();
       const addResponse = await Momento.setAddElements(
@@ -621,6 +621,38 @@ export function runSetTests(
       expect((fetchResponse as CacheSetFetch.Hit).valueSet()).toEqual(
         new Set(['foo', 'bar'])
       );
+    });
+
+    it('should support accessing value for CacheSetFetch.Hit without instanceof check', async () => {
+      const setName = v4();
+
+      await Momento.setAddElements(IntegrationTestCacheName, setName, [
+        'foo',
+        'bar',
+      ]);
+
+      let fetchResponse = await Momento.setFetch(
+        IntegrationTestCacheName,
+        setName
+      );
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Hit);
+      }, `expected a HIT but got ${fetchResponse.toString()}`);
+
+      const expectedResult = ['foo', 'bar'];
+
+      expect(fetchResponse.value()).toEqual(expectedResult);
+
+      const hit = fetchResponse as CacheSetFetch.Hit;
+      expect(hit.value()).toEqual(expectedResult);
+      expect(hit.valueArray()).toEqual(expectedResult);
+
+      fetchResponse = await Momento.setFetch(IntegrationTestCacheName, v4());
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
+      }, `expected a MISS but got ${fetchResponse.toString()}`);
+
+      expect(fetchResponse.value()).toEqual(undefined);
     });
   });
 }

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -589,13 +589,13 @@ export function runSortedSetTests(
 
       it('should return a miss if the sorted set does not exist', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetFetchByRank(
+        let fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
-        }, `expected MISS but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
 
         await Momento.sortedSetPutElements(
           IntegrationTestCacheName,
@@ -607,29 +607,29 @@ export function runSortedSetTests(
           ])
         );
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
 
-        response = await Momento.delete(
+        const deleteResponse = await Momento.delete(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheDelete.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
+          expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${deleteResponse.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
-        }, `expected MISS but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
       });
 
       it('should support happy path for fetchByRank via curried cache via ICache interface', async () => {
@@ -663,6 +663,61 @@ export function runSortedSetTests(
           {value: 'habanero', score: 68},
           {value: 'bam', score: 1000},
         ]);
+      });
+
+      it('should support accessing value for a sortedSetFetchByRank Hit without instanceof check', async () => {
+        const sortedSetName = v4();
+
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            bam: 1000,
+            foo: 1,
+            taco: 90210,
+            bar: 2,
+            burrito: 9000,
+            baz: 42,
+            habanero: 68,
+            jalapeno: 1_000_000,
+          }
+        );
+
+        let fetchResponse = await Momento.sortedSetFetchByRank(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            startRank: 1,
+            endRank: 5,
+          }
+        );
+
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+
+        const expectedResult = [
+          {value: 'bar', score: 2},
+          {value: 'baz', score: 42},
+          {value: 'habanero', score: 68},
+          {value: 'bam', score: 1000},
+        ];
+
+        expect(fetchResponse.value()).toEqual(expectedResult);
+
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
+        expect(hitResponse.value()).toEqual(expectedResult);
+        expect(hitResponse.valueArray()).toEqual(expectedResult);
+
+        fetchResponse = await Momento.sortedSetFetchByRank(
+          IntegrationTestCacheName,
+          v4()
+        );
+
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
+        expect(fetchResponse.value()).toEqual(undefined);
       });
     });
 
@@ -1162,13 +1217,13 @@ export function runSortedSetTests(
 
       it('should return a miss if the sorted set does not exist', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetFetchByRank(
+        let fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
-        }, `expected MISS but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
 
         await Momento.sortedSetPutElements(
           IntegrationTestCacheName,
@@ -1180,29 +1235,29 @@ export function runSortedSetTests(
           ])
         );
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
 
-        response = await Momento.delete(
+        const deleteResponse = await Momento.delete(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheDelete.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
+          expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
+        }, `expected SUCCESS but got ${deleteResponse.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
-        }, `expected MISS but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
       });
 
       it('should support happy path for fetchByScore via curried cache via ICache interface', async () => {
@@ -1234,6 +1289,59 @@ export function runSortedSetTests(
           {value: 'bam', score: 1000},
           {value: 'burrito', score: 9000},
         ]);
+      });
+
+      it('should support accessing value for sortedSetFetchByScore Hit without instanceof check', async () => {
+        const sortedSetName = v4();
+
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            bam: 1000,
+            foo: 1,
+            taco: 90210,
+            bar: 2,
+            burrito: 9000,
+            baz: 42,
+            habanero: 68,
+            jalapeno: 1_000_000,
+          }
+        );
+
+        let fetchResponse = await Momento.sortedSetFetchByScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            minScore: 100,
+            maxScore: 10_000,
+          }
+        );
+
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+
+        const expectedResult = [
+          {value: 'bam', score: 1000},
+          {value: 'burrito', score: 9000},
+        ];
+
+        expect(fetchResponse.value()).toEqual(expectedResult);
+
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
+        expect(hitResponse.value()).toEqual(expectedResult);
+        expect(hitResponse.valueArray()).toEqual(expectedResult);
+
+        fetchResponse = await Momento.sortedSetFetchByScore(
+          IntegrationTestCacheName,
+          v4()
+        );
+
+        expectWithMessage(() => {
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
+        expect(fetchResponse.value()).toEqual(undefined);
       });
     });
 
@@ -1404,6 +1512,45 @@ export function runSortedSetTests(
         const hitResult = result as CacheSortedSetGetScore.Hit;
         expect(hitResult.score()).toEqual(84);
       });
+
+      it('should support accessing value for CacheSortedSetGetScore.Hit without instanceof check', async () => {
+        const sortedSetName = v4();
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            foo: 42,
+            bar: 84,
+            baz: 90210,
+          }
+        );
+
+        let getScoreResponse = await Momento.sortedSetGetScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          'bar'
+        );
+        expectWithMessage(() => {
+          expect(getScoreResponse).toBeInstanceOf(CacheSortedSetGetScore.Hit);
+        }, `expected HIT but got ${getScoreResponse.toString()}`);
+
+        expect(getScoreResponse.score()).toEqual(84);
+
+        const hitResult = getScoreResponse as CacheSortedSetGetScore.Hit;
+        expect(hitResult.score()).toEqual(84);
+
+        getScoreResponse = await Momento.sortedSetGetScore(
+          IntegrationTestCacheName,
+          v4(),
+          'bar'
+        );
+
+        expectWithMessage(() => {
+          expect(getScoreResponse).toBeInstanceOf(CacheSortedSetGetScore.Miss);
+        }, `expected MISS but got ${getScoreResponse.toString()}`);
+
+        expect(getScoreResponse.score()).toEqual(undefined);
+      });
     });
 
     describe('#sortedSetGetScores', () => {
@@ -1482,6 +1629,49 @@ export function runSortedSetTests(
         const hitResult = result as CacheSortedSetGetScores.Hit;
         expect(hitResult.valueRecord()).toEqual({bar: 84, baz: 90210});
       });
+
+      it('should support accessing value for CacheSortedSetGetScores.Hit without instanceof check', async () => {
+        const sortedSetName = v4();
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            foo: 42,
+            bar: 84,
+            baz: 90210,
+          }
+        );
+
+        let getScoresResponse = await Momento.sortedSetGetScores(
+          IntegrationTestCacheName,
+          sortedSetName,
+          ['bar', 'baz']
+        );
+        expectWithMessage(() => {
+          expect(getScoresResponse).toBeInstanceOf(CacheSortedSetGetScores.Hit);
+        }, `expected HIT but got ${getScoresResponse.toString()}`);
+
+        const expectedResult = {bar: 84, baz: 90210};
+
+        expect(getScoresResponse.value()).toEqual(expectedResult);
+
+        const hitResult = getScoresResponse as CacheSortedSetGetScores.Hit;
+        expect(hitResult.value()).toEqual(expectedResult);
+        expect(hitResult.valueRecord()).toEqual(expectedResult);
+
+        getScoresResponse = await Momento.sortedSetGetScores(
+          IntegrationTestCacheName,
+          v4(),
+          ['foo', 'bar']
+        );
+
+        expectWithMessage(() => {
+          expect(getScoresResponse).toBeInstanceOf(
+            CacheSortedSetGetScores.Miss
+          );
+        }, `expected MISS but got ${getScoresResponse.toString()}`);
+        expect(getScoresResponse.value()).toEqual(undefined);
+      });
     });
 
     describe('#sortedSetIncrementScore', () => {
@@ -1508,34 +1698,36 @@ export function runSortedSetTests(
 
       it('creates sorted set and element if they do not exist', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetFetchByRank(
+        let fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Miss);
-        }, `expected MISS but got ${response.toString()}`);
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
+        }, `expected MISS but got ${fetchResponse.toString()}`);
 
-        response = await Momento.sortedSetIncrementScore(
+        let incrementResponse = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           'foo'
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse.score()).toEqual(1);
+          expect(incrementResponse).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+        let successResponse =
+          incrementResponse as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(1);
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {
             value: 'foo',
@@ -1543,7 +1735,7 @@ export function runSortedSetTests(
           },
         ]);
 
-        response = await Momento.sortedSetIncrementScore(
+        incrementResponse = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           'bar',
@@ -1551,21 +1743,23 @@ export function runSortedSetTests(
         );
 
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse2 =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse2.score()).toEqual(42);
+          expect(incrementResponse).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+        successResponse =
+          incrementResponse as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(42);
 
-        response = await Momento.sortedSetFetchByRank(
+        fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
 
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse2 = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse2 = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse2.valueArray()).toEqual([
           {value: 'foo', score: 1},
           {value: 'bar', score: 42},
@@ -1582,27 +1776,29 @@ export function runSortedSetTests(
           90210
         );
 
-        let response = await Momento.sortedSetIncrementScore(
+        const incrementResponse = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           value,
           10
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse.score()).toEqual(90220);
+          expect(incrementResponse).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+        const successResponse =
+          incrementResponse as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(90220);
 
-        response = await Momento.sortedSetFetchByRank(
+        const fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: value, score: 90220},
         ]);
@@ -1618,27 +1814,29 @@ export function runSortedSetTests(
           90210
         );
 
-        let response = await Momento.sortedSetIncrementScore(
+        const incrementResponse = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           value,
           10
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse.score()).toEqual(90220);
+          expect(incrementResponse).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+        const successResponse =
+          incrementResponse as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(90220);
 
-        response = await Momento.sortedSetFetchByRank(
+        const fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: value, score: 90220},
         ]);
@@ -1654,27 +1852,29 @@ export function runSortedSetTests(
           90210
         );
 
-        let response = await Momento.sortedSetIncrementScore(
+        const incrementRespone = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           value,
           -10
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse.score()).toEqual(90200);
+          expect(incrementRespone).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementRespone.toString()}`);
+        const successResponse =
+          incrementRespone as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(90200);
 
-        response = await Momento.sortedSetFetchByRank(
+        const fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArray()).toEqual([
           {value: value, score: 90200},
         ]);
@@ -1690,27 +1890,29 @@ export function runSortedSetTests(
           90210
         );
 
-        let response = await Momento.sortedSetIncrementScore(
+        const incrementResponse = await Momento.sortedSetIncrementScore(
           IntegrationTestCacheName,
           sortedSetName,
           value,
           -10
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
-        }, `expected SUCCESS but got ${response.toString()}`);
-        const incrementResponse =
-          response as CacheSortedSetIncrementScore.Success;
-        expect(incrementResponse.score()).toEqual(90200);
+          expect(incrementResponse).toBeInstanceOf(
+            CacheSortedSetIncrementScore.Success
+          );
+        }, `expected SUCCESS but got ${incrementResponse.toString()}`);
+        const successResponse =
+          incrementResponse as CacheSortedSetIncrementScore.Success;
+        expect(successResponse.score()).toEqual(90200);
 
-        response = await Momento.sortedSetFetchByRank(
+        const fetchResponse = await Momento.sortedSetFetchByRank(
           IntegrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheSortedSetFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheSortedSetFetch.Hit;
+          expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
+        }, `expected HIT but got ${fetchResponse.toString()}`);
+        const hitResponse = fetchResponse as CacheSortedSetFetch.Hit;
         expect(hitResponse.valueArrayUint8Elements()).toEqual([
           {value: value, score: 90200},
         ]);
@@ -1732,6 +1934,33 @@ export function runSortedSetTests(
         expectWithMessage(() => {
           expect(result).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
         }, `expected HIT but got ${result.toString()}`);
+        const success = result as CacheSortedSetIncrementScore.Success;
+        expect(success.score()).toEqual(85);
+      });
+
+      it('should support accessing value for SortedSetIncrementScore.Success without instanceof check', async () => {
+        const sortedSetName = v4();
+        await Momento.sortedSetPutElements(
+          IntegrationTestCacheName,
+          sortedSetName,
+          {
+            foo: 42,
+            bar: 84,
+            baz: 90210,
+          }
+        );
+
+        const result = await Momento.sortedSetIncrementScore(
+          IntegrationTestCacheName,
+          sortedSetName,
+          'bar'
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetIncrementScore.Success);
+        }, `expected HIT but got ${result.toString()}`);
+
+        expect(result.score()).toEqual(85);
+
         const success = result as CacheSortedSetIncrementScore.Success;
         expect(success.score()).toEqual(85);
       });

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -44,6 +44,7 @@ import {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
+  CacheDictionaryGetFields,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -203,7 +204,7 @@ export interface ICacheClient extends IControlClient, IPingClient {
     cacheName: string,
     dictionaryName: string,
     fields: string[] | Uint8Array[]
-  ): Promise<CacheDictionaryGetField.Response>;
+  ): Promise<CacheDictionaryGetFields.Response>;
   dictionaryFetch(
     cacheName: string,
     dictionaryName: string

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -43,6 +43,7 @@ import {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
+  CacheDictionaryGetFields,
   CacheDictionaryLength,
 } from '../index';
 import {
@@ -169,7 +170,7 @@ export interface IMomentoCache {
   dictionaryGetFields(
     dictionaryName: string,
     fields: string[] | Uint8Array[]
-  ): Promise<CacheDictionaryGetField.Response>;
+  ): Promise<CacheDictionaryGetFields.Response>;
   dictionaryFetch(
     dictionaryName: string
   ): Promise<CacheDictionaryFetch.Response>;

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -44,6 +44,7 @@ import {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   CacheDictionaryLength,
+  CacheDictionaryGetFields,
 } from '../../../index';
 
 export interface IDataClient {
@@ -164,7 +165,7 @@ export interface IDataClient {
     cacheName: string,
     dictionaryName: string,
     fields: string[] | Uint8Array[]
-  ): Promise<CacheDictionaryGetField.Response>;
+  ): Promise<CacheDictionaryGetFields.Response>;
   dictionaryFetch(
     cacheName: string,
     dictionaryName: string

--- a/packages/core/src/messages/responses/cache-dictionary-fetch.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-fetch.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): Record<string, string> | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly items: _DictionaryFieldValuePair[];
@@ -81,6 +88,16 @@ class _Hit extends Response {
       acc.set(TEXT_DECODER.decode(item.field), item.value);
       return acc;
     }, new Map<string, Uint8Array>());
+  }
+
+  /**
+   * Returns the data as a Record whose keys and values are utf-8 strings, decoded from the underlying byte arrays.
+   * This can be used in most places where an Object is desired.  This is a convenience alias for
+   * {valueRecordStringString}.
+   * @returns {Record<string, string>}
+   */
+  public value(): Record<string, string> {
+    return this.valueRecordStringString();
   }
 
   /**

--- a/packages/core/src/messages/responses/cache-dictionary-get-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-field.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;
@@ -37,6 +44,15 @@ class _Hit extends Response {
     super();
     this.body = body;
   }
+
+  /**
+   * Returns the data as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public value(): string {
+    return TEXT_DECODER.decode(this.body);
+  }
+
   /**
    * Returns the data as a utf-8 string, decoded from the underlying byte array.
    * @returns string

--- a/packages/core/src/messages/responses/cache-dictionary-get-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-field.ts
@@ -50,7 +50,7 @@ class _Hit extends Response {
    * @returns string
    */
   public value(): string {
-    return TEXT_DECODER.decode(this.body);
+    return this.valueString();
   }
 
   /**

--- a/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
@@ -34,7 +34,14 @@ type CacheDictionaryGetFieldResponseType =
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): Record<string, string> | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly items: _DictionaryGetResponsePart[];
@@ -141,6 +148,16 @@ class _Hit extends Response {
    * @returns {Record<string, string>}
    */
   public valueRecord(): Record<string, string> {
+    return this.valueRecordStringString();
+  }
+
+  /**
+   * Returns the data as a Record whose keys and values are utf-8 strings, decoded from the underlying byte arrays.
+   * This can be used in most places where an Object is desired.  This is a convenience alias for
+   * {valueRecordStringString}.
+   * @returns {Record<string, string>}
+   */
+  public value(): Record<string, string> {
     return this.valueRecordStringString();
   }
 

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -20,22 +20,32 @@ import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): number | undefined {
+    if (this instanceof Success) {
+      return (this as Success).value();
+    }
+    return undefined;
+  }
+}
 
 class _Success extends Response {
-  private readonly value: number;
+  private readonly _value: number;
 
   constructor(value: number) {
     super();
-    this.value = value;
+    this._value = value;
   }
 
   /**
    * The new value of the element after incrementing.
    * @returns {number}
    */
+  public value(): number {
+    return this._value;
+  }
   public valueNumber(): number {
-    return this.value;
+    return this._value;
   }
 
   public override toString(): string {

--- a/packages/core/src/messages/responses/cache-get.ts
+++ b/packages/core/src/messages/responses/cache-get.ts
@@ -6,6 +6,7 @@ import {
   ResponseMiss,
 } from './response-base';
 import {truncateString} from '../../internal/utils';
+import {CacheGet} from '../../index';
 
 const TEXT_DECODER = new TextDecoder();
 
@@ -29,7 +30,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string | undefined {
+    if (this instanceof CacheGet.Hit) {
+      return (this as CacheGet.Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;
@@ -37,6 +45,15 @@ class _Hit extends Response {
     super();
     this.body = body;
   }
+
+  /**
+   * Returns the data as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public value(): string {
+    return TEXT_DECODER.decode(this.body);
+  }
+
   /**
    * Returns the data as a utf-8 string, decoded from the underlying byte array.
    * @returns string

--- a/packages/core/src/messages/responses/cache-get.ts
+++ b/packages/core/src/messages/responses/cache-get.ts
@@ -6,7 +6,6 @@ import {
   ResponseMiss,
 } from './response-base';
 import {truncateString} from '../../internal/utils';
-import {CacheGet} from '../../index';
 
 const TEXT_DECODER = new TextDecoder();
 
@@ -32,8 +31,8 @@ const TEXT_DECODER = new TextDecoder();
  */
 export abstract class Response extends ResponseBase {
   public value(): string | undefined {
-    if (this instanceof CacheGet.Hit) {
-      return (this as CacheGet.Hit).value();
+    if (this instanceof Hit) {
+      return (this as Hit).value();
     }
     return undefined;
   }

--- a/packages/core/src/messages/responses/cache-increment.ts
+++ b/packages/core/src/messages/responses/cache-increment.ts
@@ -20,22 +20,32 @@ import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): number | undefined {
+    if (this instanceof Success) {
+      return (this as Success).value();
+    }
+    return undefined;
+  }
+}
 
 class _Success extends Response {
-  private readonly value: number;
+  private readonly _value: number;
 
   constructor(value: number) {
     super();
-    this.value = value;
+    this._value = value;
   }
 
   /**
    * The new value of the element after incrementing.
    * @returns {number}
    */
+  public value(): number {
+    return this._value;
+  }
   public valueNumber(): number {
-    return this.value;
+    return this._value;
   }
 
   public override toString(): string {

--- a/packages/core/src/messages/responses/cache-list-fetch.ts
+++ b/packages/core/src/messages/responses/cache-list-fetch.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string[] | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly _values: Uint8Array[];
@@ -60,6 +67,15 @@ class _Hit extends Response {
    * @returns {string[]}
    */
   public valueList(): string[] {
+    return this.valueListString();
+  }
+
+  /**
+   * Returns the data as an array of strings, decoded from the underlying byte array.  This is a convenience alias
+   * for {valueListString}
+   * @returns {string[]}
+   */
+  public value(): string[] {
     return this.valueListString();
   }
 

--- a/packages/core/src/messages/responses/cache-list-pop-back.ts
+++ b/packages/core/src/messages/responses/cache-list-pop-back.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;
@@ -43,6 +50,14 @@ class _Hit extends Response {
    * @returns string
    */
   public valueString(): string {
+    return TEXT_DECODER.decode(this.body);
+  }
+
+  /**
+   * Returns the data as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public value(): string {
     return TEXT_DECODER.decode(this.body);
   }
 

--- a/packages/core/src/messages/responses/cache-list-pop-front.ts
+++ b/packages/core/src/messages/responses/cache-list-pop-front.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly body: Uint8Array;
@@ -42,6 +49,14 @@ class _Hit extends Response {
    * @returns string
    */
   public valueString(): string {
+    return TEXT_DECODER.decode(this.body);
+  }
+
+  /**
+   * Returns the data as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public value(): string {
     return TEXT_DECODER.decode(this.body);
   }
 

--- a/packages/core/src/messages/responses/cache-set-fetch.ts
+++ b/packages/core/src/messages/responses/cache-set-fetch.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): string[] | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly elements: Uint8Array[];
@@ -62,6 +69,16 @@ class _Hit extends Response {
    */
   public valueSetUint8Array(): Set<Uint8Array> {
     return new Set(this.elements);
+  }
+
+  /**
+   * Returns the data as an Array whose values are utf-8 strings, decoded from the underlying byte arrays.
+   * This accessor is provided because Arrays are sometimes easier to work with in TypeScript/JavaScript than Sets are.
+   * This is a convenience alias for {valueArrayString}.
+   * @returns {string[]}
+   */
+  public value(): string[] {
+    return this.valueArrayString();
   }
 
   /**

--- a/packages/core/src/messages/responses/cache-sorted-set-fetch.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-fetch.ts
@@ -29,7 +29,14 @@ const TEXT_DECODER = new TextDecoder();
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): {value: string; score: number}[] | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly elements: _SortedSetElement[];
@@ -75,6 +82,16 @@ class _Hit extends Response {
    * @returns {value: string; score: number}[]
    */
   public valueArray(): {value: string; score: number}[] {
+    return this.valueArrayStringElements();
+  }
+
+  /**
+   * Returns the elements as an array of objects, each containing a `value` and `score` field.
+   * The value is a utf-8 string, decoded from the underlying byte array, and the score is a number.
+   * This is a convenience alias for {valueArrayStringNumber}.
+   * @returns {value: string; score: number}[]
+   */
+  public value(): {value: string; score: number}[] {
     return this.valueArrayStringElements();
   }
 

--- a/packages/core/src/messages/responses/cache-sorted-set-get-score.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-get-score.ts
@@ -26,7 +26,14 @@ import {SdkError} from '../../errors';
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public score(): number | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).score();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   private readonly _value: Uint8Array;

--- a/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
@@ -36,7 +36,14 @@ type CacheSortedSetGetScoreResponseType =
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public value(): Record<string, number> | undefined {
+    if (this instanceof Hit) {
+      return (this as Hit).value();
+    }
+    return undefined;
+  }
+}
 
 class _Hit extends Response {
   public _responses: CacheSortedSetGetScoreResponseType[] = [];
@@ -124,6 +131,16 @@ class _Hit extends Response {
    */
   public valueRecord(): Record<string, number> {
     return this.valueRecordString();
+  }
+
+  /**
+   * Returns the data as a Record whose keys and values are utf-8 strings, decoded from the underlying byte arrays.
+   * This can be used in most places where an Object is desired.  This is a convenience alias for
+   * {valueRecordStringString}.
+   * @returns {Record<string, number>}
+   */
+  public value(): Record<string, number> {
+    return this.valueRecord();
   }
 
   public override toString(): string {

--- a/packages/core/src/messages/responses/cache-sorted-set-increment-score.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-increment-score.ts
@@ -20,7 +20,14 @@ import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  public score(): number | undefined {
+    if (this instanceof Success) {
+      return (this as Success).score();
+    }
+    return undefined;
+  }
+}
 
 class _Success extends Response {
   private readonly _score: number;


### PR DESCRIPTION
This commit includes the following two major changes:
* All relevant `Hit`/`Success` classes now have a `value()` function,
  which returns the data type that we expect to be the most commonly
  used one for the response.
* All relevant `Response` classes now have a `value()` function that
  returns the `Hit`/`Success` subclass's `value()` for the happy path,
  or `undefined` for the `Miss`/`Error` path.

This should simplify a lot of example code, so that we don't have to
call `valueRecord` or similar explicitly specified accessors, and we
can now access `value()` without doing an `instanceof` check first
(even in TypeScript).

NOTE: it is crucially important that we review the choice of data
types for each `value()` function closely and make sure that we
are all aligned on those choices before this is merged.
