### PR TITLE
chore: add integration test that asserts the remaining ttl for setIfNotExists to be valid

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/data-client.ts
@@ -506,7 +506,7 @@ export class DataClient implements IDataClient {
       );
     }
     this.logger.trace(
-      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttl: ${
+      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
         ttl?.toString() ?? 'null'
       }`
     );
@@ -515,7 +515,7 @@ export class DataClient implements IDataClient {
       cacheName,
       this.convert(key),
       this.convert(value),
-      ttl || this.defaultTtlSeconds * 1000
+      ttl ? ttl * 1000 : this.defaultTtlSeconds * 1000
     );
     this.logger.trace(`'setIfNotExists' request result: ${result.toString()}`);
     return result;

--- a/packages/client-sdk-web/src/internal/data-client.ts
+++ b/packages/client-sdk-web/src/internal/data-client.ts
@@ -318,7 +318,7 @@ export class DataClient<
       );
     }
     this.logger.trace(
-      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${field.toString()}, ttl: ${
+      `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${field.toString()}, ttlSeconds: ${
         ttl?.toString() ?? 'null'
       }`
     );
@@ -327,7 +327,7 @@ export class DataClient<
       cacheName,
       convertToB64String(key),
       convertToB64String(field),
-      ttl || this.defaultTtlSeconds * 1000
+      ttl ? ttl * 1000 : this.defaultTtlSeconds * 1000
     );
     this.logger.trace(`'setIfNotExists' request result: ${result.toString()}`);
     return result;


### PR DESCRIPTION
This PR fixes a bug with `setIfNotExists` where the client provided`ttl` is interpreted as `milliseconds` instead of `seconds`. Note that some clients might have noticed this already and treated this as a `feature not bug`, and their contract for the `ttl` they provide is going to break. We're probably okay with this since the API is fairly new in this SDK? The PR has two commits:

- [Commit](https://github.com/momentohq/client-sdk-javascript/pull/792/commits/2a8a6e42a0475da87bd62d5d5993f62769f4b3bb) simply adds an integration test that sets the TTL to be `1000`, and calls `getItemTTL` to try and assert that the remaining TTL is `> 950 seconds`, and expectedly fails due to the bug.
- [Commit](https://github.com/momentohq/client-sdk-javascript/pull/792/commits/f1bb3d01110ae007fdf6d2c5c10623d8cdac840a) fixes the bug and the CI goes green.


Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/447 