### PR TITLE
fix: merge dependabot prs without the --auto flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
           GH_TOKEN: ${{secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --squash --auto "$PR_URL"
+        run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The `--auto` flag just tells github to automatically merge the pr once all checks have passed. We currently have branch protection set to prevent this, however we are already waiting for all checks to pass anyways before we are trying to merge this pr