### PR TITLE
feat: Add event loop delay logging to the metrics logging middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -5,6 +5,59 @@ import {
   ExperimentalRequestMetrics,
 } from './impl/experimental-metrics-middleware';
 import {MiddlewareRequestHandlerContext} from './middleware';
+import {
+  EventLoopDelayMonitor,
+  EventLoopUtilization,
+  monitorEventLoopDelay,
+  performance,
+} from 'perf_hooks';
+
+interface StateMetrics {
+  /**
+   * The proportion of time the event loop was busy over the last second.
+   */
+  eventLoopUtilization: number;
+
+  /**
+   * The average event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMean: number;
+
+  /**
+   * The minimum event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMin: number;
+
+  /**
+   * The 50th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP50: number;
+
+  /**
+   * The 75th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP75: number;
+
+  /**
+   * The 90th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP90: number;
+
+  /**
+   * The 95th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP95: number;
+
+  /**
+   * The 99th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP99: number;
+
+  /**
+   * The maximum event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMax: number;
+}
 
 class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMetricsMiddlewareRequestHandler {
   constructor(
@@ -30,6 +83,10 @@ class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMet
  * once the format is considered stable, this class will be renamed to remove
  * the Experimental prefix.
  *
+ * It also enables regular logging of congestion in the node event loop. Once
+ * per second it will output the event loop utilization ratio, as well as stats
+ * about the event loop delay, measured in 20ms increments.
+ *
  * WARNING: enabling this middleware may have minor performance implications,
  * so enable with caution.
  *
@@ -42,6 +99,11 @@ class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMet
  * your {Configuration} to enable this middleware.
  */
 export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMiddleware {
+  private static readonly metricsLogInterval = 1000;
+  private static readonly eventLoopDelayInterval = 20;
+  private static eldMonitor: EventLoopDelayMonitor;
+  private static elu: EventLoopUtilization;
+  private static isLoggingStarted = false;
   static numActiveRequests = 0;
 
   constructor(loggerFactory: MomentoLoggerFactory) {
@@ -50,5 +112,42 @@ export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMid
       (p, l, c) =>
         new ExperimentalMetricsLoggingMiddlewareRequestHandler(p, l, c)
     );
+    if (!ExperimentalMetricsLoggingMiddleware.isLoggingStarted) {
+      ExperimentalMetricsLoggingMiddleware.startLogging(this.logger);
+    }
+  }
+
+  private static startLogging(logger: MomentoLogger): void {
+    this.eldMonitor = monitorEventLoopDelay({
+      resolution: this.eventLoopDelayInterval,
+    });
+    this.eldMonitor.enable();
+    this.elu = performance.eventLoopUtilization();
+
+    setTimeout(() => {
+      setInterval(() => {
+        this.elu = performance.eventLoopUtilization(this.elu);
+        const metrics: StateMetrics = {
+          eventLoopUtilization: this.elu.utilization,
+          eventLoopDelayMean: this.normalizeEld(this.eldMonitor.mean),
+          eventLoopDelayMin: Math.max(
+            0,
+            this.normalizeEld(this.eldMonitor.min)
+          ),
+          eventLoopDelayP50: this.normalizeEld(this.eldMonitor.percentile(50)),
+          eventLoopDelayP75: this.normalizeEld(this.eldMonitor.percentile(75)),
+          eventLoopDelayP90: this.normalizeEld(this.eldMonitor.percentile(90)),
+          eventLoopDelayP95: this.normalizeEld(this.eldMonitor.percentile(95)),
+          eventLoopDelayP99: this.normalizeEld(this.eldMonitor.percentile(99)),
+          eventLoopDelayMax: this.normalizeEld(this.eldMonitor.max),
+        };
+        logger.info(JSON.stringify(metrics));
+        this.eldMonitor.reset();
+      }, this.metricsLogInterval);
+    }, this.metricsLogInterval);
+  }
+
+  private static normalizeEld(eventLoopDelay: number): number {
+    return eventLoopDelay / 1_000_000 - this.eventLoopDelayInterval;
   }
 }

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -125,26 +125,21 @@ export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMid
     this.eldMonitor.enable();
     this.elu = performance.eventLoopUtilization();
 
-    setTimeout(() => {
-      setInterval(() => {
-        this.elu = performance.eventLoopUtilization(this.elu);
-        const metrics: StateMetrics = {
-          eventLoopUtilization: this.elu.utilization,
-          eventLoopDelayMean: this.normalizeEld(this.eldMonitor.mean),
-          eventLoopDelayMin: Math.max(
-            0,
-            this.normalizeEld(this.eldMonitor.min)
-          ),
-          eventLoopDelayP50: this.normalizeEld(this.eldMonitor.percentile(50)),
-          eventLoopDelayP75: this.normalizeEld(this.eldMonitor.percentile(75)),
-          eventLoopDelayP90: this.normalizeEld(this.eldMonitor.percentile(90)),
-          eventLoopDelayP95: this.normalizeEld(this.eldMonitor.percentile(95)),
-          eventLoopDelayP99: this.normalizeEld(this.eldMonitor.percentile(99)),
-          eventLoopDelayMax: this.normalizeEld(this.eldMonitor.max),
-        };
-        logger.info(JSON.stringify(metrics));
-        this.eldMonitor.reset();
-      }, this.metricsLogInterval);
+    setInterval(() => {
+      this.elu = performance.eventLoopUtilization(this.elu);
+      const metrics: StateMetrics = {
+        eventLoopUtilization: this.elu.utilization,
+        eventLoopDelayMean: this.normalizeEld(this.eldMonitor.mean),
+        eventLoopDelayMin: Math.max(0, this.normalizeEld(this.eldMonitor.min)),
+        eventLoopDelayP50: this.normalizeEld(this.eldMonitor.percentile(50)),
+        eventLoopDelayP75: this.normalizeEld(this.eldMonitor.percentile(75)),
+        eventLoopDelayP90: this.normalizeEld(this.eldMonitor.percentile(90)),
+        eventLoopDelayP95: this.normalizeEld(this.eldMonitor.percentile(95)),
+        eventLoopDelayP99: this.normalizeEld(this.eldMonitor.percentile(99)),
+        eventLoopDelayMax: this.normalizeEld(this.eldMonitor.max),
+      };
+      logger.info(JSON.stringify(metrics));
+      this.eldMonitor.reset();
     }, this.metricsLogInterval);
   }
 

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -113,6 +113,7 @@ export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMid
         new ExperimentalMetricsLoggingMiddlewareRequestHandler(p, l, c)
     );
     if (!ExperimentalMetricsLoggingMiddleware.isLoggingStarted) {
+      ExperimentalMetricsLoggingMiddleware.isLoggingStarted = true;
       ExperimentalMetricsLoggingMiddleware.startLogging(this.logger);
     }
   }

--- a/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
@@ -187,7 +187,7 @@ export abstract class ExperimentalMetricsMiddlewareRequestHandler
  */
 export abstract class ExperimentalMetricsMiddleware implements Middleware {
   private numActiveRequests = 0;
-  private readonly logger: MomentoLogger;
+  protected readonly logger: MomentoLogger;
 
   private readonly requestHandlerFactoryFn: (
     parent: ExperimentalMetricsMiddleware,


### PR DESCRIPTION
Add regular logging of event loop delay and utilization to the metrics logging middleware. The built-in performance monitor doesn't work well in a per-request context, so we log event loop stats on a one-second interval.