### PR TITLE
chore: split up internal control client between vector and cache functions

### DIFF
--- a/packages/client-sdk-nodejs/src/config/configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/configurations.ts
@@ -18,7 +18,7 @@ const defaultLoggerFactory: MomentoLoggerFactory =
   new DefaultMomentoLoggerFactory();
 const defaultMiddlewares: Middleware[] = [];
 
-export function defaultRetryStrategy(
+function defaultRetryStrategy(
   loggerFactory: MomentoLoggerFactory
 ): RetryStrategy {
   return new FixedCountRetryStrategy({

--- a/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
@@ -7,7 +7,7 @@ import {
   MiddlewareStatus,
 } from '../middleware';
 import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
-import {CONNECTION_ID_KEY} from '../../../internal/data-client';
+import {CONNECTION_ID_KEY} from '../../../internal/cache-data-client';
 
 const FIELD_NAMES: Array<string> = [
   'numActiveRequestsAtStart',

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -1,0 +1,278 @@
+import {control} from '@gomomento/generated-types';
+import grpcControl = control.control_client;
+import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
+import {ClientTimeoutInterceptor} from './grpc/client-timeout-interceptor';
+import {Status} from '@grpc/grpc-js/build/src/constants';
+import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
+import {
+  CreateCache,
+  DeleteCache,
+  ListCaches,
+  CreateSigningKey,
+  ListSigningKeys,
+  RevokeSigningKey,
+  CacheFlush,
+  CredentialProvider,
+  MomentoLogger,
+  CacheInfo,
+} from '..';
+import {version} from '../../package.json';
+import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
+import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
+import {Configuration} from '../config/configuration';
+import {
+  validateCacheName,
+  validateTtlMinutes,
+} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
+import {_SigningKey} from '@gomomento/sdk-core/dist/src/messages/responses/grpc-response-types';
+import {
+  CacheLimits,
+  TopicLimits,
+} from '@gomomento/sdk-core/dist/src/messages/cache-info';
+
+export interface ControlClientProps {
+  configuration: Configuration;
+  credentialProvider: CredentialProvider;
+}
+
+export class CacheControlClient {
+  private readonly clientWrapper: GrpcClientWrapper<grpcControl.ScsControlClient>;
+  private readonly interceptors: Interceptor[];
+  private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
+  private readonly logger: MomentoLogger;
+
+  /**
+   * @param {ControlClientProps} props
+   */
+  constructor(props: ControlClientProps) {
+    this.logger = props.configuration.getLoggerFactory().getLogger(this);
+    const headers = [
+      new Header('Authorization', props.credentialProvider.getAuthToken()),
+      new Header('Agent', `nodejs:${version}`),
+    ];
+    this.interceptors = [
+      new HeaderInterceptorProvider(headers).createHeadersInterceptor(),
+      ClientTimeoutInterceptor(CacheControlClient.REQUEST_TIMEOUT_MS),
+    ];
+    this.logger.debug(
+      `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
+    );
+    this.clientWrapper = new IdleGrpcClientWrapper({
+      clientFactoryFn: () =>
+        new grpcControl.ScsControlClient(
+          props.credentialProvider.getControlEndpoint(),
+          ChannelCredentials.createSsl()
+        ),
+      loggerFactory: props.configuration.getLoggerFactory(),
+      maxIdleMillis: props.configuration
+        .getTransportStrategy()
+        .getMaxIdleMillis(),
+    });
+  }
+
+  public async createCache(name: string): Promise<CreateCache.Response> {
+    try {
+      validateCacheName(name);
+    } catch (err) {
+      return new CreateCache.Error(normalizeSdkError(err as Error));
+    }
+    this.logger.info(`Creating cache: ${name}`);
+    const request = new grpcControl._CreateCacheRequest({
+      cache_name: name,
+    });
+    return await new Promise<CreateCache.Response>(resolve => {
+      this.clientWrapper.getClient().CreateCache(
+        request,
+        {interceptors: this.interceptors},
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (err, resp) => {
+          if (err) {
+            if (err.code === Status.ALREADY_EXISTS) {
+              resolve(new CreateCache.AlreadyExists());
+            } else {
+              resolve(new CreateCache.Error(cacheServiceErrorMapper(err)));
+            }
+          } else {
+            resolve(new CreateCache.Success());
+          }
+        }
+      );
+    });
+  }
+
+  public async deleteCache(name: string): Promise<DeleteCache.Response> {
+    try {
+      validateCacheName(name);
+    } catch (err) {
+      return new DeleteCache.Error(normalizeSdkError(err as Error));
+    }
+    const request = new grpcControl._DeleteCacheRequest({
+      cache_name: name,
+    });
+    this.logger.info(`Deleting cache: ${name}`);
+    return await new Promise<DeleteCache.Response>(resolve => {
+      this.clientWrapper.getClient().DeleteCache(
+        request,
+        {interceptors: this.interceptors},
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (err, resp) => {
+          if (err) {
+            resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
+          } else {
+            resolve(new DeleteCache.Success());
+          }
+        }
+      );
+    });
+  }
+
+  public async flushCache(cacheName: string): Promise<CacheFlush.Response> {
+    try {
+      validateCacheName(cacheName);
+    } catch (err) {
+      return new CacheFlush.Error(normalizeSdkError(err as Error));
+    }
+    this.logger.trace(`Flushing cache: ${cacheName}`);
+    return await this.sendFlushCache(cacheName);
+  }
+
+  private async sendFlushCache(
+    cacheName: string
+  ): Promise<CacheFlush.Response> {
+    const request = new grpcControl._FlushCacheRequest({
+      cache_name: cacheName,
+    });
+    return await new Promise(resolve => {
+      this.clientWrapper.getClient().FlushCache(
+        request,
+        {
+          interceptors: this.interceptors,
+        },
+        (err, resp) => {
+          if (resp) {
+            resolve(new CacheFlush.Success());
+          } else {
+            resolve(new CacheFlush.Error(cacheServiceErrorMapper(err)));
+          }
+        }
+      );
+    });
+  }
+
+  public async listCaches(): Promise<ListCaches.Response> {
+    const request = new grpcControl._ListCachesRequest();
+    request.next_token = '';
+    this.logger.debug("Issuing 'listCaches' request");
+    return await new Promise<ListCaches.Response>(resolve => {
+      this.clientWrapper
+        .getClient()
+        .ListCaches(request, {interceptors: this.interceptors}, (err, resp) => {
+          if (err || !resp) {
+            resolve(new ListCaches.Error(cacheServiceErrorMapper(err)));
+          } else {
+            const caches = resp.cache.map(cache => {
+              const cacheName = cache.cache_name;
+              const topicLimits: TopicLimits = {
+                maxPublishMessageSizeKb:
+                  cache.topic_limits?.max_publish_message_size_kb || 0,
+                maxSubscriptionCount:
+                  cache.topic_limits?.max_subscription_count || 0,
+                maxPublishRate: cache.topic_limits?.max_publish_rate || 0,
+              };
+              const cacheLimits: CacheLimits = {
+                maxTtlSeconds: cache.cache_limits?.max_ttl_seconds || 0,
+                maxItemSizeKb: cache.cache_limits?.max_item_size_kb || 0,
+                maxThroughputKbps: cache.cache_limits?.max_throughput_kbps || 0,
+                maxTrafficRate: cache.cache_limits?.max_traffic_rate || 0,
+              };
+              return new CacheInfo(cacheName, topicLimits, cacheLimits);
+            });
+            resolve(new ListCaches.Success(caches));
+          }
+        });
+    });
+  }
+
+  public async createSigningKey(
+    ttlMinutes: number,
+    endpoint: string
+  ): Promise<CreateSigningKey.Response> {
+    try {
+      validateTtlMinutes(ttlMinutes);
+    } catch (err) {
+      return new CreateSigningKey.Error(normalizeSdkError(err as Error));
+    }
+    this.logger.debug("Issuing 'createSigningKey' request");
+    const request = new grpcControl._CreateSigningKeyRequest();
+    request.ttl_minutes = ttlMinutes;
+    return await new Promise<CreateSigningKey.Response>(resolve => {
+      this.clientWrapper
+        .getClient()
+        .CreateSigningKey(
+          request,
+          {interceptors: this.interceptors},
+          (err, resp) => {
+            if (err) {
+              resolve(new CreateSigningKey.Error(cacheServiceErrorMapper(err)));
+            } else {
+              const signingKey = new _SigningKey(resp?.key, resp?.expires_at);
+              resolve(new CreateSigningKey.Success(endpoint, signingKey));
+            }
+          }
+        );
+    });
+  }
+
+  public async revokeSigningKey(
+    keyId: string
+  ): Promise<RevokeSigningKey.Response> {
+    const request = new grpcControl._RevokeSigningKeyRequest();
+    request.key_id = keyId;
+    this.logger.debug("Issuing 'revokeSigningKey' request");
+    return await new Promise<RevokeSigningKey.Response>(resolve => {
+      this.clientWrapper
+        .getClient()
+        .RevokeSigningKey(request, {interceptors: this.interceptors}, err => {
+          if (err) {
+            resolve(new RevokeSigningKey.Error(cacheServiceErrorMapper(err)));
+          } else {
+            resolve(new RevokeSigningKey.Success());
+          }
+        });
+    });
+  }
+
+  public async listSigningKeys(
+    endpoint: string
+  ): Promise<ListSigningKeys.Response> {
+    const request = new grpcControl._ListSigningKeysRequest();
+    request.next_token = '';
+    this.logger.debug("Issuing 'listSigningKeys' request");
+    return await new Promise<ListSigningKeys.Response>(resolve => {
+      this.clientWrapper
+        .getClient()
+        .ListSigningKeys(
+          request,
+          {interceptors: this.interceptors},
+          (err, resp) => {
+            if (err || !resp) {
+              resolve(new ListSigningKeys.Error(cacheServiceErrorMapper(err)));
+            } else {
+              const signingKeys = resp.signing_key.map(
+                sk => new _SigningKey(sk.key_id, sk.expires_at)
+              );
+              resolve(
+                new ListSigningKeys.Success(
+                  endpoint,
+                  signingKeys,
+                  resp.next_token
+                )
+              );
+            }
+          }
+        );
+    });
+  }
+}

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -101,7 +101,7 @@ import {ConnectivityState} from '@grpc/grpc-js/build/src/connectivity-state';
 
 export const CONNECTION_ID_KEY = Symbol('connectionID');
 
-export class DataClient implements IDataClient {
+export class CacheDataClient implements IDataClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcCache.ScsClient>;
   private readonly textEncoder: TextEncoder;
   private readonly configuration: Configuration;
@@ -125,7 +125,8 @@ export class DataClient implements IDataClient {
       .getGrpcConfig();
 
     this.requestTimeoutMs =
-      grpcConfig.getDeadlineMillis() || DataClient.DEFAULT_REQUEST_TIMEOUT_MS;
+      grpcConfig.getDeadlineMillis() ||
+      CacheDataClient.DEFAULT_REQUEST_TIMEOUT_MS;
     this.validateRequestTimeout(this.requestTimeoutMs);
     this.logger.debug(
       `Creating cache client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -6,23 +6,18 @@ import {Status} from '@grpc/grpc-js/build/src/constants';
 import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
 import {
-  CreateCache,
-  DeleteCache,
   ListCaches,
   CreateSigningKey,
   ListSigningKeys,
   RevokeSigningKey,
-  CacheFlush,
   CredentialProvider,
   MomentoLogger,
-  CacheInfo,
+  VectorIndexConfiguration,
 } from '..';
 import {version} from '../../package.json';
 import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
 import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
-import {Configuration} from '../config/configuration';
 import {
-  validateCacheName,
   validateIndexName,
   validateNumDimensions,
   validateTtlMinutes,
@@ -30,21 +25,18 @@ import {
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {_SigningKey} from '@gomomento/sdk-core/dist/src/messages/responses/grpc-response-types';
 import {
-  CacheLimits,
-  TopicLimits,
-} from '@gomomento/sdk-core/dist/src/messages/cache-info';
-import {
   CreateVectorIndex,
   DeleteVectorIndex,
   ListVectorIndexes,
 } from '@gomomento/sdk-core';
+import {IVectorIndexControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 
 export interface ControlClientProps {
-  configuration: Configuration;
+  configuration: VectorIndexConfiguration;
   credentialProvider: CredentialProvider;
 }
 
-export class ControlClient {
+export class VectorIndexControlClient implements IVectorIndexControlClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcControl.ScsControlClient>;
   private readonly interceptors: Interceptor[];
   private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
@@ -61,7 +53,7 @@ export class ControlClient {
     ];
     this.interceptors = [
       new HeaderInterceptorProvider(headers).createHeadersInterceptor(),
-      ClientTimeoutInterceptor(ControlClient.REQUEST_TIMEOUT_MS),
+      ClientTimeoutInterceptor(VectorIndexControlClient.REQUEST_TIMEOUT_MS),
     ];
     this.logger.debug(
       `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
@@ -76,129 +68,6 @@ export class ControlClient {
       maxIdleMillis: props.configuration
         .getTransportStrategy()
         .getMaxIdleMillis(),
-    });
-  }
-
-  public async createCache(name: string): Promise<CreateCache.Response> {
-    try {
-      validateCacheName(name);
-    } catch (err) {
-      return new CreateCache.Error(normalizeSdkError(err as Error));
-    }
-    this.logger.info(`Creating cache: ${name}`);
-    const request = new grpcControl._CreateCacheRequest({
-      cache_name: name,
-    });
-    return await new Promise<CreateCache.Response>(resolve => {
-      this.clientWrapper.getClient().CreateCache(
-        request,
-        {interceptors: this.interceptors},
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            if (err.code === Status.ALREADY_EXISTS) {
-              resolve(new CreateCache.AlreadyExists());
-            } else {
-              resolve(new CreateCache.Error(cacheServiceErrorMapper(err)));
-            }
-          } else {
-            resolve(new CreateCache.Success());
-          }
-        }
-      );
-    });
-  }
-
-  public async deleteCache(name: string): Promise<DeleteCache.Response> {
-    try {
-      validateCacheName(name);
-    } catch (err) {
-      return new DeleteCache.Error(normalizeSdkError(err as Error));
-    }
-    const request = new grpcControl._DeleteCacheRequest({
-      cache_name: name,
-    });
-    this.logger.info(`Deleting cache: ${name}`);
-    return await new Promise<DeleteCache.Response>(resolve => {
-      this.clientWrapper.getClient().DeleteCache(
-        request,
-        {interceptors: this.interceptors},
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
-          } else {
-            resolve(new DeleteCache.Success());
-          }
-        }
-      );
-    });
-  }
-
-  public async flushCache(cacheName: string): Promise<CacheFlush.Response> {
-    try {
-      validateCacheName(cacheName);
-    } catch (err) {
-      return new CacheFlush.Error(normalizeSdkError(err as Error));
-    }
-    this.logger.trace(`Flushing cache: ${cacheName}`);
-    return await this.sendFlushCache(cacheName);
-  }
-
-  private async sendFlushCache(
-    cacheName: string
-  ): Promise<CacheFlush.Response> {
-    const request = new grpcControl._FlushCacheRequest({
-      cache_name: cacheName,
-    });
-    return await new Promise(resolve => {
-      this.clientWrapper.getClient().FlushCache(
-        request,
-        {
-          interceptors: this.interceptors,
-        },
-        (err, resp) => {
-          if (resp) {
-            resolve(new CacheFlush.Success());
-          } else {
-            resolve(new CacheFlush.Error(cacheServiceErrorMapper(err)));
-          }
-        }
-      );
-    });
-  }
-
-  public async listCaches(): Promise<ListCaches.Response> {
-    const request = new grpcControl._ListCachesRequest();
-    request.next_token = '';
-    this.logger.debug("Issuing 'listCaches' request");
-    return await new Promise<ListCaches.Response>(resolve => {
-      this.clientWrapper
-        .getClient()
-        .ListCaches(request, {interceptors: this.interceptors}, (err, resp) => {
-          if (err || !resp) {
-            resolve(new ListCaches.Error(cacheServiceErrorMapper(err)));
-          } else {
-            const caches = resp.cache.map(cache => {
-              const cacheName = cache.cache_name;
-              const topicLimits: TopicLimits = {
-                maxPublishMessageSizeKb:
-                  cache.topic_limits?.max_publish_message_size_kb || 0,
-                maxSubscriptionCount:
-                  cache.topic_limits?.max_subscription_count || 0,
-                maxPublishRate: cache.topic_limits?.max_publish_rate || 0,
-              };
-              const cacheLimits: CacheLimits = {
-                maxTtlSeconds: cache.cache_limits?.max_ttl_seconds || 0,
-                maxItemSizeKb: cache.cache_limits?.max_item_size_kb || 0,
-                maxThroughputKbps: cache.cache_limits?.max_throughput_kbps || 0,
-                maxTrafficRate: cache.cache_limits?.max_traffic_rate || 0,
-              };
-              return new CacheInfo(cacheName, topicLimits, cacheLimits);
-            });
-            resolve(new ListCaches.Success(caches));
-          }
-        });
     });
   }
 

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -24,7 +24,7 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 
-export class VectorDataClient implements IVectorIndexDataClient {
+export class VectorIndexDataClient implements IVectorIndexDataClient {
   private readonly configuration: VectorIndexConfiguration;
   private readonly credentialProvider: CredentialProvider;
   private readonly logger: MomentoLogger;

--- a/packages/client-sdk-nodejs/src/preview-vector-index-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-vector-index-client.ts
@@ -1,14 +1,12 @@
-import {ControlClient} from './internal/control-client';
 import {
   AbstractVectorIndexClient,
   IVectorIndexClient,
   IVectorIndexControlClient,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import {VectorIndexClientProps} from './vector-index-client-props';
-import {VectorDataClient} from './internal/vector-data-client';
+import {VectorIndexDataClient} from './internal/vector-index-data-client';
+import {VectorIndexControlClient} from './internal/vector-index-control-client';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
-import {CacheConfiguration} from './config/configuration';
-import {defaultRetryStrategy} from './config/configurations';
 
 /**
  * PREVIEW Vector Index Client
@@ -32,15 +30,8 @@ export class PreviewVectorIndexClient
 function createControlClient(
   props: VectorIndexClientProps
 ): IVectorIndexControlClient {
-  return new ControlClient({
-    configuration: new CacheConfiguration({
-      loggerFactory: props.configuration.getLoggerFactory(),
-      transportStrategy: props.configuration.getTransportStrategy(),
-      retryStrategy: defaultRetryStrategy(
-        props.configuration.getLoggerFactory()
-      ),
-      middlewares: [],
-    }),
+  return new VectorIndexControlClient({
+    configuration: props.configuration,
     credentialProvider: props.credentialProvider,
   });
 }
@@ -48,5 +39,5 @@ function createControlClient(
 function createDataClient(
   props: VectorIndexClientProps
 ): IVectorIndexDataClient {
-  return new VectorDataClient(props);
+  return new VectorIndexDataClient(props);
 }

--- a/packages/client-sdk-web/src/cache-client.ts
+++ b/packages/client-sdk-web/src/cache-client.ts
@@ -1,5 +1,5 @@
-import {ControlClient} from './internal/control-client';
-import {DataClient} from './internal/data-client';
+import {CacheControlClient} from './internal/cache-control-client';
+import {CacheDataClient} from './internal/cache-data-client';
 import {PingClient} from './internal/ping-client';
 import {
   AbstractCacheClient,
@@ -21,14 +21,14 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
 }
 
 function createControlClient(props: CacheClientProps): IControlClient {
-  return new ControlClient({
+  return new CacheControlClient({
     configuration: props.configuration,
     credentialProvider: props.credentialProvider,
   });
 }
 
 function createDataClient(props: CacheClientProps): IDataClient {
-  return new DataClient({
+  return new CacheDataClient({
     configuration: props.configuration,
     credentialProvider: props.credentialProvider,
     defaultTtlSeconds: props.defaultTtlSeconds,

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -15,42 +15,27 @@ import {
   _DeleteCacheRequest,
   _ListCachesRequest,
   _FlushCacheRequest,
-  _CreateIndexRequest,
-  _ListIndexesRequest,
-  _DeleteIndexRequest,
 } from '@gomomento/generated-types-webtext/dist/controlclient_pb';
 import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
-import {
-  IControlClient,
-  IVectorIndexControlClient,
-} from '@gomomento/sdk-core/dist/src/internal/clients';
+import {IControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
-import {
-  validateCacheName,
-  validateIndexName,
-  validateNumDimensions,
-} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {validateCacheName} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {getWebControlEndpoint} from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {
   CacheLimits,
   TopicLimits,
 } from '@gomomento/sdk-core/dist/src/messages/cache-info';
-import {
-  CreateVectorIndex,
-  DeleteVectorIndex,
-  ListVectorIndexes,
-} from '@gomomento/sdk-core';
 
 export interface ControlClientProps {
   configuration: Configuration;
   credentialProvider: CredentialProvider;
 }
 
-export class ControlClient<
+export class CacheControlClient<
   REQ extends Request<REQ, RESP>,
   RESP extends UnaryResponse<REQ, RESP>
-> implements IControlClient, IVectorIndexControlClient
+> implements IControlClient
 {
   private readonly clientWrapper: control.ScsControlClient;
   private readonly logger: MomentoLogger;
@@ -198,87 +183,6 @@ export class ControlClient<
               return new CacheInfo(cacheName, topicLimits, cacheLimits);
             });
             resolve(new ListCaches.Success(caches));
-          }
-        }
-      );
-    });
-  }
-
-  public async createIndex(
-    indexName: string,
-    numDimensions: number
-  ): Promise<CreateVectorIndex.Response> {
-    try {
-      validateIndexName(indexName);
-      validateNumDimensions(numDimensions);
-    } catch (err) {
-      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
-    }
-    const request = new _CreateIndexRequest();
-    request.setIndexName(indexName);
-    request.setNumDimensions(numDimensions);
-    this.logger.debug("Issuing 'createIndex' request");
-    return await new Promise<CreateVectorIndex.Response>(resolve => {
-      this.clientWrapper.createIndex(
-        request,
-        this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            if (err.code === StatusCode.ALREADY_EXISTS) {
-              resolve(new CreateVectorIndex.AlreadyExists());
-            } else {
-              resolve(
-                new CreateVectorIndex.Error(cacheServiceErrorMapper(err))
-              );
-            }
-          } else {
-            resolve(new CreateVectorIndex.Success());
-          }
-        }
-      );
-    });
-  }
-
-  public async listIndexes(): Promise<ListVectorIndexes.Response> {
-    const request = new _ListIndexesRequest();
-    this.logger.debug("Issuing 'listIndexes' request");
-    return await new Promise<ListVectorIndexes.Response>(resolve => {
-      this.clientWrapper.listIndexes(
-        request,
-        this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            resolve(new ListVectorIndexes.Error(cacheServiceErrorMapper(err)));
-          } else {
-            const indexes = resp.getIndexNamesList();
-            resolve(new ListVectorIndexes.Success(indexes));
-          }
-        }
-      );
-    });
-  }
-
-  public async deleteIndex(indexName: string) {
-    const request = new _DeleteIndexRequest();
-    try {
-      validateIndexName(indexName);
-    } catch (err) {
-      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
-    }
-    request.setIndexName(indexName);
-    this.logger.debug("Issuing 'deleteIndex' request");
-    return await new Promise<DeleteVectorIndex.Response>(resolve => {
-      this.clientWrapper.deleteIndex(
-        request,
-        this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            resolve(new DeleteVectorIndex.Error(cacheServiceErrorMapper(err)));
-          } else {
-            resolve(new DeleteVectorIndex.Success());
           }
         }
       );

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -139,7 +139,7 @@ export interface DataClientProps {
   defaultTtlSeconds: number;
 }
 
-export class DataClient<
+export class CacheDataClient<
   REQ extends Request<REQ, RESP>,
   RESP extends UnaryResponse<REQ, RESP>
 > implements IDataClient

--- a/packages/client-sdk-web/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-control-client.ts
@@ -1,0 +1,141 @@
+import {control} from '@gomomento/generated-types-webtext';
+import {CredentialProvider, MomentoLogger, VectorIndexConfiguration} from '..';
+import {Request, StatusCode, UnaryResponse} from 'grpc-web';
+import {
+  _CreateIndexRequest,
+  _ListIndexesRequest,
+  _DeleteIndexRequest,
+} from '@gomomento/generated-types-webtext/dist/controlclient_pb';
+import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+import {IVectorIndexControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
+import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
+import {
+  validateIndexName,
+  validateNumDimensions,
+} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {getWebControlEndpoint} from '../utils/web-client-utils';
+import {ClientMetadataProvider} from './client-metadata-provider';
+import {
+  CreateVectorIndex,
+  DeleteVectorIndex,
+  ListVectorIndexes,
+} from '@gomomento/sdk-core';
+
+export interface ControlClientProps {
+  configuration: VectorIndexConfiguration;
+  credentialProvider: CredentialProvider;
+}
+
+export class VectorIndexControlClient<
+  REQ extends Request<REQ, RESP>,
+  RESP extends UnaryResponse<REQ, RESP>
+> implements IVectorIndexControlClient
+{
+  private readonly clientWrapper: control.ScsControlClient;
+  private readonly logger: MomentoLogger;
+
+  private readonly clientMetadataProvider: ClientMetadataProvider;
+
+  /**
+   * @param {ControlClientProps} props
+   */
+  constructor(props: ControlClientProps) {
+    this.logger = props.configuration.getLoggerFactory().getLogger(this);
+    this.logger.debug(
+      `Creating control client using endpoint: '${getWebControlEndpoint(
+        props.credentialProvider
+      )}`
+    );
+
+    this.clientMetadataProvider = new ClientMetadataProvider({
+      authToken: props.credentialProvider.getAuthToken(),
+    });
+    this.clientWrapper = new control.ScsControlClient(
+      // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
+      getWebControlEndpoint(props.credentialProvider),
+      null,
+      {}
+    );
+  }
+
+  public async createIndex(
+    indexName: string,
+    numDimensions: number
+  ): Promise<CreateVectorIndex.Response> {
+    try {
+      validateIndexName(indexName);
+      validateNumDimensions(numDimensions);
+    } catch (err) {
+      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
+    }
+    const request = new _CreateIndexRequest();
+    request.setIndexName(indexName);
+    request.setNumDimensions(numDimensions);
+    this.logger.debug("Issuing 'createIndex' request");
+    return await new Promise<CreateVectorIndex.Response>(resolve => {
+      this.clientWrapper.createIndex(
+        request,
+        this.clientMetadataProvider.createClientMetadata(),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (err, resp) => {
+          if (err) {
+            if (err.code === StatusCode.ALREADY_EXISTS) {
+              resolve(new CreateVectorIndex.AlreadyExists());
+            } else {
+              resolve(
+                new CreateVectorIndex.Error(cacheServiceErrorMapper(err))
+              );
+            }
+          } else {
+            resolve(new CreateVectorIndex.Success());
+          }
+        }
+      );
+    });
+  }
+
+  public async listIndexes(): Promise<ListVectorIndexes.Response> {
+    const request = new _ListIndexesRequest();
+    this.logger.debug("Issuing 'listIndexes' request");
+    return await new Promise<ListVectorIndexes.Response>(resolve => {
+      this.clientWrapper.listIndexes(
+        request,
+        this.clientMetadataProvider.createClientMetadata(),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (err, resp) => {
+          if (err) {
+            resolve(new ListVectorIndexes.Error(cacheServiceErrorMapper(err)));
+          } else {
+            const indexes = resp.getIndexNamesList();
+            resolve(new ListVectorIndexes.Success(indexes));
+          }
+        }
+      );
+    });
+  }
+
+  public async deleteIndex(indexName: string) {
+    const request = new _DeleteIndexRequest();
+    try {
+      validateIndexName(indexName);
+    } catch (err) {
+      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
+    }
+    request.setIndexName(indexName);
+    this.logger.debug("Issuing 'deleteIndex' request");
+    return await new Promise<DeleteVectorIndex.Response>(resolve => {
+      this.clientWrapper.deleteIndex(
+        request,
+        this.clientMetadataProvider.createClientMetadata(),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (err, resp) => {
+          if (err) {
+            resolve(new DeleteVectorIndex.Error(cacheServiceErrorMapper(err)));
+          } else {
+            resolve(new DeleteVectorIndex.Success());
+          }
+        }
+      );
+    });
+  }
+}

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -19,7 +19,7 @@ import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {getWebVectorEndpoint} from '../utils/web-client-utils';
 
-export class VectorDataClient implements IVectorIndexDataClient {
+export class VectorIndexDataClient implements IVectorIndexDataClient {
   private readonly client: VectorIndexClient;
   private readonly logger: MomentoLogger;
   private readonly clientMetadataProvider: ClientMetadataProvider;

--- a/packages/client-sdk-web/src/preview-vector-index-client.ts
+++ b/packages/client-sdk-web/src/preview-vector-index-client.ts
@@ -1,4 +1,3 @@
-import {ControlClient} from './internal/control-client';
 import {
   AbstractVectorIndexClient,
   IVectorIndexClient,
@@ -6,8 +5,8 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import {VectorIndexClientProps} from './vector-index-client-props';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
-import {VectorDataClient} from './internal/vector-data-client';
-import {CacheConfiguration} from './config/configuration';
+import {VectorIndexDataClient} from './internal/vector-index-data-client';
+import {VectorIndexControlClient} from './internal/vector-index-control-client';
 
 /**
  * PREVIEW Vector Index Client
@@ -31,11 +30,8 @@ export class PreviewVectorIndexClient
 function createControlClient(
   props: VectorIndexClientProps
 ): IVectorIndexControlClient {
-  return new ControlClient({
-    configuration: new CacheConfiguration({
-      loggerFactory: props.configuration.getLoggerFactory(),
-      transportStrategy: props.configuration.getTransportStrategy(),
-    }),
+  return new VectorIndexControlClient({
+    configuration: props.configuration,
     credentialProvider: props.credentialProvider,
   });
 }
@@ -43,5 +39,5 @@ function createControlClient(
 function createDataClient(
   props: VectorIndexClientProps
 ): IVectorIndexDataClient {
-  return new VectorDataClient(props);
+  return new VectorIndexDataClient(props);
 }


### PR DESCRIPTION
Prior to this commit, we had a single internal ControlClient that housed the control plane APIs for both cache and vector products. This client required an instance of CacheConfiguration for its constructor, which didn't make sense for the Vector use case, so we had a bit of a hack in place to bridge it while we got the public API released.

This commit splits up the internal control client into two so that we don't have to munge the Config object. Also makes sure that all of the Vector classes are prefixed with VectorIndex for consistency.