### PR TITLE
chore: add integration test that asserts the remaining ttl for setIfNotExists to be valid

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -506,7 +506,7 @@ export class DataClient implements IDataClient {
       );
     }
     this.logger.trace(
-      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttl: ${
+      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
         ttl?.toString() ?? 'null'
       }`
     );
@@ -515,7 +515,7 @@ export class DataClient implements IDataClient {
       cacheName,
       this.convert(key),
       this.convert(value),
-      ttl || this.defaultTtlSeconds * 1000
+      ttl ? ttl * 1000 : this.defaultTtlSeconds * 1000
     );
     this.logger.trace(`'setIfNotExists' request result: ${result.toString()}`);
     return result;


### PR DESCRIPTION
This PR fixes a bug with `setIfNotExists` where the client provided`ttl` is interpreted as `milliseconds` instead of `seconds`. Note that some clients might have noticed this already and treated this as a `feature not bug`, and their contract for the `ttl` they provide is going to break. We're probably okay with this since the API is fairly new in this SDK? The PR has two commits:

- [Commit](https://github.com/momentohq/client-sdk-javascript/pull/788/commits/9c052a5a8423e9851d418ea83f72d5de5dd16b6e) simply adds an integration test that sets the TTL to be `1000`, and calls `getItemTTL` to try and assert that the remaining TTL is `> 950 seconds`, and expectedly fails due to the bug.
- [Commit](https://github.com/momentohq/client-sdk-javascript/pull/788/commits/6eb25f00160d73377e25cb792a8404fd3bcb3ff3) fixes the bug and the CI goes green.


Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/447 
