### PR TITLE
chore: update both TVM examples to vend disposable tokens

### DIFF
--- a/examples/nodejs/token-vending-machine/infrastructure/package-lock.json
+++ b/examples/nodejs/token-vending-machine/infrastructure/package-lock.json
@@ -2455,12 +2455,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2684,7 +2686,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "10.2.69",
@@ -3900,6 +3903,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -5103,6 +5107,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5545,6 +5550,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5769,6 +5775,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5783,6 +5790,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5793,7 +5801,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/config.ts
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/config.ts
@@ -1,36 +1,51 @@
-import {AllDataReadWrite, TopicRole, CacheRole, ExpiresIn, TokenScope, AllTopics, AllCaches, TokenScopes} from '@gomomento/sdk';
+import {
+  ExpiresIn,
+  AllTopics,
+  CacheRole,
+  TopicRole,
+  type DisposableTokenScope,
+} from "@gomomento/sdk";
 
 /**
- * Set the scope of permissions for your tokens. 
- * 
+ * First, set the scope of permissions for your tokens.
+ *
  * AllDataReadWrite provides read and write permissions to all of your caches:
- *    export const tokenPermissions: TokenScope =  AllDataReadWrite;
- * 
+ *    export const tokenPermissions: DisposableTokenScope =  AllDataReadWrite;
+ *
  * TokenScopes provides several functions that will return the permissions you
  * request for a given cache and topic name.
- *    export const tokenPermissions: TokenScope = TokenScopes.topicPublishSubscribe("default-cache", AllTopics);
- * 
+ *    export const tokenPermissions: DisposableTokenScope = TokenScopes.topicPublishSubscribe("your-cache-name", AllTopics);
+ *
  * You can also set it to allow subscriptions to topics in all caches if you prefer:
- *    export const tokenPermissions: TokenScope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
- * 
- * You may also provide a bespoke list of permissions for each cache and topic that you have:
- *    export const tokenPermissions: TokenScope =  {
+ *    export const tokenPermissions: DisposableTokenScope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
+ *
+ * You may also provide a bespoke list of permissions for each cache and topic that you have.
+ * The DisposableTokenScope will accept permissions of the type CachePermission, TopicPermission,
+ * or DisposableTokenCachePermission, as outlined below respectively:
+ *    export const tokenPermissions: DisposableTokenScope =  {
  *      permissions: [
  *        {
- *          role: CacheRole.ReadWrite | CacheRole.ReadOnly | CacheRole.WriteOnly, 
+ *          role: CacheRole.ReadWrite | CacheRole.ReadOnly | CacheRole.WriteOnly,
  *          cache: AllCaches | "your-cache-name"
  *        },
  *        {
- *          role: TopicRole.PublishSubscribe | TopicRole.SubscribeOnly | TopicRole.PublishOnly, 
+ *          role: TopicRole.PublishSubscribe | TopicRole.SubscribeOnly | TopicRole.PublishOnly,
  *          cache: AllCaches | "your-cache-name",
  *          topic: AllTopics | "your-topic-name"
- *        }
+ *        },
+ *        {
+ *          role: CacheRole.ReadWrite | CacheRole.ReadOnly | CacheRole.WriteOnly,
+ *          cache: AllCaches | "your-cache-name",
+ *          item: AllCacheItems | {key: "MyKey"}
+ *        },
  *      ]
  *    };
- * 
- * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#tokenscope-objects
+ *
+ * This example app generates diposable tokens by default so it uses the DisposableTokenScope
+ * to specify cache and topic permissions.
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#disposabletokenscope-objects
  */
