### PR TITLE
fix: clean up the support for overriding endpoints

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -60,10 +60,12 @@ function sessionCredsProvider(): CredentialProvider {
       environmentVariableName: 'TEST_SESSION_TOKEN',
       // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
       // steal them from the auth-token-based creds provider.
-      cacheEndpoint: credsProvider().getCacheEndpoint(),
-      controlEndpoint: credsProvider().getControlEndpoint(),
-      tokenEndpoint: credsProvider().getTokenEndpoint(),
-      vectorEndpoint: credsProvider().getVectorEndpoint(),
+      endpointOverrides: {
+        cacheEndpoint: credsProvider().getCacheEndpoint(),
+        controlEndpoint: credsProvider().getControlEndpoint(),
+        tokenEndpoint: credsProvider().getTokenEndpoint(),
+        vectorEndpoint: credsProvider().getVectorEndpoint(),
+      },
     });
   }
   return _sessionCredsProvider;

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -20,7 +20,7 @@ export function createCallMetadata(
 export function getWebControlEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  if (credentialProvider.isControlEndpointOverridden()) {
+  if (credentialProvider.areEndpointsOverridden()) {
     return withProtocolPrefix(credentialProvider.getControlEndpoint());
   }
   return withProtocolPrefix(`web.${credentialProvider.getControlEndpoint()}`);
@@ -29,7 +29,7 @@ export function getWebControlEndpoint(
 export function getWebCacheEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  if (credentialProvider.isCacheEndpointOverridden()) {
+  if (credentialProvider.areEndpointsOverridden()) {
     return withProtocolPrefix(credentialProvider.getCacheEndpoint());
   }
   return withProtocolPrefix(`web.${credentialProvider.getCacheEndpoint()}`);
@@ -38,7 +38,7 @@ export function getWebCacheEndpoint(
 export function getWebTokenEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  if (credentialProvider.isTokenEndpointOverridden()) {
+  if (credentialProvider.areEndpointsOverridden()) {
     return withProtocolPrefix(credentialProvider.getTokenEndpoint());
   }
   return withProtocolPrefix(`web.${credentialProvider.getTokenEndpoint()}`);
@@ -47,7 +47,7 @@ export function getWebTokenEndpoint(
 export function getWebVectorEndpoint(
   credentialProvider: CredentialProvider
 ): string {
-  if (credentialProvider.isVectorEndpointOverridden()) {
+  if (credentialProvider.areEndpointsOverridden()) {
     return withProtocolPrefix(credentialProvider.getVectorEndpoint());
   }
   return withProtocolPrefix(`web.${credentialProvider.getVectorEndpoint()}`);

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -30,10 +30,12 @@ function credsProvider(): CredentialProvider {
     if (isLocalhostDevelopmentMode()) {
       _credsProvider = CredentialProvider.fromEnvironmentVariable({
         environmentVariableName: 'TEST_AUTH_TOKEN',
-        controlEndpoint: 'https://no-controlplane-requests-allowed:9001',
-        cacheEndpoint: 'https://localhost:9001',
-        tokenEndpoint: 'https://localhost:9001',
-        vectorEndpoint: 'https://localhost:9001',
+        endpointOverrides: {
+          controlEndpoint: 'https://no-controlplane-requests-allowed:9001',
+          cacheEndpoint: 'https://localhost:9001',
+          tokenEndpoint: 'https://localhost:9001',
+          vectorEndpoint: 'https://localhost:9001',
+        },
       });
     } else {
       _credsProvider = CredentialProvider.fromEnvironmentVariable({
@@ -50,10 +52,12 @@ function sessionCredsProvider(): CredentialProvider {
       environmentVariableName: 'TEST_SESSION_TOKEN',
       // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
       // steal them from the auth-token-based creds provider.
-      cacheEndpoint: credsProvider().getCacheEndpoint(),
-      controlEndpoint: credsProvider().getControlEndpoint(),
-      tokenEndpoint: credsProvider().getTokenEndpoint(),
-      vectorEndpoint: credsProvider().getVectorEndpoint(),
+      endpointOverrides: {
+        cacheEndpoint: credsProvider().getCacheEndpoint(),
+        controlEndpoint: credsProvider().getControlEndpoint(),
+        tokenEndpoint: credsProvider().getTokenEndpoint(),
+        vectorEndpoint: credsProvider().getVectorEndpoint(),
+      },
     });
   }
   return _sessionCredsProvider;

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -6,6 +6,8 @@ import {CredentialProvider} from '@gomomento/sdk-core';
 import {
   getWebCacheEndpoint,
   getWebControlEndpoint,
+  getWebTokenEndpoint,
+  getWebVectorEndpoint,
 } from '../../../src/utils/web-client-utils';
 
 // These tokens have valid syntax, but they don't actually have valid credentials.  Just used for unit testing.
@@ -21,7 +23,7 @@ const base64EncodedFakeV1AuthToken = encodeToBase64(
   JSON.stringify(decodedV1Token)
 );
 
-describe('getWebControlEndpoint', () => {
+describe('getWeb*Endpoint', () => {
   it('adds "https://web." prefix to endpoints that were parsed from legacy tokens', () => {
     const credProvider = CredentialProvider.fromString({
       authToken: fakeTestLegacyToken,
@@ -39,102 +41,90 @@ describe('getWebControlEndpoint', () => {
     expect(webControlEndpoint).toEqual(
       'https://web.control.test.momentohq.com'
     );
+    const webCacheEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webCacheEndpoint).toEqual('https://web.cache.test.momentohq.com');
+    const webTokenEndpoint = getWebTokenEndpoint(credProvider);
+    expect(webTokenEndpoint).toEqual('https://web.token.test.momentohq.com');
+    const webVectorEndpoint = getWebVectorEndpoint(credProvider);
+    expect(webVectorEndpoint).toEqual('https://web.vector.test.momentohq.com');
   });
 
   it('adds https protocol, but does not add web prefix for overridden endpoints', () => {
     const credProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
-      controlEndpoint: 'some-control-endpoint',
-      cacheEndpoint: 'some-cache-endpoint',
+      endpointOverrides: {
+        controlEndpoint: 'some-control-endpoint',
+        cacheEndpoint: 'some-cache-endpoint',
+        tokenEndpoint: 'some-token-endpoint',
+        vectorEndpoint: 'some-vector-endpoint',
+      },
     });
     const webControlEndpoint = getWebControlEndpoint(credProvider);
     expect(webControlEndpoint).toEqual('https://some-control-endpoint');
+    const webCacheEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webCacheEndpoint).toEqual('https://some-cache-endpoint');
+    const webTokenEndpoint = getWebTokenEndpoint(credProvider);
+    expect(webTokenEndpoint).toEqual('https://some-token-endpoint');
+    const webVectorEndpoint = getWebVectorEndpoint(credProvider);
+    expect(webVectorEndpoint).toEqual('https://some-vector-endpoint');
   });
   it('works with overridden endpoints that already have the protocol', () => {
     const credProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
-      controlEndpoint: 'https://some-control-endpoint',
-      cacheEndpoint: 'https://some-cache-endpoint',
+      endpointOverrides: {
+        controlEndpoint: 'https://some-control-endpoint',
+        cacheEndpoint: 'https://some-cache-endpoint',
+        tokenEndpoint: 'http://some-token-endpoint',
+        vectorEndpoint: 'http://some-vector-endpoint',
+      },
     });
     const webControlEndpoint = getWebControlEndpoint(credProvider);
     expect(webControlEndpoint).toEqual('https://some-control-endpoint');
+    const webCacheEndpoint = getWebCacheEndpoint(credProvider);
+    expect(webCacheEndpoint).toEqual('https://some-cache-endpoint');
+    const webTokenEndpoint = getWebTokenEndpoint(credProvider);
+    expect(webTokenEndpoint).toEqual('http://some-token-endpoint');
+    const webVectorEndpoint = getWebVectorEndpoint(credProvider);
+    expect(webVectorEndpoint).toEqual('http://some-vector-endpoint');
   });
   describe('leaves port intact for overridden endpoints', () => {
     it("with overrides that don't contain protocol", () => {
       const credProvider = CredentialProvider.fromString({
         authToken: base64EncodedFakeV1AuthToken,
-        controlEndpoint: 'some-control-endpoint:9001',
-        cacheEndpoint: 'some-cache-endpoint:9001',
+        endpointOverrides: {
+          controlEndpoint: 'some-control-endpoint:9001',
+          cacheEndpoint: 'some-cache-endpoint:9001',
+          tokenEndpoint: 'some-token-endpoint:9001',
+          vectorEndpoint: 'some-vector-endpoint:9001',
+        },
       });
       const webControlEndpoint = getWebControlEndpoint(credProvider);
       expect(webControlEndpoint).toEqual('https://some-control-endpoint:9001');
+      const webCacheEndpoint = getWebCacheEndpoint(credProvider);
+      expect(webCacheEndpoint).toEqual('https://some-cache-endpoint:9001');
+      const webTokenEndpoint = getWebTokenEndpoint(credProvider);
+      expect(webTokenEndpoint).toEqual('https://some-token-endpoint:9001');
+      const webVectorEndpoint = getWebVectorEndpoint(credProvider);
+      expect(webVectorEndpoint).toEqual('https://some-vector-endpoint:9001');
     });
     it('with overrides that do contain protocol', () => {
       const credProvider = CredentialProvider.fromString({
         authToken: base64EncodedFakeV1AuthToken,
-        controlEndpoint: 'https://some-control-endpoint:9001',
-        cacheEndpoint: 'https://some-cache-endpoint:9001',
+        endpointOverrides: {
+          controlEndpoint: 'https://some-control-endpoint:9001',
+          cacheEndpoint: 'https://some-cache-endpoint:9001',
+          tokenEndpoint: 'http://some-token-endpoint:9001',
+          vectorEndpoint: 'http://some-vector-endpoint:9001',
+        },
       });
       const webControlEndpoint = getWebControlEndpoint(credProvider);
       expect(webControlEndpoint).toEqual('https://some-control-endpoint:9001');
-    });
-  });
-});
-
-describe('getWebCacheEndpoint', () => {
-  it('adds "https://web." prefix to endpoints that were parsed from legacy tokens', () => {
-    const credProvider = CredentialProvider.fromString({
-      authToken: fakeTestLegacyToken,
-    });
-    const webControlEndpoint = getWebCacheEndpoint(credProvider);
-    expect(webControlEndpoint).toEqual(
-      'https://web.cache-endpoint.not.a.domain'
-    );
-  });
-  it('adds "https://web." prefix to endpoints that were parsed from v1 tokens', () => {
-    const credProvider = CredentialProvider.fromString({
-      authToken: base64EncodedFakeV1AuthToken,
-    });
-    const webControlEndpoint = getWebCacheEndpoint(credProvider);
-    expect(webControlEndpoint).toEqual('https://web.cache.test.momentohq.com');
-  });
-
-  it('adds https protocol, but does not add web prefix for overridden endpoints', () => {
-    const credProvider = CredentialProvider.fromString({
-      authToken: base64EncodedFakeV1AuthToken,
-      controlEndpoint: 'some-control-endpoint',
-      cacheEndpoint: 'some-cache-endpoint',
-    });
-    const webControlEndpoint = getWebCacheEndpoint(credProvider);
-    expect(webControlEndpoint).toEqual('https://some-cache-endpoint');
-  });
-  it('works with overridden endpoints that already have the protocol', () => {
-    const credProvider = CredentialProvider.fromString({
-      authToken: base64EncodedFakeV1AuthToken,
-      controlEndpoint: 'https://some-control-endpoint',
-      cacheEndpoint: 'https://some-cache-endpoint',
-    });
-    const webControlEndpoint = getWebCacheEndpoint(credProvider);
-    expect(webControlEndpoint).toEqual('https://some-cache-endpoint');
-  });
-  describe('leaves port intact for overridden endpoints', () => {
-    it("with overrides that don't contain protocol", () => {
-      const credProvider = CredentialProvider.fromString({
-        authToken: base64EncodedFakeV1AuthToken,
-        controlEndpoint: 'some-control-endpoint:9001',
-        cacheEndpoint: 'some-cache-endpoint:9001',
-      });
-      const webControlEndpoint = getWebCacheEndpoint(credProvider);
-      expect(webControlEndpoint).toEqual('https://some-cache-endpoint:9001');
-    });
-    it('with overrides that do contain protocol', () => {
-      const credProvider = CredentialProvider.fromString({
-        authToken: base64EncodedFakeV1AuthToken,
-        controlEndpoint: 'https://some-control-endpoint:9001',
-        cacheEndpoint: 'https://some-cache-endpoint:9001',
-      });
-      const webControlEndpoint = getWebCacheEndpoint(credProvider);
-      expect(webControlEndpoint).toEqual('https://some-cache-endpoint:9001');
+      const webCacheEndpoint = getWebCacheEndpoint(credProvider);
+      expect(webCacheEndpoint).toEqual('https://some-cache-endpoint:9001');
+      const webTokenEndpoint = getWebTokenEndpoint(credProvider);
+      expect(webTokenEndpoint).toEqual('http://some-token-endpoint:9001');
+      const webVectorEndpoint = getWebVectorEndpoint(credProvider);
+      expect(webVectorEndpoint).toEqual('http://some-vector-endpoint:9001');
     });
   });
 });

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -1,25 +1,39 @@
-import {decodeAuthToken, fromEntries} from '../internal/utils';
+import {
+  AllEndpoints,
+  decodeAuthToken,
+  fromEntries,
+  populateAllEndpointsFromBaseEndpoint,
+} from '../internal/utils';
+
+export interface BaseEndpointOverride {
+  baseEndpoint: string;
+}
+
+export type EndpointOverrides = BaseEndpointOverride | AllEndpoints;
+
+function isBaseEndpointOverride(
+  endpointOverrides: EndpointOverrides
+): endpointOverrides is BaseEndpointOverride {
+  return (endpointOverrides as BaseEndpointOverride).baseEndpoint !== undefined;
+}
+
+function isAllEndpoints(
+  endpointOverrides: EndpointOverrides
+): endpointOverrides is AllEndpoints {
+  const allEndpoints = endpointOverrides as AllEndpoints;
+  return (
+    allEndpoints.cacheEndpoint !== undefined &&
+    allEndpoints.controlEndpoint !== undefined &&
+    allEndpoints.tokenEndpoint !== undefined &&
+    allEndpoints.vectorEndpoint !== undefined
+  );
+}
 
 /**
  * Encapsulates arguments for instantiating an EnvMomentoTokenProvider
  */
 interface CredentialProviderProps {
-  /**
-   * optionally overrides the default controlEndpoint
-   */
-  controlEndpoint?: string;
-  /**
-   * optionally overrides the default cacheEndpoint
-   */
-  cacheEndpoint?: string;
-  /**
-   * optionally overrides the default vectorEndpoint
-   */
-  tokenEndpoint?: string;
-  /**
-   * optionally overrides the default vectorEndpoint
-   */
-  vectorEndpoint?: string;
+  endpointOverrides?: EndpointOverrides;
 }
 
 /**
@@ -55,24 +69,9 @@ export abstract class CredentialProvider {
   abstract getVectorEndpoint(): string;
 
   /**
-   * @returns {boolean} true if the cache endpoint was manually overridden at construction time; false otherwise
+   * @returns {boolean} true if the endpoints were manually overridden at construction time; false otherwise
    */
-  abstract isCacheEndpointOverridden(): boolean;
-
-  /**
-   * @returns {boolean} true if the control endpoint was manually overridden at construction time; false otherwise
-   */
-  abstract isControlEndpointOverridden(): boolean;
-
-  /**
-   * @returns {boolean} true if the token endpoint was manually overridden at construction time; false otherwise
-   */
-  abstract isTokenEndpointOverridden(): boolean;
-
-  /**
-   * @returns {boolean} true if the vector endpoint was manually overridden at construction time; false otherwise
-   */
-  abstract isVectorEndpointOverridden(): boolean;
+  abstract areEndpointsOverridden(): boolean;
 
   static fromEnvironmentVariable(
     props: EnvMomentoTokenProviderProps
@@ -98,10 +97,7 @@ abstract class CredentialProviderBase implements CredentialProvider {
 
   abstract getVectorEndpoint(): string;
 
-  abstract isCacheEndpointOverridden(): boolean;
-  abstract isControlEndpointOverridden(): boolean;
-  abstract isTokenEndpointOverridden(): boolean;
-  abstract isVectorEndpointOverridden(): boolean;
+  abstract areEndpointsOverridden(): boolean;
 
   valueOf(): object {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -126,14 +122,8 @@ export interface StringMomentoTokenProviderProps
  */
 export class StringMomentoTokenProvider extends CredentialProviderBase {
   private readonly authToken: string;
-  private readonly controlEndpoint: string;
-  private readonly cacheEndpoint: string;
-  private readonly tokenEndpoint: string;
-  private readonly vectorEndpoint: string;
-  private readonly controlEndpointOverridden: boolean;
-  private readonly cacheEndpointOverridden: boolean;
-  private readonly tokenEndpointOverridden: boolean;
-  private readonly vectorEndpointOverridden: boolean;
+  private readonly allEndpoints: AllEndpoints;
+  private readonly endpointsOverridden: boolean;
 
   /**
    * @param {StringMomentoTokenProviderProps} props configuration options for the token provider
@@ -142,42 +132,48 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
     super();
     const decodedToken = decodeAuthToken(props.authToken);
     this.authToken = decodedToken.authToken;
-    this.controlEndpointOverridden = props.controlEndpoint !== undefined;
-    const controlEndpoint =
-      props.controlEndpoint ?? decodedToken.controlEndpoint;
-    if (controlEndpoint === undefined) {
+    if (props.endpointOverrides === undefined) {
+      this.endpointsOverridden = false;
+      if (decodedToken.controlEndpoint === undefined) {
+        throw new Error(
+          'Malformed token; unable to determine control endpoint.  Depending on the type of token you are using, you may need to specify the controlEndpoint explicitly.'
+        );
+      }
+      if (decodedToken.cacheEndpoint === undefined) {
+        throw new Error(
+          'Malformed token; unable to determine cache endpoint.  Depending on the type of token you are using, you may need to specify the cacheEndpoint explicitly.'
+        );
+      }
+      if (decodedToken.tokenEndpoint === undefined) {
+        throw new Error(
+          'Malformed token; unable to determine token endpoint.  Depending on the type of token you are using, you may need to specify the tokenEndpoint explicitly.'
+        );
+      }
+      if (decodedToken.vectorEndpoint === undefined) {
+        throw new Error(
+          'Malformed token; unable to determine vector endpoint.  Depending on the type of token you are using, you may need to specify the vectorEndpoint explicitly.'
+        );
+      }
+      this.allEndpoints = {
+        controlEndpoint: decodedToken.controlEndpoint,
+        cacheEndpoint: decodedToken.cacheEndpoint,
+        tokenEndpoint: decodedToken.tokenEndpoint,
+        vectorEndpoint: decodedToken.vectorEndpoint,
+      };
+    } else if (isAllEndpoints(props.endpointOverrides)) {
+      this.endpointsOverridden = true;
+      this.allEndpoints = props.endpointOverrides;
+    } else if (isBaseEndpointOverride(props.endpointOverrides)) {
+      this.endpointsOverridden = true;
+      this.allEndpoints = populateAllEndpointsFromBaseEndpoint(
+        props.endpointOverrides.baseEndpoint
+      );
+    } else {
       throw new Error(
-        'Malformed token; unable to determine control endpoint.  Depending on the type of token you are using, you may need to specify the controlEndpoint explicitly.'
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `Unsupported endpointOverrides: ${props.endpointOverrides}`
       );
     }
-    this.cacheEndpointOverridden = props.cacheEndpoint !== undefined;
-    const cacheEndpoint = props.cacheEndpoint ?? decodedToken.cacheEndpoint;
-    if (cacheEndpoint === undefined) {
-      throw new Error(
-        'Malformed token; unable to determine cache endpoint.  Depending on the type of token you are using, you may need to specify the cacheEndpoint explicitly.'
-      );
-    }
-
-    this.tokenEndpointOverridden = props.tokenEndpoint !== undefined;
-    const tokenEndpoint = props.tokenEndpoint ?? decodedToken.tokenEndpoint;
-    if (tokenEndpoint === undefined) {
-      throw new Error(
-        'Malformed token; unable to determine token endpoint.  Depending on the type of token you are using, you may need to specify the tokenEndpoint explicitly.'
-      );
-    }
-
-    this.vectorEndpointOverridden = props.vectorEndpoint !== undefined;
-    const vectorEndpoint = props.vectorEndpoint ?? decodedToken.vectorEndpoint;
-    if (vectorEndpoint === undefined) {
-      throw new Error(
-        'Malformed token; unable to determine vector endpoint.  Depending on the type of token you are using, you may need to specify the vectorEndpoint explicitly.'
-      );
-    }
-
-    this.controlEndpoint = controlEndpoint;
-    this.cacheEndpoint = cacheEndpoint;
-    this.tokenEndpoint = decodedToken.tokenEndpoint || cacheEndpoint;
-    this.vectorEndpoint = vectorEndpoint;
   }
 
   getAuthToken(): string {
@@ -185,35 +181,23 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
   }
 
   getCacheEndpoint(): string {
-    return this.cacheEndpoint;
+    return this.allEndpoints.cacheEndpoint;
   }
 
   getControlEndpoint(): string {
-    return this.controlEndpoint;
+    return this.allEndpoints.controlEndpoint;
   }
 
   getTokenEndpoint(): string {
-    return this.tokenEndpoint;
+    return this.allEndpoints.tokenEndpoint;
   }
 
   getVectorEndpoint(): string {
-    return this.vectorEndpoint;
+    return this.allEndpoints.vectorEndpoint;
   }
 
-  isControlEndpointOverridden(): boolean {
-    return this.controlEndpointOverridden;
-  }
-
-  isCacheEndpointOverridden(): boolean {
-    return this.cacheEndpointOverridden;
-  }
-
-  isTokenEndpointOverridden(): boolean {
-    return this.tokenEndpointOverridden;
-  }
-
-  isVectorEndpointOverridden(): boolean {
-    return this.vectorEndpointOverridden;
+  areEndpointsOverridden(): boolean {
+    return this.endpointsOverridden;
   }
 }
 
@@ -243,10 +227,7 @@ export class EnvMomentoTokenProvider extends StringMomentoTokenProvider {
     }
     super({
       authToken: authToken,
-      controlEndpoint: props.controlEndpoint,
-      cacheEndpoint: props.cacheEndpoint,
-      tokenEndpoint: props.tokenEndpoint,
-      vectorEndpoint: props.vectorEndpoint,
+      endpointOverrides: props.endpointOverrides,
     });
     this.environmentVariableName = props.environmentVariableName;
   }

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -34,6 +34,24 @@ interface TokenAndEndpoints {
   authToken: string;
 }
 
+export interface AllEndpoints {
+  controlEndpoint: string;
+  cacheEndpoint: string;
+  tokenEndpoint: string;
+  vectorEndpoint: string;
+}
+
+export function populateAllEndpointsFromBaseEndpoint(
+  baseEndpoint: string
+): AllEndpoints {
+  return {
+    controlEndpoint: `control.${baseEndpoint}`,
+    cacheEndpoint: `cache.${baseEndpoint}`,
+    tokenEndpoint: `token.${baseEndpoint}`,
+    vectorEndpoint: `vector.${baseEndpoint}`,
+  };
+}
+
 /**
  * @param {string} token
  * @returns TokenAndEndpoints
@@ -57,10 +75,7 @@ export const decodeAuthToken = (token?: string): TokenAndEndpoints => {
         throw new InvalidArgumentError('failed to parse token');
       }
       return {
-        controlEndpoint: `control.${base64DecodedToken.endpoint}`,
-        cacheEndpoint: `cache.${base64DecodedToken.endpoint}`,
-        tokenEndpoint: `token.${base64DecodedToken.endpoint}`,
-        vectorEndpoint: `vector.${base64DecodedToken.endpoint}`,
+        ...populateAllEndpointsFromBaseEndpoint(base64DecodedToken.endpoint),
         authToken: base64DecodedToken.api_key,
       };
     } else {


### PR DESCRIPTION
Our credential providers support overriding the endpoints, although we do not publicize this and I do not believe any users are using it yet.

As we have added more endpoints this has begun to get unwieldy. This commit simplifies things so that it is possible to override only the base endpoint, and allow the others to be derived from it. If you do choose to explicitly override specific endpoints you are now required to override all of them, which makes the logic simpler and allows for better compile-time checking.