### PR TITLE
fix: cancel stale workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: macos-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@
 # ******** NOTE ********
 # We have attempted to detect the languages in your repository. Please check
 # the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
+# supported CodeQL languages. 
 #
 name: "CodeQL"
 


### PR DESCRIPTION
This commit cancels in progress jobs instead of letting them run to completion. It should save us quite a bit on gh actions minutes, and will prevent dependabot from prematurely merging prs.

This pr is currently only cancelling the `build.yml` jobs https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

If we wanted to, we could try cancelling _all_ stale jobs https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run

Not sure which is the best strategy to go with, open to changing it to cancel all jobs