### PR TITLE
 fix: setIfNotExists should interpret ttl as seconds rather than milliseconds

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -506,7 +506,7 @@ export class DataClient implements IDataClient {
       );
     }
     this.logger.trace(
-      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttl: ${
+      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
         ttl?.toString() ?? 'null'
       }`
     );
@@ -515,7 +515,7 @@ export class DataClient implements IDataClient {
       cacheName,
       this.convert(key),
       this.convert(value),
-      ttl || this.defaultTtlSeconds * 1000
+      ttl ? ttl * 1000 : this.defaultTtlSeconds * 1000
     );
     this.logger.trace(`'setIfNotExists' request result: ${result.toString()}`);
     return result;


### PR DESCRIPTION
- chore: add integration test that asserts the remaining ttl for setIfNotExists to be valid
- fix: setIfNotExists should interpret ttl as seconds rather than milliseconds