-export const tokenPermissions: TokenScope = {
+export const tokenPermissions: DisposableTokenScope = {
   permissions: [
     {
       role: CacheRole.ReadWrite,
@@ -44,15 +59,17 @@ export const tokenPermissions: TokenScope = {
 ]};
 
 /**
- * Set the TTL for your tokens in terms of seconds, minutes, hours,  
- * days, or using epoch format. You may also set tokens to never expire.
- * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#generateauthtoken-api
+ * Second, set the TTL for your tokens in terms of seconds, minutes, hours,
+ * days, or using epoch format.
+ * This example app generates disposable tokens by default and disposable
+ * tokens must expire within 1 hour.
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#generatedisposabletoken-api
  */
 export const tokenExpiresIn: ExpiresIn = ExpiresIn.hours(1);
 
 /**
- * Set the authentication method for the token vending machine to protect against
- * unauthorized users. The available options are provided below.
+ * Third, set the authentication method for the token vending machine to protect 
+ * against unauthorized users. The available options are provided below.
  * 
  * Note: when using Amazon Cognito, you'll need to first sign into Cognito to get an ID
  * token that you'll include in your requests to the Token Vending Machine API. 

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/handler.ts
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/handler.ts
@@ -1,6 +1,6 @@
 import {APIGatewayProxyEvent, APIGatewayProxyEventHeaders, APIGatewayProxyResult} from 'aws-lambda';
 import {GetSecretValueCommand, SecretsManagerClient} from '@aws-sdk/client-secrets-manager';
-import {AllTopics, AuthClient, CredentialProvider, GenerateAuthToken, TokenScopes} from '@gomomento/sdk';
+import {AllTopics, AuthClient, CredentialProvider, GenerateDisposableToken, TokenScopes} from '@gomomento/sdk';
 import {tokenPermissions, tokenExpiresIn, authenticationMethod, AuthenticationMethod} from './config';
 
 const _secretsClient = new SecretsManagerClient({});
@@ -45,13 +45,13 @@ async function vendAuthToken(vendorAuthTokenSecretName: string, headers: APIGate
   let generateTokenResponse;
   if (authenticationMethod === AuthenticationMethod.AmazonCognito) {
     const cognitoUserTokenPermissions = determineCognitoUserTokenScope(headers);
-    generateTokenResponse = await momentoAuthClient.generateAuthToken(cognitoUserTokenPermissions, tokenExpiresIn);
+    generateTokenResponse = await momentoAuthClient.generateDisposableToken(cognitoUserTokenPermissions, tokenExpiresIn);
   }
   else {
-    generateTokenResponse = await momentoAuthClient.generateAuthToken(tokenPermissions, tokenExpiresIn);
+    generateTokenResponse = await momentoAuthClient.generateDisposableToken(tokenPermissions, tokenExpiresIn);
   }
 
-  if (generateTokenResponse instanceof GenerateAuthToken.Success) {
+  if (generateTokenResponse instanceof GenerateDisposableToken.Success) {
     return {
       authToken: generateTokenResponse.authToken,
       expiresAt: generateTokenResponse.expiresAt.epoch(),

--- a/examples/web/nextjs-chat/src/app/api/momento/token/config.ts
+++ b/examples/web/nextjs-chat/src/app/api/momento/token/config.ts
@@ -1,26 +1,28 @@
 import {
   ExpiresIn,
-  type TokenScope,
   AllTopics,
   AllCaches,
   TokenScopes,
+  type DisposableTokenScope,
 } from "@gomomento/sdk";
 
 /**
  * First, set the scope of permissions for your tokens.
  *
  * AllDataReadWrite provides read and write permissions to all of your caches:
- *    export const tokenPermissions: TokenScope =  AllDataReadWrite;
+ *    export const tokenPermissions: DisposableTokenScope =  AllDataReadWrite;
  *
  * TokenScopes provides several functions that will return the permissions you
  * request for a given cache and topic name.
- *    export const tokenPermissions: TokenScope = TokenScopes.topicPublishSubscribe("your-cache-name", AllTopics);
+ *    export const tokenPermissions: DisposableTokenScope = TokenScopes.topicPublishSubscribe("your-cache-name", AllTopics);
  *
  * You can also set it to allow subscriptions to topics in all caches if you prefer:
- *    export const tokenPermissions: TokenScope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
+ *    export const tokenPermissions: DisposableTokenScope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
  *
- * You may also provide a bespoke list of permissions for each cache and topic that you have:
- *    export const tokenPermissions: TokenScope =  {
+ * You may also provide a bespoke list of permissions for each cache and topic that you have.
+ * The DisposableTokenScope will accept permissions of the type CachePermission, TopicPermission,
+ * or DisposableTokenCachePermission, as outlined below respectively:
+ *    export const tokenPermissions: DisposableTokenScope =  {
  *      permissions: [
  *        {
  *          role: CacheRole.ReadWrite | CacheRole.ReadOnly | CacheRole.WriteOnly,
@@ -30,21 +32,28 @@ import {
  *          role: TopicRole.PublishSubscribe | TopicRole.SubscribeOnly | TopicRole.PublishOnly,
  *          cache: AllCaches | "your-cache-name",
  *          topic: AllTopics | "your-topic-name"
- *        }
+ *        },
+ *        {
+ *          role: CacheRole.ReadWrite | CacheRole.ReadOnly | CacheRole.WriteOnly,
+ *          cache: AllCaches | "your-cache-name",
+ *          item: AllCacheItems | {key: "MyKey"}
+ *        },
  *      ]
  *    };
  *
- * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#tokenscope-objects
+ * This example app generates diposable tokens by default so it uses the DisposableTokenScope
+ * to specify cache and topic permissions.
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#disposabletokenscope-objects
  */
-export const tokenPermissions: TokenScope = TokenScopes.topicPublishSubscribe(
-  AllCaches,
-  AllTopics,
-);
+export const tokenPermissions: DisposableTokenScope =
+  TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
 
 /**
  * Second, set the TTL for your tokens in terms of seconds, minutes, hours,
- * days, or using epoch format. You may also set tokens to never expire.
- * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#generateauthtoken-api
+ * days, or using epoch format.
+ * This example app generates disposable tokens by default and disposable
+ * tokens must expire within 1 hour.
+ * More information here: https://docs.momentohq.com/develop/api-reference/auth-tokens#generatedisposabletoken-api
  */
 export const tokenExpiresIn: ExpiresIn = ExpiresIn.minutes(30);
 

--- a/examples/web/nextjs-chat/src/app/api/momento/token/route.ts
+++ b/examples/web/nextjs-chat/src/app/api/momento/token/route.ts
@@ -1,7 +1,7 @@
 import {
   AuthClient,
   CredentialProvider,
-  GenerateAuthToken,
+  GenerateDisposableToken,
 } from "@gomomento/sdk";
 import {
   tokenPermissions,
@@ -32,20 +32,25 @@ export async function GET(_request: Request) {
       throw new Error("Unimplemented authentication method");
   }
 
-  if (generateAuthTokenResponse instanceof GenerateAuthToken.Success) {
+  if (generateAuthTokenResponse instanceof GenerateDisposableToken.Success) {
     return new Response(generateAuthTokenResponse.authToken, {
       headers: {
         "Cache-Control": "no-cache",
       },
     });
-  } else if (generateAuthTokenResponse instanceof GenerateAuthToken.Error) {
+  } else if (
+    generateAuthTokenResponse instanceof GenerateDisposableToken.Error
+  ) {
     throw new Error(generateAuthTokenResponse.message());
   }
   throw new Error("Unable to get token from momento");
 }
 
 async function fetchTokenWithOpenAuth() {
-  return await authClient.generateAuthToken(tokenPermissions, tokenExpiresIn);
+  return await authClient.generateDisposableToken(
+    tokenPermissions,
+    tokenExpiresIn,
+  );
 }
 
 async function fetchTokenWithAuthCredentials() {
@@ -55,5 +60,8 @@ async function fetchTokenWithAuthCredentials() {
     throw new Error("Unauthorized to request Momento token");
   }
 
-  return await authClient.generateAuthToken(tokenPermissions, tokenExpiresIn);
+  return await authClient.generateDisposableToken(
+    tokenPermissions,
+    tokenExpiresIn,
+  );
 }

--- a/examples/web/vite-chat-app/src/App.tsx
+++ b/examples/web/vite-chat-app/src/App.tsx
@@ -5,7 +5,7 @@ import ChatRoom from "./components/chat-room";
 export default function Home() {
   const [topic, setTopic] = useState("");
   const [username, setUsername] = useState("");
-  const [cognitoUser, setCognitoUser] = useState("ReadOnly");
+  const [cognitoUser, setCognitoUser] = useState(import.meta.env.VITE_TOKEN_VENDING_MACHINE_AUTH_TYPE === "cognito" ? "ReadOnly" : "ReadWrite");
   const [chatRoomSelected, setChatRoomSelected] = useState(false);
   const [usernameSelected, setUsernameSelected] = useState(false);
   const [cognitoUserSelected, setCognitoUserSelected] = useState(false);


### PR DESCRIPTION
Addresses [#422](https://github.com/momentohq/dev-eco-issue-tracker/issues/422). Updates both static and dynamic token vending machine examples to use generateDisposableToken instead of generateAuthToken.

Plus a bug fix for the Vite chat app to allow ReadWrite access to users if they haven't set the auth method to "cognito".