### PR TITLE
chore: rename integration test variables

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/client-timeout.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/client-timeout.test.ts
@@ -13,7 +13,7 @@ import {
   WithCache,
 } from './integration-setup';
 
-const {Momento} = SetupIntegrationTest();
+const {cacheClient} = SetupIntegrationTest();
 
 // TODO: these tests are only applicable to the nodejs CacheClient at the moment. Once the
 //  Web SDK supports the full Configuration interface, these tests should be moved into the
@@ -21,7 +21,7 @@ const {Momento} = SetupIntegrationTest();
 describe('client timeout tests', () => {
   it('should timeout on a set request that exceeds specified timeout', async () => {
     const cacheName = testCacheName();
-    const defaultTimeoutClient = Momento;
+    const defaultTimeoutClient = cacheClient;
     const shortTimeoutTransportStrategy = integrationTestCacheClientProps()
       .configuration.getTransportStrategy()
       .withClientTimeoutMillis(1);
@@ -52,7 +52,7 @@ describe('client timeout tests', () => {
 
   it('should timeout on a setIfNotExists request that exceeds specified timeout', async () => {
     const cacheName = testCacheName();
-    const defaultTimeoutClient = Momento;
+    const defaultTimeoutClient = cacheClient;
     const shortTimeoutTransportStrategy = integrationTestCacheClientProps()
       .configuration.getTransportStrategy()
       .withClientTimeoutMillis(1);

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -111,8 +111,8 @@ function momentoVectorClientForTesting(): PreviewVectorIndexClient {
 }
 
 export function SetupIntegrationTest(): {
-  Momento: CacheClient;
-  IntegrationTestCacheName: string;
+  cacheClient: CacheClient;
+  integrationTestCacheName: string;
 } {
   const cacheName = testCacheName();
 
@@ -136,17 +136,21 @@ export function SetupIntegrationTest(): {
   });
 
   const client = momentoClientForTesting();
-  return {Momento: client, IntegrationTestCacheName: cacheName};
+  return {cacheClient: client, integrationTestCacheName: cacheName};
 }
 
 export function SetupTopicIntegrationTest(): {
   topicClient: TopicClient;
-  Momento: CacheClient;
-  IntegrationTestCacheName: string;
+  cacheClient: CacheClient;
+  integrationTestCacheName: string;
 } {
-  const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+  const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
   const topicClient = momentoTopicClientForTesting();
-  return {topicClient, Momento, IntegrationTestCacheName};
+  return {
+    topicClient,
+    cacheClient: cacheClient,
+    integrationTestCacheName: integrationTestCacheName,
+  };
 }
 
 export function SetupVectorIntegrationTest(): {

--- a/packages/client-sdk-nodejs/test/integration/shared/create-delete-list-cache.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/create-delete-list-cache.test.ts
@@ -1,6 +1,6 @@
 import {runCreateDeleteListCacheTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento} = SetupIntegrationTest();
+const {cacheClient} = SetupIntegrationTest();
 
-runCreateDeleteListCacheTests(Momento);
+runCreateDeleteListCacheTests(cacheClient);

--- a/packages/client-sdk-nodejs/test/integration/shared/dictionary.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/dictionary.test.ts
@@ -1,6 +1,6 @@
 import {runDictionaryTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runDictionaryTests(Momento, IntegrationTestCacheName);
+runDictionaryTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/get-set-delete.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/get-set-delete.test.ts
@@ -1,6 +1,6 @@
 import {runGetSetDeleteTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runGetSetDeleteTests(Momento, IntegrationTestCacheName);
+runGetSetDeleteTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/item-get-ttl.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/item-get-ttl.test.ts
@@ -1,6 +1,6 @@
 import {SetupIntegrationTest} from '../integration-setup';
 import {runItemGetTtlTest} from '@gomomento/common-integration-tests/dist/src/item-get-ttl';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runItemGetTtlTest(Momento, IntegrationTestCacheName);
+runItemGetTtlTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/item-get-type.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/item-get-type.test.ts
@@ -1,6 +1,6 @@
 import {SetupIntegrationTest} from '../integration-setup';
 import {runItemGetTypeTest} from '@gomomento/common-integration-tests';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runItemGetTypeTest(Momento, IntegrationTestCacheName);
+runItemGetTypeTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/keys-exist.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/keys-exist.test.ts
@@ -1,6 +1,6 @@
 import {runKeysExistTest} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runKeysExistTest(Momento, IntegrationTestCacheName);
+runKeysExistTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/list.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/list.test.ts
@@ -1,6 +1,6 @@
 import {runListTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runListTests(Momento, IntegrationTestCacheName);
+runListTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/set.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/set.test.ts
@@ -1,6 +1,6 @@
 import {runSetTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runSetTests(Momento, IntegrationTestCacheName);
+runSetTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/sorted-set.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/sorted-set.test.ts
@@ -1,6 +1,6 @@
 import {runSortedSetTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runSortedSetTests(Momento, IntegrationTestCacheName);
+runSortedSetTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/topic-client.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/topic-client.test.ts
@@ -1,6 +1,6 @@
 import {runTopicClientTests} from '@gomomento/common-integration-tests';
 import {SetupTopicIntegrationTest} from '../integration-setup';
 
-const {topicClient, Momento, IntegrationTestCacheName} =
+const {topicClient, cacheClient, integrationTestCacheName} =
   SetupTopicIntegrationTest();
-runTopicClientTests(topicClient, Momento, IntegrationTestCacheName);
+runTopicClientTests(topicClient, cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/shared/update-ttl.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/update-ttl.test.ts
@@ -1,6 +1,6 @@
 import {runUpdateTtlTest} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runUpdateTtlTest(Momento, IntegrationTestCacheName);
+runUpdateTtlTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-nodejs/test/integration/signing-keys.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/signing-keys.test.ts
@@ -5,13 +5,13 @@ import {
 } from '@gomomento/sdk-core';
 import {SetupIntegrationTest} from './integration-setup';
 
-const {Momento} = SetupIntegrationTest();
+const {cacheClient} = SetupIntegrationTest();
 
 describe('Signing keys', () => {
   it('should create, list, and revoke a signing key', async () => {
-    const createSigningKeyResponse = await Momento.createSigningKey(30);
+    const createSigningKeyResponse = await cacheClient.createSigningKey(30);
     expect(createSigningKeyResponse).toBeInstanceOf(CreateSigningKey.Success);
-    let listSigningKeysResponse = await Momento.listSigningKeys();
+    let listSigningKeysResponse = await cacheClient.listSigningKeys();
     expect(listSigningKeysResponse).toBeInstanceOf(ListSigningKeys.Success);
     let signingKeys = (
       listSigningKeysResponse as ListSigningKeys.Success
@@ -27,11 +27,11 @@ describe('Signing keys', () => {
             (createSigningKeyResponse as CreateSigningKey.Success).getKeyId()
         )
     ).toEqual(true);
-    const revokeResponse = await Momento.revokeSigningKey(
+    const revokeResponse = await cacheClient.revokeSigningKey(
       (createSigningKeyResponse as CreateSigningKey.Success).getKeyId()
     );
     expect(revokeResponse).toBeInstanceOf(RevokeSigningKey.Success);
-    listSigningKeysResponse = await Momento.listSigningKeys();
+    listSigningKeysResponse = await cacheClient.listSigningKeys();
     expect(listSigningKeysResponse).toBeInstanceOf(ListSigningKeys.Success);
     signingKeys = (
       listSigningKeysResponse as ListSigningKeys.Success

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -99,8 +99,8 @@ function momentoVectorClientForTesting(): PreviewVectorIndexClient {
 }
 
 export function SetupIntegrationTest(): {
-  Momento: CacheClient;
-  IntegrationTestCacheName: string;
+  cacheClient: CacheClient;
+  integrationTestCacheName: string;
 } {
   const cacheName = testCacheName();
 
@@ -121,17 +121,21 @@ export function SetupIntegrationTest(): {
   });
 
   const client = momentoClientForTesting();
-  return {Momento: client, IntegrationTestCacheName: cacheName};
+  return {cacheClient: client, integrationTestCacheName: cacheName};
 }
 
 export function SetupTopicIntegrationTest(): {
   topicClient: ITopicClient;
-  Momento: CacheClient;
-  IntegrationTestCacheName: string;
+  cacheClient: CacheClient;
+  integrationTestCacheName: string;
 } {
-  const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+  const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
   const topicClient = momentoTopicClientForTesting();
-  return {topicClient, Momento, IntegrationTestCacheName};
+  return {
+    topicClient,
+    cacheClient: cacheClient,
+    integrationTestCacheName: integrationTestCacheName,
+  };
 }
 
 export function SetupVectorIntegrationTest(): {

--- a/packages/client-sdk-web/test/integration/shared/create-delete-list-cache.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/create-delete-list-cache.test.ts
@@ -1,6 +1,6 @@
 import {runCreateDeleteListCacheTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento} = SetupIntegrationTest();
+const {cacheClient} = SetupIntegrationTest();
 
-runCreateDeleteListCacheTests(Momento);
+runCreateDeleteListCacheTests(cacheClient);

--- a/packages/client-sdk-web/test/integration/shared/dictionary.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/dictionary.test.ts
@@ -1,6 +1,6 @@
 import {runDictionaryTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runDictionaryTests(Momento, IntegrationTestCacheName);
+runDictionaryTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/get-set-delete.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/get-set-delete.test.ts
@@ -1,6 +1,6 @@
 import {runGetSetDeleteTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runGetSetDeleteTests(Momento, IntegrationTestCacheName);
+runGetSetDeleteTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/item-get-ttl.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/item-get-ttl.test.ts
@@ -1,6 +1,6 @@
 import {SetupIntegrationTest} from '../integration-setup';
 import {runItemGetTtlTest} from '@gomomento/common-integration-tests/dist/src/item-get-ttl';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runItemGetTtlTest(Momento, IntegrationTestCacheName);
+runItemGetTtlTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/item-get-type.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/item-get-type.test.ts
@@ -1,6 +1,6 @@
 import {SetupIntegrationTest} from '../integration-setup';
 import {runItemGetTypeTest} from '@gomomento/common-integration-tests';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runItemGetTypeTest(Momento, IntegrationTestCacheName);
+runItemGetTypeTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/keys-exist.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/keys-exist.test.ts
@@ -1,6 +1,6 @@
 import {runKeysExistTest} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runKeysExistTest(Momento, IntegrationTestCacheName);
+runKeysExistTest(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/list.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/list.test.ts
@@ -1,6 +1,6 @@
 import {runListTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runListTests(Momento, IntegrationTestCacheName);
+runListTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/set.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/set.test.ts
@@ -1,6 +1,6 @@
 import {runSetTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runSetTests(Momento, IntegrationTestCacheName);
+runSetTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/sorted-set.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/sorted-set.test.ts
@@ -1,6 +1,6 @@
 import {runSortedSetTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runSortedSetTests(Momento, IntegrationTestCacheName);
+runSortedSetTests(cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/topic-client.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/topic-client.test.ts
@@ -1,6 +1,6 @@
 import {runTopicClientTests} from '@gomomento/common-integration-tests';
 import {SetupTopicIntegrationTest} from '../integration-setup';
 
-const {topicClient, Momento, IntegrationTestCacheName} =
+const {topicClient, cacheClient, integrationTestCacheName} =
   SetupTopicIntegrationTest();
-runTopicClientTests(topicClient, Momento, IntegrationTestCacheName);
+runTopicClientTests(topicClient, cacheClient, integrationTestCacheName);

--- a/packages/client-sdk-web/test/integration/shared/update-ttl.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/update-ttl.test.ts
@@ -1,6 +1,6 @@
 import {runUpdateTtlTest} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {Momento, IntegrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-runUpdateTtlTest(Momento, IntegrationTestCacheName);
+runUpdateTtlTest(cacheClient, integrationTestCacheName);

--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -17,19 +17,19 @@ import {
   CacheSet,
 } from '@gomomento/sdk-core';
 
-export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
+export function runCreateDeleteListCacheTests(cacheClient: ICacheClient) {
   describe('create/delete cache', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.createCache(props.cacheName);
+      return cacheClient.createCache(props.cacheName);
     });
 
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.deleteCache(props.cacheName);
+      return cacheClient.deleteCache(props.cacheName);
     });
 
     it('should return NotFoundError if deleting a non-existent cache', async () => {
       const cacheName = testCacheName();
-      const deleteResponse = await Momento.deleteCache(cacheName);
+      const deleteResponse = await cacheClient.deleteCache(cacheName);
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(DeleteCache.Error);
       }, `expected ERROR but got ${deleteResponse.toString()}`);
@@ -42,16 +42,16 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
 
     it('should return AlreadyExists response if trying to create a cache that already exists', async () => {
       const cacheName = testCacheName();
-      await WithCache(Momento, cacheName, async () => {
-        const createResponse = await Momento.createCache(cacheName);
+      await WithCache(cacheClient, cacheName, async () => {
+        const createResponse = await cacheClient.createCache(cacheName);
         expect(createResponse).toBeInstanceOf(CreateCache.AlreadyExists);
       });
     });
 
     it('should create 1 cache and list the created cache', async () => {
       const cacheName = testCacheName();
-      await WithCache(Momento, cacheName, async () => {
-        const listResponse = await Momento.listCaches();
+      await WithCache(cacheClient, cacheName, async () => {
+        const listResponse = await cacheClient.listCaches();
         expectWithMessage(() => {
           expect(listResponse).toBeInstanceOf(ListCaches.Success);
         }, `expected SUCCESS but got ${listResponse.toString()}`);
@@ -78,12 +78,12 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
 
   describe('flush cache', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.flushCache(props.cacheName);
+      return cacheClient.flushCache(props.cacheName);
     });
 
     it('should return NotFoundError if flushing a non-existent cache', async () => {
       const cacheName = testCacheName();
-      const flushResponse = await Momento.flushCache(cacheName);
+      const flushResponse = await cacheClient.flushCache(cacheName);
       expectWithMessage(() => {
         expect(flushResponse).toBeInstanceOf(CacheFlush.Error);
       }, `expected ERROR but got ${flushResponse.toString()}`);
@@ -96,8 +96,8 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
 
     it('should return success while flushing empty cache', async () => {
       const cacheName = testCacheName();
-      await WithCache(Momento, cacheName, async () => {
-        const flushResponse = await Momento.flushCache(cacheName);
+      await WithCache(cacheClient, cacheName, async () => {
+        const flushResponse = await cacheClient.flushCache(cacheName);
         expectWithMessage(() => {
           expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
         }, `expected SUCCESS but got ${flushResponse.toString()}`);
@@ -110,21 +110,21 @@ export function runCreateDeleteListCacheTests(Momento: ICacheClient) {
       const key2 = v4();
       const value1 = v4();
       const value2 = v4();
-      await WithCache(Momento, cacheName, async () => {
-        const setResponse1 = await Momento.set(cacheName, key1, value1);
+      await WithCache(cacheClient, cacheName, async () => {
+        const setResponse1 = await cacheClient.set(cacheName, key1, value1);
         expectWithMessage(() => {
           expect(setResponse1).toBeInstanceOf(CacheSet.Success);
         }, `expected SUCCESS but got ${setResponse1.toString()}`);
-        const setResponse2 = await Momento.set(cacheName, key2, value2);
+        const setResponse2 = await cacheClient.set(cacheName, key2, value2);
         expectWithMessage(() => {
           expect(setResponse2).toBeInstanceOf(CacheSet.Success);
         }, `expected SUCCESS but got ${setResponse2.toString()}`);
-        const flushResponse = await Momento.flushCache(cacheName);
+        const flushResponse = await cacheClient.flushCache(cacheName);
         expectWithMessage(() => {
           expect(flushResponse).toBeInstanceOf(CacheFlush.Success);
         }, `expected SUCCESS but got ${flushResponse.toString()}`);
-        const getResponse1 = await Momento.get(cacheName, key1);
-        const getResponse2 = await Momento.get(cacheName, key2);
+        const getResponse1 = await cacheClient.get(cacheName, key1);
+        const getResponse2 = await cacheClient.get(cacheName, key2);
         expectWithMessage(() => {
           expect(getResponse1).toBeInstanceOf(CacheGet.Miss);
         }, `expected MISS but got ${getResponse1.toString()}`);

--- a/packages/common-integration-tests/src/dictionary.ts
+++ b/packages/common-integration-tests/src/dictionary.ts
@@ -32,8 +32,8 @@ import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
 
 export function runDictionaryTests(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('Integration tests for dictionary operations', () => {
     const itBehavesLikeItValidates = (
@@ -49,7 +49,7 @@ export function runDictionaryTests(
 
       it('validates its dictionary name', async () => {
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: '  ',
           field: v4(),
         });
@@ -65,7 +65,7 @@ export function runDictionaryTests(
     ) => {
       it('misses when the dictionary does not exist', async () => {
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: v4(),
           field: v4(),
         });
@@ -81,8 +81,8 @@ export function runDictionaryTests(
         const dictionaryName = v4();
 
         // Make sure the dictionary exists.
-        const setResponse = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const setResponse = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           v4(),
           v4()
@@ -92,7 +92,7 @@ export function runDictionaryTests(
         }, `expected SUCCESS but got ${setResponse.toString()}`);
 
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: v4(),
         });
@@ -105,8 +105,8 @@ export function runDictionaryTests(
         const fieldName = new TextEncoder().encode(v4());
 
         // Make sure the dictionary exists.
-        const setResponse = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const setResponse = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           v4(),
           v4()
@@ -116,7 +116,7 @@ export function runDictionaryTests(
         }, `expected SUCCESS but got ${setResponse.toString()}`);
 
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: fieldName,
         });
@@ -136,7 +136,7 @@ export function runDictionaryTests(
         const timeout = 1;
 
         let changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: field,
           value: 'value1',
@@ -145,7 +145,7 @@ export function runDictionaryTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
 
         changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: field,
           value: 'value2',
@@ -154,8 +154,8 @@ export function runDictionaryTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
         await sleep(timeout * 1000);
 
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -170,7 +170,7 @@ export function runDictionaryTests(
         const timeout = 1;
 
         let changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: field,
           value: 'value1',
@@ -179,7 +179,7 @@ export function runDictionaryTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
 
         changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           dictionaryName: dictionaryName,
           field: field,
           value: 'value2',
@@ -188,8 +188,8 @@ export function runDictionaryTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
         await sleep(timeout * 1000);
 
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -201,7 +201,10 @@ export function runDictionaryTests(
 
     describe('#dictionaryFetch', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryFetch(props.cacheName, props.dictionaryName);
+        return cacheClient.dictionaryFetch(
+          props.cacheName,
+          props.dictionaryName
+        );
       };
 
       itBehavesLikeItValidates(responder);
@@ -209,14 +212,14 @@ export function runDictionaryTests(
 
       it('should return expected toString value with dictionaryFetch', async () => {
         const dictionaryName = v4();
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           'a',
           'b'
         );
-        const response = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -234,8 +237,8 @@ export function runDictionaryTests(
         const field2 = 'bar';
         const value2 = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -243,8 +246,8 @@ export function runDictionaryTests(
           ])
         );
 
-        const response = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -296,8 +299,8 @@ export function runDictionaryTests(
         const field2 = uint8ArrayForTest(v4());
         const value2 = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -305,8 +308,8 @@ export function runDictionaryTests(
           ])
         );
 
-        const response = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -326,22 +329,22 @@ export function runDictionaryTests(
 
       it('should do nothing with dictionaryFetch if dictionary does not exist', async () => {
         const dictionaryName = v4();
-        let fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Miss);
         }, `expected MISS but got ${fetchResponse.toString()}`);
-        const deleteResponse = await Momento.delete(
-          IntegrationTestCacheName,
+        const deleteResponse = await cacheClient.delete(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
           expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
         }, `expected SUCCESS but got ${fetchResponse.toString()}`);
-        fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -351,8 +354,8 @@ export function runDictionaryTests(
 
       it('should delete with dictionaryFetch if dictionary exists', async () => {
         const dictionaryName = v4();
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [v4(), v4()],
@@ -361,24 +364,24 @@ export function runDictionaryTests(
           ])
         );
 
-        let fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
         }, `expected HIT but got ${fetchResponse.toString()}`);
 
-        const deleteResponse = await Momento.delete(
-          IntegrationTestCacheName,
+        const deleteResponse = await cacheClient.delete(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
           expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
         }, `expected SUCCESS but got ${fetchResponse.toString()}`);
 
-        fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -388,7 +391,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryFetch via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {a: 'A', b: 'B'});
 
@@ -403,14 +406,14 @@ export function runDictionaryTests(
       it('should support accessing value for CacheDictionaryFetch.Hit without instanceof check', async () => {
         const dictionaryName = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {a: 'A', b: 'B'}
         );
 
-        let fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -425,8 +428,8 @@ export function runDictionaryTests(
         expect(hit.value()).toEqual(expectedValue);
         expect(hit.valueRecord()).toEqual(expectedValue);
 
-        fetchResponse = await Momento.dictionaryFetch(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.dictionaryFetch(
+          integrationTestCacheName,
           v4()
         );
 
@@ -439,7 +442,7 @@ export function runDictionaryTests(
 
     describe('#dictionaryGetField', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryGetField(
+        return cacheClient.dictionaryGetField(
           props.cacheName,
           props.dictionaryName,
           v4()
@@ -455,8 +458,8 @@ export function runDictionaryTests(
         const field = v4();
         const value = v4();
 
-        const response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -465,8 +468,8 @@ export function runDictionaryTests(
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -480,7 +483,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryGetField via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -498,8 +501,8 @@ export function runDictionaryTests(
       it('should support accessing value for CacheDictionaryGetField.Hit without instanceof check', async () => {
         const dictionaryName = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {
             a: 'A',
@@ -507,8 +510,8 @@ export function runDictionaryTests(
           }
         );
 
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           'b'
         );
@@ -522,8 +525,8 @@ export function runDictionaryTests(
         expect(hit.valueString()).toEqual('B');
         expect(hit.value()).toEqual('B');
 
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           v4(),
           'foo'
         );
@@ -536,7 +539,7 @@ export function runDictionaryTests(
 
     describe('#dictionaryGetFields', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryGetFields(
+        return cacheClient.dictionaryGetFields(
           props.cacheName,
           props.dictionaryName,
           [props.field] as string[] | Uint8Array[]
@@ -548,20 +551,20 @@ export function runDictionaryTests(
 
       it('return expected toString value', async () => {
         const dictionaryName = v4();
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           'a',
           'b'
         );
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           'c',
           'd'
         );
-        const getResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           ['a', 'c']
         );
@@ -580,8 +583,8 @@ export function runDictionaryTests(
         const field2 = 'bar';
         const value2 = v4();
         const field3 = 'baz';
-        let response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        let response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field1,
           value1
@@ -589,8 +592,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field2,
           value2
@@ -598,8 +601,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        const getResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           [field1, field2, field3]
         );
@@ -677,8 +680,8 @@ export function runDictionaryTests(
         const field2 = uint8ArrayForTest(v4());
         const value2 = uint8ArrayForTest(v4());
         const field3 = uint8ArrayForTest(v4());
-        let response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        let response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field1,
           value1
@@ -686,8 +689,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field2,
           value2
@@ -695,8 +698,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        const getResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           [field1, field2, field3]
         );
@@ -742,7 +745,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryGetFields via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -764,8 +767,8 @@ export function runDictionaryTests(
       it('should support accessing value for CacheDictionaryGetFields.Hit without instanceof check', async () => {
         const dictionaryName = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {
             a: 'A',
@@ -774,8 +777,8 @@ export function runDictionaryTests(
           }
         );
 
-        let getResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           ['a', 'c']
         );
@@ -791,8 +794,8 @@ export function runDictionaryTests(
         expect(hit.value()).toEqual(expectedResult);
         expect(hit.valueRecord()).toEqual(expectedResult);
 
-        getResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           v4(),
           ['foo', 'bar']
         );
@@ -806,7 +809,7 @@ export function runDictionaryTests(
 
     describe('#dictionaryIncrement', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryIncrement(
+        return cacheClient.dictionaryIncrement(
           props.cacheName,
           props.dictionaryName,
           props.field
@@ -814,7 +817,7 @@ export function runDictionaryTests(
       };
 
       const changeResponder = (props: ValidateDictionaryChangerProps) => {
-        return Momento.dictionaryIncrement(
+        return cacheClient.dictionaryIncrement(
           props.cacheName,
           props.dictionaryName,
           props.field,
@@ -829,8 +832,8 @@ export function runDictionaryTests(
       it('increments from 0 to expected amount with string field', async () => {
         const dictionaryName = v4();
         const field = v4();
-        let incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        let incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           1
@@ -844,8 +847,8 @@ export function runDictionaryTests(
           incrementResponse as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(1);
 
-        incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           41
@@ -859,8 +862,8 @@ export function runDictionaryTests(
         expect(successResponse.valueNumber()).toEqual(42);
         expect(successResponse.toString()).toEqual('Success: value: 42');
 
-        incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           -1042
@@ -873,8 +876,8 @@ export function runDictionaryTests(
         successResponse = incrementResponse as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(-1000);
 
-        const getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -888,8 +891,8 @@ export function runDictionaryTests(
       it('increments from 0 to expected amount with Uint8Array field', async () => {
         const dictionaryName = v4();
         const field = new TextEncoder().encode(v4());
-        let incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        let incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           1
@@ -903,8 +906,8 @@ export function runDictionaryTests(
           incrementResponse as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(1);
 
-        incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           41
@@ -918,8 +921,8 @@ export function runDictionaryTests(
         expect(successResponse.valueNumber()).toEqual(42);
         expect(successResponse.toString()).toEqual('Success: value: 42');
 
-        incrementResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        incrementResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           -1042
@@ -932,8 +935,8 @@ export function runDictionaryTests(
         successResponse = incrementResponse as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(-1000);
 
-        const getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -948,14 +951,14 @@ export function runDictionaryTests(
         const dictionaryName = v4();
         const field = v4();
 
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           '10'
         );
-        let response = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           0
@@ -966,8 +969,8 @@ export function runDictionaryTests(
         let successResponse = response as CacheDictionaryIncrement.Success;
         expect(successResponse.valueNumber()).toEqual(10);
 
-        response = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        response = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           90
@@ -979,14 +982,14 @@ export function runDictionaryTests(
         expect(successResponse.valueNumber()).toEqual(100);
 
         // Reset field
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           '0'
         );
-        response = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        response = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field,
           0
@@ -1002,14 +1005,14 @@ export function runDictionaryTests(
         const dictionaryName = v4();
         const field = v4();
 
-        await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           'abcxyz'
         );
-        const response = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1024,7 +1027,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryIncrement via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -1042,8 +1045,8 @@ export function runDictionaryTests(
       it('should support accessing value for CacheDictionaryIncrement.Success without instanceof check', async () => {
         const dictionaryName = v4();
 
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {
             a: 'A',
@@ -1051,8 +1054,8 @@ export function runDictionaryTests(
           }
         );
 
-        const successResponse = await Momento.dictionaryIncrement(
-          IntegrationTestCacheName,
+        const successResponse = await cacheClient.dictionaryIncrement(
+          integrationTestCacheName,
           dictionaryName,
           'b'
         );
@@ -1071,7 +1074,7 @@ export function runDictionaryTests(
 
     describe('#dictionaryRemoveField', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryRemoveField(
+        return cacheClient.dictionaryRemoveField(
           props.cacheName,
           props.dictionaryName,
           props.field
@@ -1086,16 +1089,16 @@ export function runDictionaryTests(
         const value = new TextEncoder().encode(v4());
 
         // When the field does not exist.
-        let getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
         expectWithMessage(() => {
           expect(getFieldResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
         }, `expected MISS but got ${getFieldResponse.toString()}`);
-        let removeFieldResponse = await Momento.dictionaryRemoveField(
-          IntegrationTestCacheName,
+        let removeFieldResponse = await cacheClient.dictionaryRemoveField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1104,8 +1107,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1114,8 +1117,8 @@ export function runDictionaryTests(
         }, `expected MISS but got ${getFieldResponse.toString()}`);
 
         // When the field exists.
-        const setFieldResponse = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const setFieldResponse = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -1125,16 +1128,16 @@ export function runDictionaryTests(
             CacheDictionarySetField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
         expectWithMessage(() => {
           expect(getFieldResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
         }, `expected HIT but got ${getFieldResponse.toString()}`);
-        removeFieldResponse = await Momento.dictionaryRemoveField(
-          IntegrationTestCacheName,
+        removeFieldResponse = await cacheClient.dictionaryRemoveField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1143,8 +1146,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1159,16 +1162,16 @@ export function runDictionaryTests(
         const value = v4();
 
         // When the field does not exist.
-        let getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
         expectWithMessage(() => {
           expect(getFieldResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
         }, `expected MISS but got ${getFieldResponse.toString()}`);
-        let removeFieldResponse = await Momento.dictionaryRemoveField(
-          IntegrationTestCacheName,
+        let removeFieldResponse = await cacheClient.dictionaryRemoveField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1177,8 +1180,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1187,8 +1190,8 @@ export function runDictionaryTests(
         }, `expected MISS but got ${getFieldResponse.toString()}`);
 
         // When the field exists.
-        const setFieldResponse = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const setFieldResponse = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -1198,16 +1201,16 @@ export function runDictionaryTests(
             CacheDictionarySetField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
         expectWithMessage(() => {
           expect(getFieldResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
         }, `expected HIT but got ${getFieldResponse.toString()}`);
-        removeFieldResponse = await Momento.dictionaryRemoveField(
-          IntegrationTestCacheName,
+        removeFieldResponse = await cacheClient.dictionaryRemoveField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1216,8 +1219,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveField.Success
           );
         }, `expected SUCCESS but got ${getFieldResponse.toString()}`);
-        getFieldResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getFieldResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1228,7 +1231,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryRemoveField via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -1253,7 +1256,7 @@ export function runDictionaryTests(
 
     describe('#dictionaryRemoveFields', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionaryRemoveFields(
+        return cacheClient.dictionaryRemoveFields(
           props.cacheName,
           props.dictionaryName,
           [props.field] as string[] | Uint8Array[]
@@ -1274,8 +1277,8 @@ export function runDictionaryTests(
         ]);
 
         // When the fields do not exist.
-        let getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        let getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1284,8 +1287,8 @@ export function runDictionaryTests(
             CacheDictionaryGetFields.Miss
           );
         }, `expected MISS but got ${getFieldsResponse.toString()}`);
-        let removeFieldsResponse = await Momento.dictionaryRemoveFields(
-          IntegrationTestCacheName,
+        let removeFieldsResponse = await cacheClient.dictionaryRemoveFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1294,8 +1297,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveFields.Success
           );
         }, `expected SUCCESS but got ${removeFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1306,8 +1309,8 @@ export function runDictionaryTests(
         }, `expected MISS but got ${getFieldsResponse.toString()}`);
 
         // When the fields exist.
-        const setFieldsResponse = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const setFieldsResponse = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           setFields
         );
@@ -1316,8 +1319,8 @@ export function runDictionaryTests(
             CacheDictionarySetFields.Success
           );
         }, `expected SUCCESS but got ${setFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1326,8 +1329,8 @@ export function runDictionaryTests(
             CacheDictionaryGetFields.Hit
           );
         }, `expected HIT but got ${getFieldsResponse.toString()}`);
-        removeFieldsResponse = await Momento.dictionaryRemoveFields(
-          IntegrationTestCacheName,
+        removeFieldsResponse = await cacheClient.dictionaryRemoveFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1336,8 +1339,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveFields.Success
           );
         }, `expected SUCCESS but got ${removeFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1357,8 +1360,8 @@ export function runDictionaryTests(
         ]);
 
         // When the fields do not exist.
-        let getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        let getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1367,8 +1370,8 @@ export function runDictionaryTests(
             CacheDictionaryGetFields.Miss
           );
         }, `expected MISS but got ${getFieldsResponse.toString()}`);
-        let removeFieldsResponse = await Momento.dictionaryRemoveFields(
-          IntegrationTestCacheName,
+        let removeFieldsResponse = await cacheClient.dictionaryRemoveFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1377,8 +1380,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveFields.Success
           );
         }, `expected SUCCESS but got ${removeFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1389,8 +1392,8 @@ export function runDictionaryTests(
         }, `expected MISS but got ${getFieldsResponse.toString()}`);
 
         // When the fields exist.
-        const setFieldsResponse = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const setFieldsResponse = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           setFields
         );
@@ -1399,8 +1402,8 @@ export function runDictionaryTests(
             CacheDictionarySetFields.Success
           );
         }, `expected SUCCESS but got ${setFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1409,8 +1412,8 @@ export function runDictionaryTests(
             CacheDictionaryGetFields.Hit
           );
         }, `expected HIT but got ${getFieldsResponse.toString()}`);
-        removeFieldsResponse = await Momento.dictionaryRemoveFields(
-          IntegrationTestCacheName,
+        removeFieldsResponse = await cacheClient.dictionaryRemoveFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1419,8 +1422,8 @@ export function runDictionaryTests(
             CacheDictionaryRemoveFields.Success
           );
         }, `expected SUCCESS but got ${removeFieldsResponse.toString()}`);
-        getFieldsResponse = await Momento.dictionaryGetFields(
-          IntegrationTestCacheName,
+        getFieldsResponse = await cacheClient.dictionaryGetFields(
+          integrationTestCacheName,
           dictionaryName,
           fields
         );
@@ -1433,7 +1436,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionaryRemoveFields via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -1462,7 +1465,7 @@ export function runDictionaryTests(
 
     describe('#dictionarySetField', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionarySetField(
+        return cacheClient.dictionarySetField(
           props.cacheName,
           props.dictionaryName,
           props.field,
@@ -1471,7 +1474,7 @@ export function runDictionaryTests(
       };
 
       const changeResponder = (props: ValidateDictionaryChangerProps) => {
-        return Momento.dictionarySetField(
+        return cacheClient.dictionarySetField(
           props.cacheName,
           props.dictionaryName,
           props.field,
@@ -1487,8 +1490,8 @@ export function runDictionaryTests(
         const dictionaryName = v4();
         const field = uint8ArrayForTest(v4());
         const value = uint8ArrayForTest(v4());
-        const response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -1496,8 +1499,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1513,8 +1516,8 @@ export function runDictionaryTests(
         const dictionaryName = v4();
         const field = v4();
         const value = v4();
-        const response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -1522,8 +1525,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1539,8 +1542,8 @@ export function runDictionaryTests(
         const dictionaryName = v4();
         const field = v4();
         const value = uint8ArrayForTest(v4());
-        const response = await Momento.dictionarySetField(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetField(
+          integrationTestCacheName,
           dictionaryName,
           field,
           value
@@ -1548,8 +1551,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetField.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        const getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field
         );
@@ -1563,7 +1566,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionarySetField via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         const response = await cache.dictionarySetField(
           dictionaryName,
@@ -1587,7 +1590,7 @@ export function runDictionaryTests(
 
     describe('#dictionarySetFields', () => {
       const responder = (props: ValidateDictionaryProps) => {
-        return Momento.dictionarySetFields(
+        return cacheClient.dictionarySetFields(
           props.cacheName,
           props.dictionaryName,
           new Map([[props.field, v4()]])
@@ -1595,7 +1598,7 @@ export function runDictionaryTests(
       };
 
       const changeResponder = (props: ValidateDictionaryChangerProps) => {
-        return Momento.dictionarySetFields(
+        return cacheClient.dictionarySetFields(
           props.cacheName,
           props.dictionaryName,
           new Map([[props.field, props.value]]),
@@ -1612,8 +1615,8 @@ export function runDictionaryTests(
         const value1 = uint8ArrayForTest(v4());
         const field2 = uint8ArrayForTest(v4());
         const value2 = uint8ArrayForTest(v4());
-        const response = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -1622,8 +1625,8 @@ export function runDictionaryTests(
           {ttl: CollectionTtl.of(10)}
         );
         expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field1
         );
@@ -1633,8 +1636,8 @@ export function runDictionaryTests(
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueUint8Array()).toEqual(value1);
         }
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field2
         );
@@ -1652,8 +1655,8 @@ export function runDictionaryTests(
         const value1 = v4();
         const field2 = v4();
         const value2 = v4();
-        const response = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -1664,8 +1667,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field1
         );
@@ -1675,8 +1678,8 @@ export function runDictionaryTests(
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field2
         );
@@ -1694,8 +1697,8 @@ export function runDictionaryTests(
         const value1 = v4();
         const field2 = 'bar';
         const value2 = v4();
-        const response = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {foo: value1, bar: value2},
           {ttl: CollectionTtl.of(10)}
@@ -1703,8 +1706,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field1
         );
@@ -1714,8 +1717,8 @@ export function runDictionaryTests(
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field2
         );
@@ -1733,8 +1736,8 @@ export function runDictionaryTests(
         const value1 = uint8ArrayForTest(v4());
         const field2 = v4();
         const value2 = uint8ArrayForTest(v4());
-        const response = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -1745,8 +1748,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field1
         );
@@ -1757,8 +1760,8 @@ export function runDictionaryTests(
           expect(getResponse.valueUint8Array()).toEqual(value1);
         }
 
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field2
         );
@@ -1777,8 +1780,8 @@ export function runDictionaryTests(
         const value1 = v4();
         const field2 = 'bar';
         const value2 = v4();
-        const response = await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        const response = await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           {foo: textEncoder.encode(value1), bar: textEncoder.encode(value2)},
           {ttl: CollectionTtl.of(10)}
@@ -1786,8 +1789,8 @@ export function runDictionaryTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDictionarySetFields.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        let getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        let getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field1
         );
@@ -1797,8 +1800,8 @@ export function runDictionaryTests(
         if (getResponse instanceof CacheDictionaryGetField.Hit) {
           expect(getResponse.valueString()).toEqual(value1);
         }
-        getResponse = await Momento.dictionaryGetField(
-          IntegrationTestCacheName,
+        getResponse = await cacheClient.dictionaryGetField(
+          integrationTestCacheName,
           dictionaryName,
           field2
         );
@@ -1812,7 +1815,7 @@ export function runDictionaryTests(
 
       it('should support happy path for dictionarySetFields via curried cache via ICache interface', async () => {
         const dictionaryName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         const response = await cache.dictionarySetFields(dictionaryName, {
           a: 'A',
@@ -1836,12 +1839,15 @@ export function runDictionaryTests(
 
     describe('#dictionaryLength', () => {
       itBehavesLikeItValidates((props: ValidateDictionaryProps) => {
-        return Momento.dictionaryLength(props.cacheName, props.dictionaryName);
+        return cacheClient.dictionaryLength(
+          props.cacheName,
+          props.dictionaryName
+        );
       });
 
       it('returns a miss if the dictionary does not exist', async () => {
-        const resp = await Momento.dictionaryLength(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.dictionaryLength(
+          integrationTestCacheName,
           v4()
         );
         expect(resp).toBeInstanceOf(CacheDictionaryLength.Miss);
@@ -1853,8 +1859,8 @@ export function runDictionaryTests(
         const value1 = uint8ArrayForTest(v4());
         const field2 = v4();
         const value2 = uint8ArrayForTest(v4());
-        await Momento.dictionarySetFields(
-          IntegrationTestCacheName,
+        await cacheClient.dictionarySetFields(
+          integrationTestCacheName,
           dictionaryName,
           new Map([
             [field1, value1],
@@ -1863,8 +1869,8 @@ export function runDictionaryTests(
           {ttl: CollectionTtl.of(10)}
         );
 
-        const resp = await Momento.dictionaryLength(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.dictionaryLength(
+          integrationTestCacheName,
           dictionaryName
         );
         expectWithMessage(() => {
@@ -1880,7 +1886,7 @@ export function runDictionaryTests(
         const field2 = v4();
         const value2 = uint8ArrayForTest(v4());
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.dictionarySetFields(
           dictionaryName,

--- a/packages/common-integration-tests/src/get-set-delete.ts
+++ b/packages/common-integration-tests/src/get-set-delete.ts
@@ -18,33 +18,36 @@ import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
 
 export function runGetSetDeleteTests(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('get/set/delete', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.get(props.cacheName, v4());
+      return cacheClient.get(props.cacheName, v4());
     });
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.set(props.cacheName, v4(), v4());
+      return cacheClient.set(props.cacheName, v4(), v4());
     });
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.delete(props.cacheName, v4());
+      return cacheClient.delete(props.cacheName, v4());
     });
 
     it('should set and get string from cache', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
 
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -56,15 +59,18 @@ export function runGetSetDeleteTests(
     it('should set and get bytes from cache', async () => {
       const cacheKey = new TextEncoder().encode(v4());
       const cacheValue = new TextEncoder().encode(v4());
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -74,15 +80,18 @@ export function runGetSetDeleteTests(
       const cacheKey = v4();
       const cacheValue = new TextEncoder().encode(v4());
       const decodedValue = new TextDecoder().decode(cacheValue);
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -94,15 +103,18 @@ export function runGetSetDeleteTests(
     it('should set byte key with string value', async () => {
       const cacheValue = v4();
       const cacheKey = new TextEncoder().encode(v4());
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -114,8 +126,8 @@ export function runGetSetDeleteTests(
     it('should set and get string from cache and returned set value matches string cacheValue', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
@@ -127,8 +139,8 @@ export function runGetSetDeleteTests(
     it('should set string key with bytes value and returned set value matches byte cacheValue', async () => {
       const cacheKey = v4();
       const cacheValue = new TextEncoder().encode(v4());
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
@@ -140,26 +152,29 @@ export function runGetSetDeleteTests(
     it('should set and then delete a value in cache', async () => {
       const cacheKey = v4();
       const cacheValue = new TextEncoder().encode(v4());
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheValue);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
 
-      const deleteResponse = await Momento.delete(
-        IntegrationTestCacheName,
+      const deleteResponse = await cacheClient.delete(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
       }, `expected SUCCESS but got ${deleteResponse.toString()}`);
-      const getMiss = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getMiss = await cacheClient.get(integrationTestCacheName, cacheKey);
       expect(getMiss).toBeInstanceOf(CacheGet.Miss);
     });
 
     it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with string key/value', async () => {
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         v4(),
         v4(),
         {ttl: -1}
@@ -175,8 +190,8 @@ export function runGetSetDeleteTests(
     it('should set string key/value with valid ttl and get successfully', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue,
         {ttl: 15}
@@ -185,7 +200,10 @@ export function runGetSetDeleteTests(
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -193,8 +211,8 @@ export function runGetSetDeleteTests(
 
     it('should set with valid ttl and should return miss when ttl is expired', async () => {
       const cacheKey = v4();
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         v4(),
         {ttl: 1}
@@ -204,7 +222,10 @@ export function runGetSetDeleteTests(
       }, `expected SUCCESS but got ${setResponse.toString()}`);
       await sleep(3000);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Miss);
       }, `expected MISS but got ${getResponse.toString()}`);
@@ -214,7 +235,7 @@ export function runGetSetDeleteTests(
       const cacheKey = v4();
       const cacheValue = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       const setResponse = await cache.set(cacheKey, cacheValue);
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
@@ -231,7 +252,7 @@ export function runGetSetDeleteTests(
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
       }, `expected SUCCESS but got ${deleteResponse.toString()}`);
-      const getMiss = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getMiss = await cacheClient.get(integrationTestCacheName, cacheKey);
       expect(getMiss).toBeInstanceOf(CacheGet.Miss);
     });
 
@@ -239,15 +260,18 @@ export function runGetSetDeleteTests(
       const cacheKey = v4();
       const cacheValue = v4();
 
-      const setResponse = await Momento.set(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `expected SUCCESS but got ${setResponse.toString()}`);
-      let getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      let getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -258,7 +282,7 @@ export function runGetSetDeleteTests(
       expect(hitResponse.value()).toEqual(cacheValue);
       expect(hitResponse.valueString()).toEqual(cacheValue);
 
-      getResponse = await Momento.get(IntegrationTestCacheName, v4());
+      getResponse = await cacheClient.get(integrationTestCacheName, v4());
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Miss);
       }, `expected MISS but got ${getResponse.toString()}`);
@@ -269,13 +293,13 @@ export function runGetSetDeleteTests(
 
   describe('#increment', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.increment(props.cacheName, v4(), 1);
+      return cacheClient.increment(props.cacheName, v4(), 1);
     });
 
     it('increments from 0 to expected amount with string field', async () => {
       const field = v4();
-      let incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      let incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         1
       );
@@ -285,8 +309,8 @@ export function runGetSetDeleteTests(
       let successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
-      incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         41
       );
@@ -297,8 +321,8 @@ export function runGetSetDeleteTests(
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
 
-      incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         -1042
       );
@@ -308,7 +332,10 @@ export function runGetSetDeleteTests(
       successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, field);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        field
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -318,8 +345,8 @@ export function runGetSetDeleteTests(
 
     it('increments from 0 to expected amount with Uint8Array field', async () => {
       const field = new TextEncoder().encode(v4());
-      let incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      let incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         1
       );
@@ -329,8 +356,8 @@ export function runGetSetDeleteTests(
       let successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(1);
 
-      incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         41
       );
@@ -341,8 +368,8 @@ export function runGetSetDeleteTests(
       expect(successResponse.valueNumber()).toEqual(42);
       expect(successResponse.toString()).toEqual('Success: value: 42');
 
-      incrementResponse = await Momento.increment(
-        IntegrationTestCacheName,
+      incrementResponse = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         -1042
       );
@@ -352,7 +379,10 @@ export function runGetSetDeleteTests(
       successResponse = incrementResponse as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(-1000);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, field);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        field
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -363,9 +393,9 @@ export function runGetSetDeleteTests(
     it('increments with setting and resetting field', async () => {
       const field = v4();
 
-      await Momento.set(IntegrationTestCacheName, field, '10');
-      let response = await Momento.increment(
-        IntegrationTestCacheName,
+      await cacheClient.set(integrationTestCacheName, field, '10');
+      let response = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         0
       );
@@ -375,7 +405,11 @@ export function runGetSetDeleteTests(
       let successResponse = response as CacheIncrement.Success;
       expect(successResponse.valueNumber()).toEqual(10);
 
-      response = await Momento.increment(IntegrationTestCacheName, field, 90);
+      response = await cacheClient.increment(
+        integrationTestCacheName,
+        field,
+        90
+      );
       expectWithMessage(() => {
         expect(response).toBeInstanceOf(CacheIncrement.Success);
       }, `expected SUCCESS but got ${response.toString()}`);
@@ -383,8 +417,12 @@ export function runGetSetDeleteTests(
       expect(successResponse.valueNumber()).toEqual(100);
 
       // Reset field
-      await Momento.set(IntegrationTestCacheName, field, '0');
-      response = await Momento.increment(IntegrationTestCacheName, field, 0);
+      await cacheClient.set(integrationTestCacheName, field, '0');
+      response = await cacheClient.increment(
+        integrationTestCacheName,
+        field,
+        0
+      );
       expectWithMessage(() => {
         expect(response).toBeInstanceOf(CacheIncrement.Success);
       }, `expected SUCCESS but got ${response.toString()}`);
@@ -395,9 +433,9 @@ export function runGetSetDeleteTests(
     it('fails with precondition with a bad amount', async () => {
       const field = v4();
 
-      await Momento.set(IntegrationTestCacheName, field, 'abcxyz');
-      const response = await Momento.increment(
-        IntegrationTestCacheName,
+      await cacheClient.set(integrationTestCacheName, field, 'abcxyz');
+      const response = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         1
       );
@@ -412,7 +450,7 @@ export function runGetSetDeleteTests(
 
     it('should support happy path for increment via curried cache via ICache interface', async () => {
       const field = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.set(field, '10');
       const response = await cache.increment(field, 42);
@@ -426,9 +464,9 @@ export function runGetSetDeleteTests(
     it('should support accessing value for CacheIncrement.Success without instanceof check', async () => {
       const field = v4();
 
-      await Momento.set(IntegrationTestCacheName, field, '10');
-      const response = await Momento.increment(
-        IntegrationTestCacheName,
+      await cacheClient.set(integrationTestCacheName, field, '10');
+      const response = await cacheClient.increment(
+        integrationTestCacheName,
         field,
         42
       );
@@ -446,21 +484,24 @@ export function runGetSetDeleteTests(
 
   describe('#setIfNotExists', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.setIfNotExists(props.cacheName, v4(), v4());
+      return cacheClient.setIfNotExists(props.cacheName, v4(), v4());
     });
 
     it('should set and get string from cache', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -472,8 +513,8 @@ export function runGetSetDeleteTests(
     it('should set and get remaining ttl from cache greater than expected', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue,
         {ttl: 1000}
@@ -481,8 +522,8 @@ export function runGetSetDeleteTests(
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const getTTLResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const getTTLResponse = await cacheClient.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -493,7 +534,10 @@ export function runGetSetDeleteTests(
         // will be greater than 950 seconds at least
         expect(getTTLResponse.remainingTtlMillis()).toBeGreaterThan(950 * 1000);
       }
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -506,16 +550,16 @@ export function runGetSetDeleteTests(
       const cacheKey = v4();
       const cacheValueOld = 'value1';
       const cacheValueNew = 'value2';
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValueOld
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const setIfNotExistsResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setIfNotExistsResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValueNew
       );
@@ -524,7 +568,10 @@ export function runGetSetDeleteTests(
           CacheSetIfNotExists.NotStored
         );
       }, `expected NOTSTORED but goit ${setIfNotExistsResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -536,15 +583,18 @@ export function runGetSetDeleteTests(
     it('should set and get bytes from cache', async () => {
       const cacheKey = new TextEncoder().encode(v4());
       const cacheValue = new TextEncoder().encode(v4());
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -554,15 +604,18 @@ export function runGetSetDeleteTests(
       const cacheKey = v4();
       const cacheValue = new TextEncoder().encode(v4());
       const decodedValue = new TextDecoder().decode(cacheValue);
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -574,15 +627,18 @@ export function runGetSetDeleteTests(
     it('should set byte key with string value', async () => {
       const cacheValue = v4();
       const cacheKey = new TextEncoder().encode(v4());
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `expected HIT but got ${getResponse.toString()}`);
@@ -594,8 +650,8 @@ export function runGetSetDeleteTests(
     it('should set and get string from cache and returned set value matches string cacheValue', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
@@ -607,8 +663,8 @@ export function runGetSetDeleteTests(
     it('should set string key with bytes value and returned set value matches byte cacheValue', async () => {
       const cacheKey = v4();
       const cacheValue = new TextEncoder().encode(v4());
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue
       );
@@ -618,8 +674,8 @@ export function runGetSetDeleteTests(
     });
 
     it('should return INVALID_ARGUMENT_ERROR for invalid ttl when set with string key/value', async () => {
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         v4(),
         v4(),
         {ttl: -1}
@@ -635,8 +691,8 @@ export function runGetSetDeleteTests(
     it('should set string key/value with valid ttl and get successfully', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         cacheValue,
         {ttl: 15}
@@ -645,7 +701,10 @@ export function runGetSetDeleteTests(
         expect(setResponse).toBeInstanceOf(CacheSetIfNotExists.Stored);
       }, `expected STORED but got ${setResponse.toString()}`);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       if (getResponse instanceof CacheGet.Hit) {
         expect(getResponse.valueString()).toEqual(cacheValue);
       }
@@ -653,8 +712,8 @@ export function runGetSetDeleteTests(
 
     it('should set with valid ttl and should return miss when ttl is expired', async () => {
       const cacheKey = v4();
-      const setResponse = await Momento.setIfNotExists(
-        IntegrationTestCacheName,
+      const setResponse = await cacheClient.setIfNotExists(
+        integrationTestCacheName,
         cacheKey,
         v4(),
         {ttl: 1}
@@ -664,7 +723,10 @@ export function runGetSetDeleteTests(
       }, `expected STORED but got ${setResponse.toString()}`);
       await sleep(3000);
 
-      const getResponse = await Momento.get(IntegrationTestCacheName, cacheKey);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Miss);
       }, `expected MISS but got ${getResponse.toString()}`);
@@ -673,7 +735,7 @@ export function runGetSetDeleteTests(
     it('should support happy path for setIfNotExists via curried cache via ICache interface', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       const setResponse = await cache.setIfNotExists(cacheKey, cacheValue);
       expectWithMessage(() => {

--- a/packages/common-integration-tests/src/item-get-ttl.ts
+++ b/packages/common-integration-tests/src/item-get-ttl.ts
@@ -8,24 +8,24 @@ import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache'
 import {CacheItemGetTtl, CollectionTtl} from '@gomomento/sdk-core';
 import {delay} from './auth-client';
 export function runItemGetTtlTest(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  momento: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('item ttl', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.itemGetTtl(props.cacheName, v4());
+      return momento.itemGetTtl(props.cacheName, v4());
     });
 
     it('should get item ttl remaining for a scalar', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue, {
+      await momento.set(integrationTestCacheName, cacheKey, cacheValue, {
         ttl: 10,
       });
 
       // string cache key
-      let itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      let itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -36,8 +36,8 @@ export function runItemGetTtlTest(
       expect(hitResult.remainingTtlMillis()).toBeGreaterThan(7000);
 
       // byte array cache key
-      itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -51,8 +51,8 @@ export function runItemGetTtlTest(
     it('should get item ttl remaining for a dictionary', async () => {
       const cacheKey = v4();
       const cacheValue = {foo: v4()};
-      await Momento.dictionarySetFields(
-        IntegrationTestCacheName,
+      await momento.dictionarySetFields(
+        integrationTestCacheName,
         cacheKey,
         cacheValue,
         {
@@ -61,8 +61,8 @@ export function runItemGetTtlTest(
       );
 
       // string cache key
-      const itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -76,8 +76,8 @@ export function runItemGetTtlTest(
     it('should return a miss for a non-existent key', async () => {
       const cacheKey = v4();
       // string cache key
-      const itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -88,13 +88,13 @@ export function runItemGetTtlTest(
     it('should return a miss for an expired key', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue, {
+      await momento.set(integrationTestCacheName, cacheKey, cacheValue, {
         ttl: 2,
       });
 
       // string cache key
-      let itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      let itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -104,8 +104,8 @@ export function runItemGetTtlTest(
       await delay(2000);
 
       // byte array cache key
-      itemGetTtlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      itemGetTtlResponse = await momento.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -116,11 +116,11 @@ export function runItemGetTtlTest(
     it('should support happy path for itemGetTtl via curried cache via ICache interface', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue, {
+      await momento.set(integrationTestCacheName, cacheKey, cacheValue, {
         ttl: 10,
       });
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = momento.cache(integrationTestCacheName);
 
       // string cache key
       const itemGetTtlResponse = await cache.itemGetTtl(cacheKey);

--- a/packages/common-integration-tests/src/item-get-type.ts
+++ b/packages/common-integration-tests/src/item-get-type.ts
@@ -8,22 +8,22 @@ import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache'
 import {CacheItemGetType} from '@gomomento/sdk-core';
 import {ItemType} from '@gomomento/sdk-core/dist/src/utils';
 export function runItemGetTypeTest(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('item type', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.itemGetType(props.cacheName, v4());
+      return cacheClient.itemGetType(props.cacheName, v4());
     });
 
     it('should get item type scalar', async () => {
       const cacheKey = v4();
       const cacheValue = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheValue);
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheValue);
 
       // string cache key
-      let itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      let itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -33,8 +33,8 @@ export function runItemGetTypeTest(
       expect(hitResult.itemType()).toEqual(ItemType.SCALAR);
 
       // byte array cache key
-      itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -46,16 +46,16 @@ export function runItemGetTypeTest(
 
     it('should get item type dictionary', async () => {
       const cacheKey = v4();
-      await Momento.dictionarySetField(
-        IntegrationTestCacheName,
+      await cacheClient.dictionarySetField(
+        integrationTestCacheName,
         cacheKey,
         v4(),
         v4()
       );
 
       // string cache key
-      let itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      let itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -65,8 +65,8 @@ export function runItemGetTypeTest(
       expect(hitResult.itemType()).toEqual(ItemType.DICTIONARY);
 
       // byte array cache key
-      itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -78,11 +78,11 @@ export function runItemGetTypeTest(
 
     it('should get item type list', async () => {
       const cacheKey = v4();
-      await Momento.listPushFront(IntegrationTestCacheName, cacheKey, v4());
+      await cacheClient.listPushFront(integrationTestCacheName, cacheKey, v4());
 
       // string cache key
-      let itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      let itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -92,8 +92,8 @@ export function runItemGetTypeTest(
       expect(hitResult.itemType()).toEqual(ItemType.LIST);
 
       // byte array cache key
-      itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -105,11 +105,11 @@ export function runItemGetTypeTest(
 
     it('should get item type set', async () => {
       const cacheKey = v4();
-      await Momento.setAddElement(IntegrationTestCacheName, cacheKey, v4());
+      await cacheClient.setAddElement(integrationTestCacheName, cacheKey, v4());
 
       // string cache key
-      let itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      let itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -119,8 +119,8 @@ export function runItemGetTypeTest(
       expect(hitResult.itemType()).toEqual(ItemType.SET);
 
       // byte array cache key
-      itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -132,16 +132,16 @@ export function runItemGetTypeTest(
 
     it('should get item type sorted set', async () => {
       const cacheKey = v4();
-      await Momento.sortedSetPutElement(
-        IntegrationTestCacheName,
+      await cacheClient.sortedSetPutElement(
+        integrationTestCacheName,
         cacheKey,
         'a',
         42
       );
 
       // string cache key
-      let itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      let itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -151,8 +151,8 @@ export function runItemGetTypeTest(
       expect(hitResult.itemType()).toEqual(ItemType.SORTED_SET);
 
       // byte array cache key
-      itemGetTypeResponse = await Momento.itemGetType(
-        IntegrationTestCacheName,
+      itemGetTypeResponse = await cacheClient.itemGetType(
+        integrationTestCacheName,
         new TextEncoder().encode(cacheKey)
       );
       expectWithMessage(() => {
@@ -165,7 +165,7 @@ export function runItemGetTypeTest(
     it('should support happy path for itemGetType via curried cache via ICache interface', async () => {
       const cacheKey = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.dictionarySetField(cacheKey, v4(), v4());
 
       // string cache key

--- a/packages/common-integration-tests/src/keys-exist.ts
+++ b/packages/common-integration-tests/src/keys-exist.ts
@@ -7,16 +7,19 @@ import {
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
 import {CacheKeyExists, CacheKeysExist} from '@gomomento/sdk-core';
 export function runKeysExistTest(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('#keyExists', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.keyExists(props.cacheName, v4());
+      return cacheClient.keyExists(props.cacheName, v4());
     });
 
     it('should return false for given key if cache is empty', async () => {
-      const response = await Momento.keyExists(IntegrationTestCacheName, v4());
+      const response = await cacheClient.keyExists(
+        integrationTestCacheName,
+        v4()
+      );
 
       expectWithMessage(() => {
         expect(response).toBeInstanceOf(CacheKeyExists.Success);
@@ -29,10 +32,10 @@ export function runKeysExistTest(
     it('should return false for given key if cache is not empty but does not have the key', async () => {
       const cacheKey = v4();
       const anotherKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey);
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey);
 
-      const response = await Momento.keyExists(
-        IntegrationTestCacheName,
+      const response = await cacheClient.keyExists(
+        integrationTestCacheName,
         anotherKey
       );
 
@@ -46,10 +49,10 @@ export function runKeysExistTest(
 
     it('should return true for given key if cache is not empty and has the key', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey);
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey);
 
-      const response = await Momento.keyExists(
-        IntegrationTestCacheName,
+      const response = await cacheClient.keyExists(
+        integrationTestCacheName,
         cacheKey
       );
 
@@ -63,7 +66,7 @@ export function runKeysExistTest(
 
     it('should support happy path for keyExists via curried cache via ICache interface', async () => {
       const cacheKey = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.set(cacheKey, cacheKey);
 
       const response = await cache.keyExists(cacheKey);
@@ -79,11 +82,14 @@ export function runKeysExistTest(
 
   describe('#keysExist', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.keysExist(props.cacheName, [v4()]);
+      return cacheClient.keysExist(props.cacheName, [v4()]);
     });
 
     it('should return empty list if given empty key list', async () => {
-      const response = await Momento.keysExist(IntegrationTestCacheName, []);
+      const response = await cacheClient.keysExist(
+        integrationTestCacheName,
+        []
+      );
 
       expectWithMessage(() => {
         expect(response).toBeInstanceOf(CacheKeysExist.Success);
@@ -98,11 +104,11 @@ export function runKeysExistTest(
       const key2 = v4();
       const key3 = v4();
       const key4 = v4();
-      await Momento.set(IntegrationTestCacheName, key1, key1);
-      await Momento.set(IntegrationTestCacheName, key3, key3);
+      await cacheClient.set(integrationTestCacheName, key1, key1);
+      await cacheClient.set(integrationTestCacheName, key3, key3);
 
-      const responseOrdering1 = await Momento.keysExist(
-        IntegrationTestCacheName,
+      const responseOrdering1 = await cacheClient.keysExist(
+        integrationTestCacheName,
         [key1, key2, key3]
       );
 
@@ -113,8 +119,8 @@ export function runKeysExistTest(
       const successOrdering1 = responseOrdering1 as CacheKeyExists.Success;
       expect(successOrdering1.exists()).toEqual([true, false, true]);
 
-      const responseOrdering2 = await Momento.keysExist(
-        IntegrationTestCacheName,
+      const responseOrdering2 = await cacheClient.keysExist(
+        integrationTestCacheName,
         [key2, key3, key1]
       );
 
@@ -125,8 +131,8 @@ export function runKeysExistTest(
       const successOrdering2 = responseOrdering2 as CacheKeyExists.Success;
       expect(successOrdering2.exists()).toEqual([false, true, true]);
 
-      const responseOrdering3 = await Momento.keysExist(
-        IntegrationTestCacheName,
+      const responseOrdering3 = await cacheClient.keysExist(
+        integrationTestCacheName,
         [key2, key4]
       );
 
@@ -141,7 +147,7 @@ export function runKeysExistTest(
     it('should support happy path for keysExist via curried cache via ICache interface', async () => {
       const cacheKey1 = v4();
       const cacheKey2 = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.set(cacheKey1, cacheKey1);
 
       const response = await cache.keysExist([cacheKey1, cacheKey2]);

--- a/packages/common-integration-tests/src/list.ts
+++ b/packages/common-integration-tests/src/list.ts
@@ -30,8 +30,8 @@ import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
 
 export function runListTests(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('lists', () => {
     const itBehavesLikeItValidates = (
@@ -43,7 +43,7 @@ export function runListTests(
 
       it('validates its list name', async () => {
         const response = await getResponse({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           listName: '  ',
         });
 
@@ -71,7 +71,7 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
             ttl: ttl,
@@ -79,8 +79,8 @@ export function runListTests(
         }
         await sleep(1000);
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -96,7 +96,7 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
             ttl: ttl,
@@ -106,8 +106,8 @@ export function runListTests(
           await sleep((timeout / 2) * 1000);
         }
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -129,7 +129,7 @@ export function runListTests(
         let length = 0;
         for (const value of values) {
           const resp = await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
           });
@@ -151,14 +151,14 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
           });
         }
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -175,15 +175,15 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
             truncateToSize: 2,
           });
         }
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -208,14 +208,14 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
           });
         }
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -232,15 +232,15 @@ export function runListTests(
 
         for (const value of values) {
           await addValue({
-            cacheName: IntegrationTestCacheName,
+            cacheName: integrationTestCacheName,
             listName: listName,
             value: value,
             truncateToSize: 2,
           });
         }
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -255,12 +255,12 @@ export function runListTests(
 
     describe('#listFetch', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listFetch(props.cacheName, props.listName);
+        return cacheClient.listFetch(props.cacheName, props.listName);
       });
 
       it('returns a miss if the list does not exist', async () => {
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           v4()
         );
         expect(respFetch).toBeInstanceOf(CacheListFetch.Miss);
@@ -271,14 +271,14 @@ export function runListTests(
         const valueString = 'abc123';
         const valueBytes = new Uint8Array([97, 98, 99, 49, 50, 51]);
 
-        await Momento.listPushFront(
-          IntegrationTestCacheName,
+        await cacheClient.listPushFront(
+          integrationTestCacheName,
           listName,
           valueString
         );
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -297,23 +297,27 @@ export function runListTests(
 
       it('returns a miss if the list is deleted', async () => {
         const listName = v4();
-        await Momento.listPushFront(IntegrationTestCacheName, listName, '123');
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        await cacheClient.listPushFront(
+          integrationTestCacheName,
+          listName,
+          '123'
+        );
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
           expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         }, `expected a HIT but got ${respFetch.toString()}`);
 
-        const deleteResp = await Momento.delete(
-          IntegrationTestCacheName,
+        const deleteResp = await cacheClient.delete(
+          integrationTestCacheName,
           listName
         );
         expect(deleteResp).toBeInstanceOf(CacheDelete.Success);
 
-        const respFetch2 = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch2 = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -326,14 +330,14 @@ export function runListTests(
         const valueArray = ['a', 'b', 'c', '1', '2', '3'];
         const valueStringExpected = ['c', '1'];
 
-        await Momento.listConcatenateBack(
-          IntegrationTestCacheName,
+        await cacheClient.listConcatenateBack(
+          integrationTestCacheName,
           listName,
           valueArray
         );
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName,
           {
             startIndex: 2,
@@ -352,7 +356,7 @@ export function runListTests(
       it('should support happy path for listFetch via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -369,13 +373,14 @@ export function runListTests(
       it('should support accessing value for CacheListFetch.Hit without instanceof check', async () => {
         const listName = v4();
 
-        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
-          'foo',
-          'bar',
-        ]);
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
+          listName,
+          ['foo', 'bar']
+        );
 
-        let fetchResponse = await Momento.listFetch(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -390,7 +395,10 @@ export function runListTests(
         expect(hitResponse.value()).toEqual(expectedResult);
         expect(hitResponse.valueList()).toEqual(expectedResult);
 
-        fetchResponse = await Momento.listFetch(IntegrationTestCacheName, v4());
+        fetchResponse = await cacheClient.listFetch(
+          integrationTestCacheName,
+          v4()
+        );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheListFetch.Miss);
         }, `expected a MISS but got ${fetchResponse.toString()}`);
@@ -400,11 +408,14 @@ export function runListTests(
 
     describe('#listLength', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listLength(props.cacheName, props.listName);
+        return cacheClient.listLength(props.cacheName, props.listName);
       });
 
       it('returns a miss if the list does not exist', async () => {
-        const resp = await Momento.listLength(IntegrationTestCacheName, v4());
+        const resp = await cacheClient.listLength(
+          integrationTestCacheName,
+          v4()
+        );
         expect(resp).toBeInstanceOf(CacheListLength.Miss);
       });
 
@@ -412,14 +423,14 @@ export function runListTests(
         const listName = v4();
         const values = ['one', 'two', 'three'];
 
-        await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values
         );
 
-        const resp = await Momento.listLength(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.listLength(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -431,7 +442,7 @@ export function runListTests(
       it('should support happy path for listLength via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -445,11 +456,14 @@ export function runListTests(
 
     describe('#listPopBack', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listPopBack(props.cacheName, props.listName);
+        return cacheClient.listPopBack(props.cacheName, props.listName);
       });
 
       it('misses when the list does not exist', async () => {
-        const resp = await Momento.listPopBack(IntegrationTestCacheName, v4());
+        const resp = await cacheClient.listPopBack(
+          integrationTestCacheName,
+          v4()
+        );
         expectWithMessage(() => {
           expect(resp).toBeInstanceOf(CacheListPopBack.Miss);
         }, `expected a MISS but got ${resp.toString()}`);
@@ -461,14 +475,14 @@ export function runListTests(
         const poppedValue = values[values.length - 1];
         const poppedBinary = Uint8Array.of(108, 111, 108);
 
-        await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values
         );
 
-        const resp = await Momento.listPopBack(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.listPopBack(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -485,7 +499,7 @@ export function runListTests(
       it('should support happy path for listPopBack via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -499,13 +513,14 @@ export function runListTests(
       it('should support accessing value for CacheListPopBack.Hit without instanceof check', async () => {
         const listName = v4();
 
-        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
-          'foo',
-          'bar',
-        ]);
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
+          listName,
+          ['foo', 'bar']
+        );
 
-        let popResponse = await Momento.listPopBack(
-          IntegrationTestCacheName,
+        let popResponse = await cacheClient.listPopBack(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -518,7 +533,10 @@ export function runListTests(
         expect(hitResponse.value()).toEqual('bar');
         expect(hitResponse.valueString()).toEqual('bar');
 
-        popResponse = await Momento.listPopBack(IntegrationTestCacheName, v4());
+        popResponse = await cacheClient.listPopBack(
+          integrationTestCacheName,
+          v4()
+        );
         expectWithMessage(() => {
           expect(popResponse).toBeInstanceOf(CacheListPopBack.Miss);
         }, `expected a MISS but got ${popResponse.toString()}`);
@@ -528,11 +546,14 @@ export function runListTests(
 
     describe('#listPopFront', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listPopFront(props.cacheName, props.listName);
+        return cacheClient.listPopFront(props.cacheName, props.listName);
       });
 
       it('misses when the list does not exist', async () => {
-        const resp = await Momento.listPopFront(IntegrationTestCacheName, v4());
+        const resp = await cacheClient.listPopFront(
+          integrationTestCacheName,
+          v4()
+        );
         expectWithMessage(() => {
           expect(resp).toBeInstanceOf(CacheListPopFront.Miss);
         }, `expected a MISS but got ${resp.toString()}`);
@@ -544,14 +565,14 @@ export function runListTests(
         const poppedValue = values[0];
         const poppedBinary = Uint8Array.of(108, 111, 108);
 
-        await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values
         );
 
-        const resp = await Momento.listPopFront(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.listPopFront(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -568,7 +589,7 @@ export function runListTests(
       it('should support happy path for listPopFront via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -582,13 +603,14 @@ export function runListTests(
       it('should support accessing value for CacheListPopFront.Hit without instanceof check', async () => {
         const listName = v4();
 
-        await Momento.listConcatenateFront(IntegrationTestCacheName, listName, [
-          'foo',
-          'bar',
-        ]);
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
+          listName,
+          ['foo', 'bar']
+        );
 
-        let popResponse = await Momento.listPopFront(
-          IntegrationTestCacheName,
+        let popResponse = await cacheClient.listPopFront(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -601,8 +623,8 @@ export function runListTests(
         expect(hitResponse.value()).toEqual('foo');
         expect(hitResponse.valueString()).toEqual('foo');
 
-        popResponse = await Momento.listPopFront(
-          IntegrationTestCacheName,
+        popResponse = await cacheClient.listPopFront(
+          integrationTestCacheName,
           v4()
         );
         expectWithMessage(() => {
@@ -614,11 +636,11 @@ export function runListTests(
 
     describe('#listPushBack', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listPushBack(props.cacheName, props.listName, v4());
+        return cacheClient.listPushBack(props.cacheName, props.listName, v4());
       });
 
       itBehavesLikeItAddsValuesToTheBack((props: addValueProps) => {
-        return Momento.listPushBack(
+        return cacheClient.listPushBack(
           props.cacheName,
           props.listName,
           props.value,
@@ -630,8 +652,8 @@ export function runListTests(
       });
 
       it('returns a CacheListPushBack response', async () => {
-        const resp = await Momento.listPushBack(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.listPushBack(
+          integrationTestCacheName,
           v4(),
           'test'
         );
@@ -643,7 +665,7 @@ export function runListTests(
       it('should support happy path for listPushBack via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -666,11 +688,11 @@ export function runListTests(
 
     describe('#listPushFront', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listPushFront(props.cacheName, props.listName, v4());
+        return cacheClient.listPushFront(props.cacheName, props.listName, v4());
       });
 
       itBehavesLikeItAddsValuesToTheFront((props: addValueProps) => {
-        return Momento.listPushFront(
+        return cacheClient.listPushFront(
           props.cacheName,
           props.listName,
           props.value,
@@ -682,8 +704,8 @@ export function runListTests(
       });
 
       it('returns a CacheListPushFront response', async () => {
-        const resp = await Momento.listPushFront(
-          IntegrationTestCacheName,
+        const resp = await cacheClient.listPushFront(
+          integrationTestCacheName,
           v4(),
           'test'
         );
@@ -695,7 +717,7 @@ export function runListTests(
       it('should support happy path for listPushFront via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -718,7 +740,11 @@ export function runListTests(
 
     describe('#listRemoveValue', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listRemoveValue(props.cacheName, props.listName, v4());
+        return cacheClient.listRemoveValue(
+          props.cacheName,
+          props.listName,
+          v4()
+        );
       });
 
       it('removes values', async () => {
@@ -733,21 +759,21 @@ export function runListTests(
         const expectedValues = ['turn me on', 'dead man'];
         const removeValue = 'number 9';
 
-        await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values
         );
 
-        const respRemove = await Momento.listRemoveValue(
-          IntegrationTestCacheName,
+        const respRemove = await cacheClient.listRemoveValue(
+          integrationTestCacheName,
           listName,
           removeValue
         );
         expect(respRemove).toBeInstanceOf(CacheListRemoveValue.Success);
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -761,7 +787,7 @@ export function runListTests(
       it('should support happy path for listRemoveValue via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar', 'baz']);
 
@@ -783,11 +809,14 @@ export function runListTests(
 
     describe('#listRetain', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listRetain(props.cacheName, props.listName);
+        return cacheClient.listRetain(props.cacheName, props.listName);
       });
 
       it('returns Success if the list does not exist', async () => {
-        const resp = await Momento.listRetain(IntegrationTestCacheName, v4());
+        const resp = await cacheClient.listRetain(
+          integrationTestCacheName,
+          v4()
+        );
         expectWithMessage(() => {
           expect(resp).toBeInstanceOf(CacheListRetain.Success);
         }, `expected a SUCCESS but got ${resp.toString()}`);
@@ -799,8 +828,8 @@ export function runListTests(
         const valueStringExpected = ['b'];
         const valueBytesExpected = new Uint8Array([98]);
 
-        const listPushResponse = await Momento.listConcatenateBack(
-          IntegrationTestCacheName,
+        const listPushResponse = await cacheClient.listConcatenateBack(
+          integrationTestCacheName,
           listName,
           valueString
         );
@@ -816,8 +845,8 @@ export function runListTests(
           endIndex: 2,
         };
 
-        const respRetain = await Momento.listRetain(
-          IntegrationTestCacheName,
+        const respRetain = await cacheClient.listRetain(
+          integrationTestCacheName,
           listName,
           retainOptions
         );
@@ -825,8 +854,8 @@ export function runListTests(
           expect(respRetain).toBeInstanceOf(CacheListRetain.Success);
         }, `expected a SUCCESS but got ${respRetain.toString()}`);
 
-        const respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        const respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
 
@@ -847,7 +876,7 @@ export function runListTests(
       it('should support happy path for listRetain via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, [
           'foo',
@@ -877,13 +906,15 @@ export function runListTests(
 
     describe('#listConcatenateBack', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listConcatenateBack(props.cacheName, props.listName, [
-          v4(),
-        ]);
+        return cacheClient.listConcatenateBack(
+          props.cacheName,
+          props.listName,
+          [v4()]
+        );
       });
 
       itBehavesLikeItAddsValuesToTheBack((props: addValueProps) => {
-        return Momento.listConcatenateBack(
+        return cacheClient.listConcatenateBack(
           props.cacheName,
           props.listName,
           [props.value] as string[] | Uint8Array[],
@@ -899,8 +930,8 @@ export function runListTests(
         const values1 = ['1', '2', '3', '4'];
         const values2 = ['this', 'that'];
 
-        let respConcat = await Momento.listConcatenateBack(
-          IntegrationTestCacheName,
+        let respConcat = await cacheClient.listConcatenateBack(
+          integrationTestCacheName,
           listName,
           values1
         );
@@ -911,8 +942,8 @@ export function runListTests(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length);
 
-        let respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        let respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -922,8 +953,8 @@ export function runListTests(
           values1
         );
 
-        respConcat = await Momento.listConcatenateBack(
-          IntegrationTestCacheName,
+        respConcat = await cacheClient.listConcatenateBack(
+          integrationTestCacheName,
           listName,
           values2
         );
@@ -934,7 +965,10 @@ export function runListTests(
           (respConcat as CacheListConcatenateBack.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
-        respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
+        respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
+          listName
+        );
         expectWithMessage(() => {
           expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         }, `expected a HIT but got ${respFetch.toString()}`);
@@ -946,7 +980,7 @@ export function runListTests(
       it('should support happy path for listConcatenateBack via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 
@@ -973,13 +1007,15 @@ export function runListTests(
 
     describe('#listConcatenateFront', () => {
       itBehavesLikeItValidates((props: ValidateListProps) => {
-        return Momento.listConcatenateFront(props.cacheName, props.listName, [
-          v4(),
-        ]);
+        return cacheClient.listConcatenateFront(
+          props.cacheName,
+          props.listName,
+          [v4()]
+        );
       });
 
       itBehavesLikeItAddsValuesToTheFront((props: addValueProps) => {
-        return Momento.listConcatenateFront(
+        return cacheClient.listConcatenateFront(
           props.cacheName,
           props.listName,
           [props.value] as string[] | Uint8Array[],
@@ -995,8 +1031,8 @@ export function runListTests(
         const values1 = ['1', '2', '3', '4'];
         const values2 = ['this', 'that'];
 
-        let respConcat = await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        let respConcat = await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values1
         );
@@ -1007,8 +1043,8 @@ export function runListTests(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length);
 
-        let respFetch = await Momento.listFetch(
-          IntegrationTestCacheName,
+        let respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
           listName
         );
         expectWithMessage(() => {
@@ -1018,8 +1054,8 @@ export function runListTests(
           values1
         );
 
-        respConcat = await Momento.listConcatenateFront(
-          IntegrationTestCacheName,
+        respConcat = await cacheClient.listConcatenateFront(
+          integrationTestCacheName,
           listName,
           values2
         );
@@ -1030,7 +1066,10 @@ export function runListTests(
           (respConcat as CacheListConcatenateFront.Success).listLength()
         ).toEqual(values1.length + values2.length);
 
-        respFetch = await Momento.listFetch(IntegrationTestCacheName, listName);
+        respFetch = await cacheClient.listFetch(
+          integrationTestCacheName,
+          listName
+        );
         expectWithMessage(() => {
           expect(respFetch).toBeInstanceOf(CacheListFetch.Hit);
         }, `expected a HIT but got ${respFetch.toString()}`);
@@ -1042,7 +1081,7 @@ export function runListTests(
       it('should support happy path for listConcatenateFront via curried cache via ICache interface', async () => {
         const listName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.listConcatenateFront(listName, ['foo', 'bar']);
 

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -26,8 +26,8 @@ const LOL_BYTE_ARRAY = Uint8Array.of(108, 111, 108);
 const FOO_BYTE_ARRAY = Uint8Array.of(102, 111, 111);
 
 export function runSetTests(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('Integration tests for convenience operations on sets datastructure', () => {
     const itBehavesLikeItValidates = (
@@ -39,7 +39,7 @@ export function runSetTests(
 
       it('validates its set name', async () => {
         const response = await getResponse({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           setName: '  ',
         });
 
@@ -50,24 +50,26 @@ export function runSetTests(
     };
 
     itBehavesLikeItValidates((props: ValidateSetProps) => {
-      return Momento.setAddElement(props.cacheName, props.setName, v4());
+      return cacheClient.setAddElement(props.cacheName, props.setName, v4());
     });
     itBehavesLikeItValidates((props: ValidateSetProps) => {
-      return Momento.setAddElements(props.cacheName, props.setName, [v4()]);
+      return cacheClient.setAddElements(props.cacheName, props.setName, [v4()]);
     });
     itBehavesLikeItValidates((props: ValidateSetProps) => {
-      return Momento.setFetch(props.cacheName, props.setName);
+      return cacheClient.setFetch(props.cacheName, props.setName);
     });
     itBehavesLikeItValidates((props: ValidateSetProps) => {
-      return Momento.setRemoveElements(props.cacheName, props.setName, [v4()]);
+      return cacheClient.setRemoveElements(props.cacheName, props.setName, [
+        v4(),
+      ]);
     });
   });
 
   describe('#addElement', () => {
     it('should succeed for addElement with a byte array happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElement(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElement(
+        integrationTestCacheName,
         setName,
         LOL_BYTE_ARRAY
       );
@@ -75,8 +77,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -89,8 +91,8 @@ export function runSetTests(
 
     it('should succeed for addElement with a string happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElement(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElement(
+        integrationTestCacheName,
         setName,
         'lol'
       );
@@ -98,8 +100,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -113,7 +115,7 @@ export function runSetTests(
     it('should support happy path for addElement via curried cache via ICache interface', async () => {
       const setName = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.setAddElements(setName, ['foo', 'bar']);
 
@@ -135,8 +137,8 @@ export function runSetTests(
   describe('#removeElement', () => {
     it('should succeed for removeElement with a byte array happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY, LOL_BYTE_ARRAY]
       );
@@ -144,15 +146,15 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElement(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElement(
+        integrationTestCacheName,
         setName,
         FOO_BYTE_ARRAY
       );
       expect(removeResponse).toBeInstanceOf(CacheSetRemoveElement.Success);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -165,8 +167,8 @@ export function runSetTests(
 
     it('should succeed for removeElement with a string array happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY, LOL_BYTE_ARRAY]
       );
@@ -174,8 +176,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElement(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElement(
+        integrationTestCacheName,
         setName,
         'foo'
       );
@@ -183,8 +185,8 @@ export function runSetTests(
         expect(removeResponse).toBeInstanceOf(CacheSetRemoveElement.Success);
       }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -198,7 +200,7 @@ export function runSetTests(
     it('should support happy path for removeElement via curried cache via ICache interface', async () => {
       const setName = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.setAddElements(setName, ['foo', 'bar', 'baz']);
 
@@ -220,8 +222,8 @@ export function runSetTests(
   describe('#addElements', () => {
     it('should succeed for addElements with byte arrays happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
@@ -229,8 +231,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -243,8 +245,8 @@ export function runSetTests(
 
     it('should succeed for addElements with byte arrays happy path with no refresh ttl', async () => {
       const setName = v4();
-      let addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      let addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(2, false)}
@@ -253,8 +255,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(10, false)}
@@ -265,8 +267,8 @@ export function runSetTests(
 
       await sleep(2_000);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -276,8 +278,8 @@ export function runSetTests(
 
     it('should succeed for addElements with byte arrays happy path with refresh ttl', async () => {
       const setName = v4();
-      let addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      let addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(2, false)}
@@ -286,8 +288,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY],
         {ttl: new CollectionTtl(10, true)}
@@ -298,8 +300,8 @@ export function runSetTests(
 
       await sleep(2_000);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -318,8 +320,8 @@ export function runSetTests(
 
     it('should succeed for addElements for string arrays happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         ['lol', 'foo']
       );
@@ -327,8 +329,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -345,16 +347,16 @@ export function runSetTests(
 
     it('should succeed for addElements with duplicate elements', async () => {
       const setName = v4();
-      let addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      let addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
       expectWithMessage(() => {
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
-      addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY]
       );
@@ -362,8 +364,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -377,7 +379,7 @@ export function runSetTests(
     it('should support happy path for addElements via curried cache via ICache interface', async () => {
       const setName = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.setAddElements(setName, ['foo', 'bar']);
 
@@ -399,8 +401,8 @@ export function runSetTests(
   describe('#removeElements', () => {
     it('should succeed for removeElements byte arrays happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
@@ -408,8 +410,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElements(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElements(
+        integrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY]
       );
@@ -417,8 +419,8 @@ export function runSetTests(
         expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
       }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -431,8 +433,8 @@ export function runSetTests(
 
     it('should succeed for removeElements string arrays happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         ['lol', 'foo']
       );
@@ -440,8 +442,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElements(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElements(
+        integrationTestCacheName,
         setName,
         ['foo']
       );
@@ -449,8 +451,8 @@ export function runSetTests(
         expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
       }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -463,8 +465,8 @@ export function runSetTests(
 
     it('should succeed for removeElements when the element does not exist', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY]
       );
@@ -472,8 +474,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElements(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElements(
+        integrationTestCacheName,
         setName,
         [FOO_BYTE_ARRAY]
       );
@@ -481,8 +483,8 @@ export function runSetTests(
         expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
       }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -495,8 +497,8 @@ export function runSetTests(
 
     it('should succeed for removeElements when bytes/strings are used together', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
@@ -504,8 +506,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const removeResponse = await Momento.setRemoveElements(
-        IntegrationTestCacheName,
+      const removeResponse = await cacheClient.setRemoveElements(
+        integrationTestCacheName,
         setName,
         ['lol']
       );
@@ -513,8 +515,8 @@ export function runSetTests(
         expect(removeResponse).toBeInstanceOf(CacheSetRemoveElements.Success);
       }, `expected SUCCESS but got ${removeResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -528,7 +530,7 @@ export function runSetTests(
     it('should support happy path for removeElements via curried cache via ICache interface', async () => {
       const setName = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.setAddElements(setName, ['foo', 'bar', 'baz', 'bam']);
 
@@ -550,8 +552,8 @@ export function runSetTests(
   describe('#setFetch', () => {
     it('should succeed for string arrays happy path', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         ['how', 'ya', 'ding']
       );
@@ -559,8 +561,8 @@ export function runSetTests(
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
 
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -576,8 +578,8 @@ export function runSetTests(
     });
 
     it('should return MISS if set does not exist', async () => {
-      const noKeyGetResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const noKeyGetResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         'this-set-doesnt-exist'
       );
       expect(noKeyGetResponse).toBeInstanceOf(CacheSetFetch.Miss);
@@ -585,21 +587,21 @@ export function runSetTests(
 
     it('should return MISS if set has been deleted', async () => {
       const setName = v4();
-      const addResponse = await Momento.setAddElements(
-        IntegrationTestCacheName,
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
         setName,
         [LOL_BYTE_ARRAY, FOO_BYTE_ARRAY]
       );
       expectWithMessage(() => {
         expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
       }, `expected SUCCESS but got ${addResponse.toString()}`);
-      const deleteResponse = await Momento.delete(
-        IntegrationTestCacheName,
+      const deleteResponse = await cacheClient.delete(
+        integrationTestCacheName,
         setName
       );
       expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
-      const fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      const fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -610,7 +612,7 @@ export function runSetTests(
     it('should support happy path for fetch via curried cache via ICache interface', async () => {
       const setName = v4();
 
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
 
       await cache.setAddElements(setName, ['foo', 'bar']);
 
@@ -626,13 +628,13 @@ export function runSetTests(
     it('should support accessing value for CacheSetFetch.Hit without instanceof check', async () => {
       const setName = v4();
 
-      await Momento.setAddElements(IntegrationTestCacheName, setName, [
+      await cacheClient.setAddElements(integrationTestCacheName, setName, [
         'foo',
         'bar',
       ]);
 
-      let fetchResponse = await Momento.setFetch(
-        IntegrationTestCacheName,
+      let fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
         setName
       );
       expectWithMessage(() => {
@@ -647,7 +649,10 @@ export function runSetTests(
       expect(new Set(hit.value())).toEqual(new Set(expectedResult));
       expect(new Set(hit.valueArray())).toEqual(new Set(expectedResult));
 
-      fetchResponse = await Momento.setFetch(IntegrationTestCacheName, v4());
+      fetchResponse = await cacheClient.setFetch(
+        integrationTestCacheName,
+        v4()
+      );
       expectWithMessage(() => {
         expect(fetchResponse).toBeInstanceOf(CacheSetFetch.Miss);
       }, `expected a MISS but got ${fetchResponse.toString()}`);

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -34,8 +34,8 @@ import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 
 export function runSortedSetTests(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('Integration tests for sorted set operations', () => {
     it('is good at logic', async () => {
@@ -56,7 +56,7 @@ export function runSortedSetTests(
 
       it('validates its sorted set name', async () => {
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: '  ',
           value: v4(),
         });
@@ -72,7 +72,7 @@ export function runSortedSetTests(
     ) => {
       it('misses when the sorted set does not exist', async () => {
         const response = await responder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: v4(),
           value: v4(),
         });
@@ -92,7 +92,7 @@ export function runSortedSetTests(
         const timeout = 1;
 
         let changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: sortedSetName,
           value: value,
           score: 42,
@@ -101,7 +101,7 @@ export function runSortedSetTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
 
         changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: sortedSetName,
           value: value,
           score: 42,
@@ -110,8 +110,8 @@ export function runSortedSetTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
         await sleep(timeout * 1000);
 
-        const getResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -125,7 +125,7 @@ export function runSortedSetTests(
         const timeout = 1;
 
         let changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: sortedSetName,
           value: value,
           score: 42,
@@ -134,7 +134,7 @@ export function runSortedSetTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
 
         changeResponse = await changeResponder({
-          cacheName: IntegrationTestCacheName,
+          cacheName: integrationTestCacheName,
           sortedSetName: sortedSetName,
           value: value,
           score: 42,
@@ -143,8 +143,8 @@ export function runSortedSetTests(
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
         await sleep(timeout * 1000);
 
-        const getResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const getResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -155,7 +155,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetFetchByRank', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetFetchByRank(
+        return cacheClient.sortedSetFetchByRank(
           props.cacheName,
           props.sortedSetName
         );
@@ -166,14 +166,14 @@ export function runSortedSetTests(
 
       it('should return expected toString value with sortedSetFetch', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           'a',
           42
         );
-        const response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -191,8 +191,8 @@ export function runSortedSetTests(
         const field2 = 'bar';
         const score2 = 42;
 
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [field1, score1],
@@ -200,8 +200,8 @@ export function runSortedSetTests(
           ])
         );
 
-        const response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -232,8 +232,8 @@ export function runSortedSetTests(
         const sortedSetName = v4();
 
         beforeAll(done => {
-          const setupPromise = Momento.sortedSetPutElements(
-            IntegrationTestCacheName,
+          const setupPromise = cacheClient.sortedSetPutElements(
+            integrationTestCacheName,
             sortedSetName,
             {
               bam: 1000,
@@ -256,8 +256,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the specified range if start rank is specified', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: 4,
@@ -277,8 +277,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the specified range if end rank is specified', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               endRank: 3,
@@ -297,8 +297,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the specified range if both start and end rank are specified', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: 1,
@@ -319,8 +319,8 @@ export function runSortedSetTests(
         });
 
         it('should return an empty list if start rank is out of bounds', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: 10,
@@ -335,8 +335,8 @@ export function runSortedSetTests(
         });
 
         it('should return all the remaining elements if end rank is out of bounds', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: 5,
@@ -356,8 +356,8 @@ export function runSortedSetTests(
         });
 
         it('should return the last elements if start rank is negative', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: -5,
@@ -378,8 +378,8 @@ export function runSortedSetTests(
         });
 
         it('should return all but the last elements if end rank is negative', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               endRank: -2,
@@ -401,8 +401,8 @@ export function runSortedSetTests(
         });
 
         it('should return a range from the end of the set if both start and end rank are negative', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               startRank: -5,
@@ -422,8 +422,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch in ascending order if order is explicitly specified', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Ascending,
@@ -447,8 +447,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch in descending order if specified', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -472,8 +472,8 @@ export function runSortedSetTests(
         });
 
         it('should support descending order with a start rank', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -493,8 +493,8 @@ export function runSortedSetTests(
         });
 
         it('should support descending order with a end rank', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -514,8 +514,8 @@ export function runSortedSetTests(
         });
 
         it('should support descending order with a start and end rank', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -535,8 +535,8 @@ export function runSortedSetTests(
         });
 
         it('should error if start rank is greater than end rank', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -561,8 +561,8 @@ export function runSortedSetTests(
         });
 
         it('should error if negative start rank is less than negative end rank', async () => {
-          const response = await Momento.sortedSetFetchByRank(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByRank(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -589,16 +589,16 @@ export function runSortedSetTests(
 
       it('should return a miss if the sorted set does not exist', async () => {
         const sortedSetName = v4();
-        let fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
         }, `expected MISS but got ${fetchResponse.toString()}`);
 
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [v4(), 1],
@@ -607,24 +607,24 @@ export function runSortedSetTests(
           ])
         );
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
         }, `expected HIT but got ${fetchResponse.toString()}`);
 
-        const deleteResponse = await Momento.delete(
-          IntegrationTestCacheName,
+        const deleteResponse = await cacheClient.delete(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
         }, `expected SUCCESS but got ${deleteResponse.toString()}`);
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -635,7 +635,7 @@ export function runSortedSetTests(
       it('should support happy path for fetchByRank via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.sortedSetPutElements(sortedSetName, {
           bam: 1000,
@@ -668,8 +668,8 @@ export function runSortedSetTests(
       it('should support accessing value for a sortedSetFetchByRank Hit without instanceof check', async () => {
         const sortedSetName = v4();
 
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             bam: 1000,
@@ -683,8 +683,8 @@ export function runSortedSetTests(
           }
         );
 
-        let fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName,
           {
             startRank: 1,
@@ -709,8 +709,8 @@ export function runSortedSetTests(
         expect(hitResponse.value()).toEqual(expectedResult);
         expect(hitResponse.valueArray()).toEqual(expectedResult);
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           v4()
         );
 
@@ -723,7 +723,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetFetchByScore', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetFetchByScore(
+        return cacheClient.sortedSetFetchByScore(
           props.cacheName,
           props.sortedSetName
         );
@@ -734,14 +734,14 @@ export function runSortedSetTests(
 
       it('should return expected toString value', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           'a',
           42
         );
-        const response = await Momento.sortedSetFetchByScore(
-          IntegrationTestCacheName,
+        const response = await cacheClient.sortedSetFetchByScore(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -759,8 +759,8 @@ export function runSortedSetTests(
         const field2 = 'bar';
         const score2 = 42;
 
-        const putResponse = await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        const putResponse = await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [field1, score1],
@@ -771,8 +771,8 @@ export function runSortedSetTests(
           expect(putResponse).toBeInstanceOf(CacheSortedSetPutElements.Success);
         }, `expected SUCCESS but got ${putResponse.toString()}`);
 
-        const response = await Momento.sortedSetFetchByScore(
-          IntegrationTestCacheName,
+        const response = await cacheClient.sortedSetFetchByScore(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -803,8 +803,8 @@ export function runSortedSetTests(
         const sortedSetName = v4();
 
         beforeAll(done => {
-          const setupPromise = Momento.sortedSetPutElements(
-            IntegrationTestCacheName,
+          const setupPromise = cacheClient.sortedSetPutElements(
+            integrationTestCacheName,
             sortedSetName,
             {
               bam: 1000,
@@ -827,8 +827,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the matching elements if minScore is specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -848,8 +848,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the matching elements if maxScore is specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               maxScore: 1000,
@@ -870,8 +870,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch only the matching elements if minScore and maxScore are specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -890,8 +890,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch an empty list if minScore is out of range', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 2_000_000,
@@ -906,8 +906,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch an empty list if maxScore is out of range', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               maxScore: 0,
@@ -922,8 +922,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch the whole set if minScore is less than the minimum score', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 0,
@@ -947,8 +947,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch the whole set if maxScore is greater than the maximum score', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               maxScore: 2_000_000,
@@ -972,8 +972,8 @@ export function runSortedSetTests(
         });
 
         it('should error if minScore is greater than maxScore', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 1_000,
@@ -997,8 +997,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch starting from the offset if specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1017,8 +1017,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch the specified number of results if count is specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1037,8 +1037,8 @@ export function runSortedSetTests(
         });
 
         it('should fetch the specified number of results from the offset if both count and offset are specified', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 10,
@@ -1059,8 +1059,8 @@ export function runSortedSetTests(
         });
 
         it('should return an empty list if offset is greater than the size of the results', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1076,8 +1076,8 @@ export function runSortedSetTests(
         });
 
         it('should return all remaining results if count is greater than the number of available results', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1098,8 +1098,8 @@ export function runSortedSetTests(
         });
 
         it('should error if count is negative', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1123,8 +1123,8 @@ export function runSortedSetTests(
         });
 
         it('should error if offset is negative', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               minScore: 100,
@@ -1148,8 +1148,8 @@ export function runSortedSetTests(
         });
 
         it('should return results in ascending order if order is explicitly set to ascending', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Ascending,
@@ -1170,8 +1170,8 @@ export function runSortedSetTests(
         });
 
         it('should return results in descending order if order is set to descending', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -1192,8 +1192,8 @@ export function runSortedSetTests(
         });
 
         it('should support offset and count when returning results in descending order', async () => {
-          const response = await Momento.sortedSetFetchByScore(
-            IntegrationTestCacheName,
+          const response = await cacheClient.sortedSetFetchByScore(
+            integrationTestCacheName,
             sortedSetName,
             {
               order: SortedSetOrder.Descending,
@@ -1217,16 +1217,16 @@ export function runSortedSetTests(
 
       it('should return a miss if the sorted set does not exist', async () => {
         const sortedSetName = v4();
-        let fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
         }, `expected MISS but got ${fetchResponse.toString()}`);
 
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [v4(), 1],
@@ -1235,24 +1235,24 @@ export function runSortedSetTests(
           ])
         );
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Hit);
         }, `expected HIT but got ${fetchResponse.toString()}`);
 
-        const deleteResponse = await Momento.delete(
-          IntegrationTestCacheName,
+        const deleteResponse = await cacheClient.delete(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(deleteResponse).toBeInstanceOf(CacheDelete.Success);
         }, `expected SUCCESS but got ${deleteResponse.toString()}`);
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1263,7 +1263,7 @@ export function runSortedSetTests(
       it('should support happy path for fetchByScore via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
 
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
 
         await cache.sortedSetPutElements(sortedSetName, {
           bam: 1000,
@@ -1294,8 +1294,8 @@ export function runSortedSetTests(
       it('should support accessing value for sortedSetFetchByScore Hit without instanceof check', async () => {
         const sortedSetName = v4();
 
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             bam: 1000,
@@ -1309,8 +1309,8 @@ export function runSortedSetTests(
           }
         );
 
-        let fetchResponse = await Momento.sortedSetFetchByScore(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.sortedSetFetchByScore(
+          integrationTestCacheName,
           sortedSetName,
           {
             minScore: 100,
@@ -1333,8 +1333,8 @@ export function runSortedSetTests(
         expect(hitResponse.value()).toEqual(expectedResult);
         expect(hitResponse.valueArray()).toEqual(expectedResult);
 
-        fetchResponse = await Momento.sortedSetFetchByScore(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByScore(
+          integrationTestCacheName,
           v4()
         );
 
@@ -1347,7 +1347,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetGetRank', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetGetRank(
+        return cacheClient.sortedSetGetRank(
           props.cacheName,
           props.sortedSetName,
           props.value
@@ -1359,14 +1359,14 @@ export function runSortedSetTests(
 
       it('retrieves rank for a value that exists', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        let result = await Momento.sortedSetGetRank(
-          IntegrationTestCacheName,
+        let result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
           sortedSetName,
           'bar'
         );
@@ -1376,8 +1376,8 @@ export function runSortedSetTests(
         let hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(1);
 
-        result = await Momento.sortedSetGetRank(
-          IntegrationTestCacheName,
+        result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
           sortedSetName,
           'baz'
         );
@@ -1387,8 +1387,8 @@ export function runSortedSetTests(
         hitResult = result as CacheSortedSetGetRank.Hit;
         expect(hitResult.rank()).toEqual(2);
 
-        result = await Momento.sortedSetGetRank(
-          IntegrationTestCacheName,
+        result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
           sortedSetName,
           'foo'
         );
@@ -1401,14 +1401,14 @@ export function runSortedSetTests(
 
       it('returns a miss for a value that does not exist', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        const result = await Momento.sortedSetGetRank(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
           sortedSetName,
           'taco'
         );
@@ -1419,7 +1419,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetGetRank via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -1437,7 +1437,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetGetScore', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetGetScore(
+        return cacheClient.sortedSetGetScore(
           props.cacheName,
           props.sortedSetName,
           props.value
@@ -1449,14 +1449,14 @@ export function runSortedSetTests(
 
       it('retrieves score for a value that exists', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        let result = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        let result = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           sortedSetName,
           'bar'
         );
@@ -1466,8 +1466,8 @@ export function runSortedSetTests(
         let hitResult = result as CacheSortedSetGetScore.Hit;
         expect(hitResult.score()).toEqual(84);
 
-        result = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        result = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           sortedSetName,
           'baz'
         );
@@ -1480,14 +1480,14 @@ export function runSortedSetTests(
 
       it('returns a miss for a value that does not exist', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        const result = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           sortedSetName,
           'taco'
         );
@@ -1498,7 +1498,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetGetScore via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -1515,8 +1515,8 @@ export function runSortedSetTests(
 
       it('should support accessing value for CacheSortedSetGetScore.Hit without instanceof check', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 42,
@@ -1525,8 +1525,8 @@ export function runSortedSetTests(
           }
         );
 
-        let getScoreResponse = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        let getScoreResponse = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           sortedSetName,
           'bar'
         );
@@ -1539,8 +1539,8 @@ export function runSortedSetTests(
         const hitResult = getScoreResponse as CacheSortedSetGetScore.Hit;
         expect(hitResult.score()).toEqual(84);
 
-        getScoreResponse = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        getScoreResponse = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           v4(),
           'bar'
         );
@@ -1555,7 +1555,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetGetScores', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetGetScores(
+        return cacheClient.sortedSetGetScores(
           props.cacheName,
           props.sortedSetName,
           [props.value] as string[] | Uint8Array[]
@@ -1567,14 +1567,14 @@ export function runSortedSetTests(
 
       it('retrieves scores for values that exist', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        const result = await Momento.sortedSetGetScores(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetGetScores(
+          integrationTestCacheName,
           sortedSetName,
           ['bar', 'baz']
         );
@@ -1590,14 +1590,14 @@ export function runSortedSetTests(
 
       it('returns partial record if some values do not exist', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84, baz: 90210}
         );
 
-        const result = await Momento.sortedSetGetScores(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetGetScores(
+          integrationTestCacheName,
           sortedSetName,
           ['bar', 'taco']
         );
@@ -1612,7 +1612,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetGetScores via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -1632,8 +1632,8 @@ export function runSortedSetTests(
 
       it('should support accessing value for CacheSortedSetGetScores.Hit without instanceof check', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 42,
@@ -1642,8 +1642,8 @@ export function runSortedSetTests(
           }
         );
 
-        let getScoresResponse = await Momento.sortedSetGetScores(
-          IntegrationTestCacheName,
+        let getScoresResponse = await cacheClient.sortedSetGetScores(
+          integrationTestCacheName,
           sortedSetName,
           ['bar', 'baz']
         );
@@ -1659,8 +1659,8 @@ export function runSortedSetTests(
         expect(hitResult.value()).toEqual(expectedResult);
         expect(hitResult.valueRecord()).toEqual(expectedResult);
 
-        getScoresResponse = await Momento.sortedSetGetScores(
-          IntegrationTestCacheName,
+        getScoresResponse = await cacheClient.sortedSetGetScores(
+          integrationTestCacheName,
           v4(),
           ['foo', 'bar']
         );
@@ -1676,7 +1676,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetIncrementScore', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetIncrementScore(
+        return cacheClient.sortedSetIncrementScore(
           props.cacheName,
           props.sortedSetName,
           props.value
@@ -1684,7 +1684,7 @@ export function runSortedSetTests(
       };
 
       const changeResponder = (props: ValidateSortedSetChangerProps) => {
-        return Momento.sortedSetIncrementScore(
+        return cacheClient.sortedSetIncrementScore(
           props.cacheName,
           props.sortedSetName,
           props.value,
@@ -1698,16 +1698,16 @@ export function runSortedSetTests(
 
       it('creates sorted set and element if they do not exist', async () => {
         const sortedSetName = v4();
-        let fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        let fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(fetchResponse).toBeInstanceOf(CacheSortedSetFetch.Miss);
         }, `expected MISS but got ${fetchResponse.toString()}`);
 
-        let incrementResponse = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        let incrementResponse = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           'foo'
         );
@@ -1720,8 +1720,8 @@ export function runSortedSetTests(
           incrementResponse as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(1);
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1735,8 +1735,8 @@ export function runSortedSetTests(
           },
         ]);
 
-        incrementResponse = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        incrementResponse = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           'bar',
           42
@@ -1751,8 +1751,8 @@ export function runSortedSetTests(
           incrementResponse as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(42);
 
-        fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
 
@@ -1769,15 +1769,15 @@ export function runSortedSetTests(
       it('increments an existing field by the expected amount for a string value', async () => {
         const sortedSetName = v4();
         const value = 'foo';
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           value,
           90210
         );
 
-        const incrementResponse = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        const incrementResponse = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           value,
           10
@@ -1791,8 +1791,8 @@ export function runSortedSetTests(
           incrementResponse as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(90220);
 
-        const fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1807,15 +1807,15 @@ export function runSortedSetTests(
       it('increments an existing field by the expected amount for a bytes value', async () => {
         const sortedSetName = v4();
         const value = uint8ArrayForTest('foo');
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           value,
           90210
         );
 
-        const incrementResponse = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        const incrementResponse = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           value,
           10
@@ -1829,8 +1829,8 @@ export function runSortedSetTests(
           incrementResponse as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(90220);
 
-        const fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1845,15 +1845,15 @@ export function runSortedSetTests(
       it('decrements an existing field by the expected amount for a string value', async () => {
         const sortedSetName = v4();
         const value = 'foo';
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           value,
           90210
         );
 
-        const incrementRespone = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        const incrementRespone = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           value,
           -10
@@ -1867,8 +1867,8 @@ export function runSortedSetTests(
           incrementRespone as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(90200);
 
-        const fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1883,15 +1883,15 @@ export function runSortedSetTests(
       it('increments an existing field by the expected amount for a bytes value', async () => {
         const sortedSetName = v4();
         const value = uint8ArrayForTest('foo');
-        await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           value,
           90210
         );
 
-        const incrementResponse = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        const incrementResponse = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           value,
           -10
@@ -1905,8 +1905,8 @@ export function runSortedSetTests(
           incrementResponse as CacheSortedSetIncrementScore.Success;
         expect(successResponse.score()).toEqual(90200);
 
-        const fetchResponse = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        const fetchResponse = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -1920,7 +1920,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetIncrementScore via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -1940,8 +1940,8 @@ export function runSortedSetTests(
 
       it('should support accessing value for SortedSetIncrementScore.Success without instanceof check', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 42,
@@ -1950,8 +1950,8 @@ export function runSortedSetTests(
           }
         );
 
-        const result = await Momento.sortedSetIncrementScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetIncrementScore(
+          integrationTestCacheName,
           sortedSetName,
           'bar'
         );
@@ -1968,7 +1968,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetRemoveElement', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetRemoveElement(
+        return cacheClient.sortedSetRemoveElement(
           props.cacheName,
           props.sortedSetName,
           props.value
@@ -1979,8 +1979,8 @@ export function runSortedSetTests(
 
       it('should remove a string value', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 21,
@@ -1988,8 +1988,8 @@ export function runSortedSetTests(
           }
         );
 
-        let response = await Momento.sortedSetRemoveElement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElement(
+          integrationTestCacheName,
           sortedSetName,
           'foo'
         );
@@ -1997,8 +1997,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2010,8 +2010,8 @@ export function runSortedSetTests(
 
       it('should remove a bytes value', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [uint8ArrayForTest('foo'), 21],
@@ -2019,8 +2019,8 @@ export function runSortedSetTests(
           ])
         );
 
-        let response = await Momento.sortedSetRemoveElement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElement(
+          integrationTestCacheName,
           sortedSetName,
           uint8ArrayForTest('foo')
         );
@@ -2028,8 +2028,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2043,8 +2043,8 @@ export function runSortedSetTests(
 
       it("should do nothing for a value that doesn't exist", async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 21,
@@ -2052,8 +2052,8 @@ export function runSortedSetTests(
           }
         );
 
-        let response = await Momento.sortedSetRemoveElement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElement(
+          integrationTestCacheName,
           sortedSetName,
           'taco'
         );
@@ -2061,8 +2061,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElement.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2077,7 +2077,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetRemoveElement via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2102,7 +2102,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetRemoveElements', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetRemoveElements(
+        return cacheClient.sortedSetRemoveElements(
           props.cacheName,
           props.sortedSetName,
           ['foo']
@@ -2113,8 +2113,8 @@ export function runSortedSetTests(
 
       it('should remove string values', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 21,
@@ -2123,8 +2123,8 @@ export function runSortedSetTests(
           }
         );
 
-        let response = await Momento.sortedSetRemoveElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElements(
+          integrationTestCacheName,
           sortedSetName,
           ['foo', 'baz']
         );
@@ -2132,8 +2132,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2145,8 +2145,8 @@ export function runSortedSetTests(
 
       it('should remove bytes values', async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [uint8ArrayForTest('foo'), 21],
@@ -2155,8 +2155,8 @@ export function runSortedSetTests(
           ])
         );
 
-        let response = await Momento.sortedSetRemoveElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElements(
+          integrationTestCacheName,
           sortedSetName,
           [uint8ArrayForTest('foo'), uint8ArrayForTest('baz')]
         );
@@ -2164,8 +2164,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2179,8 +2179,8 @@ export function runSortedSetTests(
 
       it("should do nothing for values that don't exist", async () => {
         const sortedSetName = v4();
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {
             foo: 21,
@@ -2189,8 +2189,8 @@ export function runSortedSetTests(
           }
         );
 
-        let response = await Momento.sortedSetRemoveElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetRemoveElements(
+          integrationTestCacheName,
           sortedSetName,
           ['taco', 'habanero']
         );
@@ -2198,8 +2198,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetRemoveElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2215,7 +2215,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetRemoveElements via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2242,7 +2242,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetPutElement', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetPutElement(
+        return cacheClient.sortedSetPutElement(
           props.cacheName,
           props.sortedSetName,
           props.value,
@@ -2251,7 +2251,7 @@ export function runSortedSetTests(
       };
 
       const changeResponder = (props: ValidateSortedSetChangerProps) => {
-        return Momento.sortedSetPutElement(
+        return cacheClient.sortedSetPutElement(
           props.cacheName,
           props.sortedSetName,
           props.value,
@@ -2265,8 +2265,8 @@ export function runSortedSetTests(
 
       it('should store an element with a string value', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           'foo',
           42
@@ -2275,8 +2275,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2288,8 +2288,8 @@ export function runSortedSetTests(
 
       it('should store an element with a bytes value', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElement(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElement(
+          integrationTestCacheName,
           sortedSetName,
           uint8ArrayForTest('foo'),
           42
@@ -2298,8 +2298,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetPutElement.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2313,7 +2313,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetPutElement via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2344,7 +2344,7 @@ export function runSortedSetTests(
 
     describe('#sortedSetPutElements', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetPutElements(
+        return cacheClient.sortedSetPutElements(
           props.cacheName,
           props.sortedSetName,
           new Map([[props.value, 42]])
@@ -2352,7 +2352,7 @@ export function runSortedSetTests(
       };
 
       const changeResponder = (props: ValidateSortedSetChangerProps) => {
-        return Momento.sortedSetPutElements(
+        return cacheClient.sortedSetPutElements(
           props.cacheName,
           props.sortedSetName,
           new Map([[props.value, props.score]]),
@@ -2365,8 +2365,8 @@ export function runSortedSetTests(
 
       it('should store elements with a string values passed via Map', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             ['foo', 42],
@@ -2377,8 +2377,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2393,8 +2393,8 @@ export function runSortedSetTests(
 
       it('should store elements with a string values passed via Record', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           {foo: 42, bar: 84}
         );
@@ -2402,8 +2402,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2418,8 +2418,8 @@ export function runSortedSetTests(
 
       it('should store elements with a bytes values passed via Map', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             [uint8ArrayForTest('foo'), 42],
@@ -2430,8 +2430,8 @@ export function runSortedSetTests(
           expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
 
-        response = await Momento.sortedSetFetchByRank(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetFetchByRank(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2446,7 +2446,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetPutElements via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2477,7 +2477,10 @@ export function runSortedSetTests(
 
     describe('#sortedSetLength', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetLength(props.cacheName, props.sortedSetName);
+        return cacheClient.sortedSetLength(
+          props.cacheName,
+          props.sortedSetName
+        );
       };
 
       itBehavesLikeItValidates(responder);
@@ -2487,14 +2490,14 @@ export function runSortedSetTests(
         const sortedSetName = v4();
         const setValues = {foo: 42, bar: 84, baz: 90210};
         const numElements = Object.keys(setValues).length;
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
 
-        const result = await Momento.sortedSetLength(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLength(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2507,7 +2510,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetLength via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2525,7 +2528,10 @@ export function runSortedSetTests(
 
     describe('#sortedSetLengthByScore', () => {
       const responder = (props: ValidateSortedSetProps) => {
-        return Momento.sortedSetLength(props.cacheName, props.sortedSetName);
+        return cacheClient.sortedSetLength(
+          props.cacheName,
+          props.sortedSetName
+        );
       };
 
       itBehavesLikeItValidates(responder);
@@ -2535,14 +2541,14 @@ export function runSortedSetTests(
         const sortedSetName = v4();
         const setValues = {foo: 42, bar: 84, baz: 90210};
         const numElements = Object.keys(setValues).length;
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
 
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2557,14 +2563,14 @@ export function runSortedSetTests(
         const sortedSetName = v4();
         const setValues = {foo: 42, bar: 42, baz: 42};
         const numElements = Object.keys(setValues).length;
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
 
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2589,14 +2595,14 @@ export function runSortedSetTests(
           fire: 555,
         };
         const numElements = Object.keys(setValues).length;
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
 
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
@@ -2620,8 +2626,8 @@ export function runSortedSetTests(
           earth: 555,
           fire: 555,
         };
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
@@ -2630,8 +2636,8 @@ export function runSortedSetTests(
           minScore: 42,
           maxScore: undefined,
         };
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName,
           scoreRange
         );
@@ -2654,8 +2660,8 @@ export function runSortedSetTests(
           earth: 555,
           fire: 555,
         };
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
@@ -2664,8 +2670,8 @@ export function runSortedSetTests(
           minScore: undefined,
           maxScore: 42,
         };
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName,
           scoreRange
         );
@@ -2688,8 +2694,8 @@ export function runSortedSetTests(
           earth: 555,
           fire: 555,
         };
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
@@ -2698,8 +2704,8 @@ export function runSortedSetTests(
           minScore: 0,
           maxScore: 100,
         };
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName,
           scoreRange
         );
@@ -2722,8 +2728,8 @@ export function runSortedSetTests(
           earth: -555,
           fire: -555,
         };
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
@@ -2732,8 +2738,8 @@ export function runSortedSetTests(
           minScore: -100,
           maxScore: 0,
         };
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName,
           scoreRange
         );
@@ -2756,8 +2762,8 @@ export function runSortedSetTests(
           earth: 555,
           fire: 555,
         };
-        await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           setValues
         );
@@ -2766,8 +2772,8 @@ export function runSortedSetTests(
           minScore: 1,
           maxScore: 42,
         };
-        const result = await Momento.sortedSetLengthByScore(
-          IntegrationTestCacheName,
+        const result = await cacheClient.sortedSetLengthByScore(
+          integrationTestCacheName,
           sortedSetName,
           scoreRange
         );
@@ -2779,7 +2785,7 @@ export function runSortedSetTests(
 
       it('should support happy path for sortedSetLengthByScore via curried cache via ICache interface', async () => {
         const sortedSetName = v4();
-        const cache = Momento.cache(IntegrationTestCacheName);
+        const cache = cacheClient.cache(integrationTestCacheName);
         await cache.sortedSetPutElements(sortedSetName, {
           foo: 42,
           bar: 84,
@@ -2801,8 +2807,8 @@ export function runSortedSetTests(
     describe('test deleting sorted set', () => {
       it('returns a miss for a deleted sorted set', async () => {
         const sortedSetName = v4();
-        let response = await Momento.sortedSetPutElements(
-          IntegrationTestCacheName,
+        let response = await cacheClient.sortedSetPutElements(
+          integrationTestCacheName,
           sortedSetName,
           new Map([
             ['foo', 42],
@@ -2812,15 +2818,15 @@ export function runSortedSetTests(
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheSortedSetPutElements.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        response = await Momento.delete(
-          IntegrationTestCacheName,
+        response = await cacheClient.delete(
+          integrationTestCacheName,
           sortedSetName
         );
         expectWithMessage(() => {
           expect(response).toBeInstanceOf(CacheDelete.Success);
         }, `expected SUCCESS but got ${response.toString()}`);
-        response = await Momento.sortedSetGetScore(
-          IntegrationTestCacheName,
+        response = await cacheClient.sortedSetGetScore(
+          integrationTestCacheName,
           sortedSetName,
           'foo'
         );

--- a/packages/common-integration-tests/src/update-ttl.ts
+++ b/packages/common-integration-tests/src/update-ttl.ts
@@ -12,17 +12,17 @@ import {
   CacheItemGetTtl,
 } from '@gomomento/sdk-core';
 export function runUpdateTtlTest(
-  Momento: ICacheClient,
-  IntegrationTestCacheName: string
+  cacheClient: ICacheClient,
+  integrationTestCacheName: string
 ) {
   describe('#updateTTL', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.updateTtl(props.cacheName, v4(), 10000);
+      return cacheClient.updateTtl(props.cacheName, v4(), 10000);
     });
 
     it('should Miss for a key that does not exist in the cache', async () => {
-      const response = await Momento.updateTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.updateTtl(
+        integrationTestCacheName,
         v4(),
         20000
       );
@@ -34,12 +34,12 @@ export function runUpdateTtlTest(
 
     it('should Set the new TTL for a key that exists in the cache', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.updateTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.updateTtl(
+        integrationTestCacheName,
         cacheKey,
         20000
       );
@@ -47,8 +47,8 @@ export function runUpdateTtlTest(
         expect(response).toBeInstanceOf(CacheUpdateTtl.Set);
       }, `expected SET but got ${response.toString()}`);
 
-      const ttlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const ttlResponse = await cacheClient.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -62,12 +62,12 @@ export function runUpdateTtlTest(
 
     it('should Error if given a TTL below 0', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.updateTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.updateTtl(
+        integrationTestCacheName,
         cacheKey,
         -20000
       );
@@ -79,7 +79,7 @@ export function runUpdateTtlTest(
 
     it('should support happy path for updateTTL via curried cache via ICache interface', async () => {
       const cacheKey = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.set(cacheKey, cacheKey, {
         ttl: 10,
       });
@@ -102,12 +102,12 @@ export function runUpdateTtlTest(
 
   describe('#increaseTTL', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.increaseTtl(props.cacheName, v4(), 10000);
+      return cacheClient.increaseTtl(props.cacheName, v4(), 10000);
     });
 
     it('should Miss if given key does not exist in the cache', async () => {
-      const response = await Momento.increaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.increaseTtl(
+        integrationTestCacheName,
         v4(),
         20000
       );
@@ -119,12 +119,12 @@ export function runUpdateTtlTest(
 
     it('should Set the new TTL for a key that exists in the cache and new TTL is greater than current TTL', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.increaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.increaseTtl(
+        integrationTestCacheName,
         cacheKey,
         20000
       );
@@ -132,8 +132,8 @@ export function runUpdateTtlTest(
         expect(response).toBeInstanceOf(CacheIncreaseTtl.Set);
       }, `expected SET but got ${response.toString()}`);
 
-      const ttlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const ttlResponse = await cacheClient.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -147,12 +147,12 @@ export function runUpdateTtlTest(
 
     it('should Error if given TTL is less than current TTL', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.increaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.increaseTtl(
+        integrationTestCacheName,
         cacheKey,
         5000
       );
@@ -163,12 +163,12 @@ export function runUpdateTtlTest(
 
     it('should Error if given a TTL below 0', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.increaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.increaseTtl(
+        integrationTestCacheName,
         cacheKey,
         -20000
       );
@@ -180,7 +180,7 @@ export function runUpdateTtlTest(
 
     it('should support happy path for increaseTTL via curried cache via ICache interface', async () => {
       const cacheKey = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.set(cacheKey, cacheKey, {
         ttl: 10,
       });
@@ -203,12 +203,12 @@ export function runUpdateTtlTest(
 
   describe('#decreaseTTL', () => {
     ItBehavesLikeItValidatesCacheName((props: ValidateCacheProps) => {
-      return Momento.decreaseTtl(props.cacheName, v4(), 10000);
+      return cacheClient.decreaseTtl(props.cacheName, v4(), 10000);
     });
 
     it('should Miss if given key does not exist in the cache', async () => {
-      const response = await Momento.decreaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.decreaseTtl(
+        integrationTestCacheName,
         v4(),
         5000
       );
@@ -220,12 +220,12 @@ export function runUpdateTtlTest(
 
     it('should Set the new TTL for a key that exists in the cache and new TTL is less than current TTL', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.decreaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.decreaseTtl(
+        integrationTestCacheName,
         cacheKey,
         5000
       );
@@ -233,8 +233,8 @@ export function runUpdateTtlTest(
         expect(response).toBeInstanceOf(CacheDecreaseTtl.Set);
       }, `expected SET but got ${response.toString()}`);
 
-      const ttlResponse = await Momento.itemGetTtl(
-        IntegrationTestCacheName,
+      const ttlResponse = await cacheClient.itemGetTtl(
+        integrationTestCacheName,
         cacheKey
       );
       expectWithMessage(() => {
@@ -248,12 +248,12 @@ export function runUpdateTtlTest(
 
     it('should Error if given TTL is greater than current TTL', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.decreaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.decreaseTtl(
+        integrationTestCacheName,
         cacheKey,
         20000
       );
@@ -264,12 +264,12 @@ export function runUpdateTtlTest(
 
     it('should Error if given a TTL below 0', async () => {
       const cacheKey = v4();
-      await Momento.set(IntegrationTestCacheName, cacheKey, cacheKey, {
+      await cacheClient.set(integrationTestCacheName, cacheKey, cacheKey, {
         ttl: 10,
       });
 
-      const response = await Momento.decreaseTtl(
-        IntegrationTestCacheName,
+      const response = await cacheClient.decreaseTtl(
+        integrationTestCacheName,
         cacheKey,
         -20000
       );
@@ -281,7 +281,7 @@ export function runUpdateTtlTest(
 
     it('should support happy path for decreaseTTL via curried cache via ICache interface', async () => {
       const cacheKey = v4();
-      const cache = Momento.cache(IntegrationTestCacheName);
+      const cache = cacheClient.cache(integrationTestCacheName);
       await cache.set(cacheKey, cacheKey, {
         ttl: 10,
       });

--- a/packages/common-integration-tests/src/vector-control-plane.ts
+++ b/packages/common-integration-tests/src/vector-control-plane.ts
@@ -14,22 +14,22 @@ import {
   MomentoErrorCode,
 } from '@gomomento/sdk-core';
 
-export function runVectorControlPlaneTest(Momento: IVectorIndexClient) {
+export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
   describe('create/delete vector index', () => {
     ItBehavesLikeItValidatesIndexName((props: ValidateVectorProps) => {
-      return Momento.createIndex(props.indexName, props.numDimensions);
+      return vectorClient.createIndex(props.indexName, props.numDimensions);
     });
     ItBehavesLikeItValidatesIndexName((props: ValidateVectorProps) => {
-      return Momento.deleteIndex(props.indexName);
+      return vectorClient.deleteIndex(props.indexName);
     });
 
     ItBehavesLikeItValidatesNumDimensions((props: ValidateVectorProps) => {
-      return Momento.createIndex(props.indexName, props.numDimensions);
+      return vectorClient.createIndex(props.indexName, props.numDimensions);
     });
 
     it('should return a NotFoundError if deleting a non-existent index', async () => {
       const indexName = testIndexName();
-      const deleteResponse = await Momento.deleteIndex(indexName);
+      const deleteResponse = await vectorClient.deleteIndex(indexName);
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(DeleteVectorIndex.Error);
       }, `expected ERROR but got ${deleteResponse.toString()}`);
@@ -42,16 +42,16 @@ export function runVectorControlPlaneTest(Momento: IVectorIndexClient) {
 
     it('should return AlreadyExists response if trying to create a index that already exists', async () => {
       const indexName = testIndexName();
-      await WithIndex(Momento, indexName, 10, async () => {
-        const createResponse = await Momento.createIndex(indexName, 1);
+      await WithIndex(vectorClient, indexName, 10, async () => {
+        const createResponse = await vectorClient.createIndex(indexName, 1);
         expect(createResponse).toBeInstanceOf(CreateVectorIndex.AlreadyExists);
       });
     });
 
     it('should create and list an index', async () => {
       const indexName = testIndexName();
-      await WithIndex(Momento, indexName, 10, async () => {
-        const listResponse = await Momento.listIndexes();
+      await WithIndex(vectorClient, indexName, 10, async () => {
+        const listResponse = await vectorClient.listIndexes();
         expectWithMessage(() => {
           expect(listResponse).toBeInstanceOf(ListVectorIndexes.Success);
         }, `expected SUCCESS but got ${listResponse.toString()}`);
@@ -64,9 +64,9 @@ export function runVectorControlPlaneTest(Momento: IVectorIndexClient) {
 
     it('should delete an index', async () => {
       const indexName = testIndexName();
-      const createResponse = await Momento.createIndex(indexName, 1);
+      const createResponse = await vectorClient.createIndex(indexName, 1);
       expect(createResponse).toBeInstanceOf(CreateVectorIndex.Success);
-      const deleteResponse = await Momento.deleteIndex(indexName);
+      const deleteResponse = await vectorClient.deleteIndex(indexName);
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(DeleteVectorIndex.Success);
       }, `expected SUCCESS but got ${deleteResponse.toString()}`);


### PR DESCRIPTION
This commit contains no functional changes; it simply renames some variables that we have been using in integration tests. Our integration test setup code, from way back at the beginning of the repo, created variables named `Momento` and `IntegrationTestCacheName` that it injected into all of the tests. The upper-case naming is not idiomatic of TS/JS, and the name `Momento` is confusing when the object is a `CacheClient`. This has been annoying me for a long time so this commit just fixes the names.