### PR TITLE
chore: add validation for eager connection timeout

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -8,7 +8,10 @@ import {
   MomentoLogger,
 } from '.';
 import {CacheClientProps, EagerCacheClientProps} from './cache-client-props';
-import {range} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {
+  range,
+  validateValidForSeconds,
+} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 import {AbstractCacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache/AbstractCacheClient';
 
@@ -61,6 +64,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       props.eagerConnectTimeout !== undefined
         ? props.eagerConnectTimeout
         : EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS;
+    validateValidForSeconds(timeout);
     // client need to explicitly set the value as 0 to disable eager connection.
     if (props.eagerConnectTimeout !== 0) {
       await Promise.all(

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -10,12 +10,12 @@ import {
 import {CacheClientProps, EagerCacheClientProps} from './cache-client-props';
 import {
   range,
-  validateValidForSeconds,
+  validateTimeout,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 import {AbstractCacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache/AbstractCacheClient';
 
-const EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS = 30;
+const EAGER_CONNECTION_DEFAULT_TIMEOUT_SECONDS = 30;
 /**
  * Momento Cache Client.
  *
@@ -63,8 +63,9 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     const timeout =
       props.eagerConnectTimeout !== undefined
         ? props.eagerConnectTimeout
-        : EAGER_CONNECITON_DEFAULT_TIMEOUT_SECONDS;
-    validateValidForSeconds(timeout);
+        : EAGER_CONNECTION_DEFAULT_TIMEOUT_SECONDS;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    validateTimeout(timeout);
     // client need to explicitly set the value as 0 to disable eager connection.
     if (props.eagerConnectTimeout !== 0) {
       await Promise.all(

--- a/packages/core/src/internal/utils/validators.ts
+++ b/packages/core/src/internal/utils/validators.ts
@@ -99,6 +99,12 @@ export function validateValidForSeconds(validForSeconds: number) {
   }
 }
 
+export function validateTimeout(timeout: number) {
+  if (timeout < 0) {
+    throw new InvalidArgumentError('timeout must be positive');
+  }
+}
+
 function isEmpty(str: string): boolean {
   return !str.trim();
 }


### PR DESCRIPTION
Noticed while wiring the same on Python SDK that we need a validation for a better UX