### PR TITLE
feat: rename `AuthClient.generateAuthToken` to `AuthClient.generateApiKey`

### DIFF
--- a/examples/nodejs/access-control/access-control.ts
+++ b/examples/nodejs/access-control/access-control.ts
@@ -69,7 +69,7 @@ async function get(cacheClient: CacheClient, cacheName: string, key: string) {
 
 async function generateAuthToken(
   authClient: AuthClient,
-  scope: PermissionScope,
+  scope: TokenScope,
   durationSeconds: number
 ): Promise<[string, string]> {
   const generateTokenResponse = await authClient.generateAuthToken(scope, ExpiresIn.seconds(durationSeconds));

--- a/examples/nodejs/access-control/access-control.ts
+++ b/examples/nodejs/access-control/access-control.ts
@@ -69,7 +69,7 @@ async function get(cacheClient: CacheClient, cacheName: string, key: string) {
 
 async function generateAuthToken(
   authClient: AuthClient,
-  scope: TokenScope,
+  scope: PermissionScope,
   durationSeconds: number
 ): Promise<[string, string]> {
   const generateTokenResponse = await authClient.generateAuthToken(scope, ExpiresIn.seconds(durationSeconds));

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -118,8 +118,12 @@ import {
   Permission,
   Permissions,
   AllDataReadWrite,
+  PermissionScope,
+  PermissionScopes,
+  /**
+   * @deprecated please use 'PermissionScope' instead
+   */
   TokenScope,
-  TokenScopes,
   DisposableTokenScope,
   DisposableTokenScopes,
   CacheName,
@@ -205,8 +209,16 @@ export {
   Permission,
   Permissions,
   AllDataReadWrite,
+  PermissionScope,
+  /**
+   * @deprecated please use 'PermissionScope' instead
+   */
   TokenScope,
-  TokenScopes,
+  PermissionScopes,
+  /**
+   * @deprecated please use 'PermissionScopes' instead
+   */
+  PermissionScopes as TokenScopes,
   DisposableTokenScope,
   DisposableTokenScopes,
   CacheName,

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -19,7 +19,7 @@ import {
   CredentialProvider,
   RefreshApiKey,
   GenerateApiKey,
-  TokenScope,
+  PermissionScope,
   Permissions,
   Permission,
   TopicPermission,
@@ -34,12 +34,12 @@ import {
   AllCacheItems,
   isCacheItemKey,
   isCacheItemKeyPrefix,
+  DisposableTokenScope,
 } from '@gomomento/sdk-core';
 import {IAuthClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {AuthClientProps} from '../auth-client-props';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
-  DisposableTokenScope,
   asCachePermission,
   asPermissionsObject,
   asTopicPermission,
@@ -47,14 +47,16 @@ import {
   isPermissionsObject,
   isTopicPermission,
   PredefinedScope,
-  isDisposableTokenPermissionsObject,
+} from '@gomomento/sdk-core/dist/src/auth/tokens/permission-scope';
+import {permission_messages} from '@gomomento/generated-types/dist/permissionmessages';
+import {convert} from './utils';
+import {
+  asDisposableTokenCachePermission,
   asDisposableTokenPermissionsObject,
   DisposableTokenCachePermission,
   isDisposableTokenCachePermission,
-  asDisposableTokenCachePermission,
-} from '@gomomento/sdk-core/dist/src/auth/tokens/token-scope';
-import {permission_messages} from '@gomomento/generated-types/dist/permissionmessages';
-import {convert} from './utils';
+  isDisposableTokenPermissionsObject,
+} from '@gomomento/sdk-core/dist/src/auth/tokens/disposable-token-scope';
 
 export class InternalAuthClient implements IAuthClient {
   private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
@@ -72,7 +74,7 @@ export class InternalAuthClient implements IAuthClient {
   }
 
   public async generateApiKey(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     const authClient = new grpcAuth.AuthClient(
@@ -131,7 +133,7 @@ export class InternalAuthClient implements IAuthClient {
    * @deprecated please use `generateApiKey` instead
    */
   public generateAuthToken(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     return this.generateApiKey(scope, expiresIn);
@@ -237,7 +239,7 @@ export class InternalAuthClient implements IAuthClient {
 }
 
 export function permissionsFromTokenScope(
-  scope: TokenScope
+  scope: PermissionScope
 ): permission_messages.Permissions {
   const result = new permission_messages.Permissions();
   if (scope instanceof InternalSuperUserPermissions) {

--- a/packages/client-sdk-nodejs/test/unit/auth-client.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/auth-client.test.ts
@@ -12,7 +12,7 @@ import {
   permissionsFromDisposableTokenScope,
 } from '../../src/internal/internal-auth-client';
 import {permission_messages} from '@gomomento/generated-types/dist/permissionmessages';
-import {DisposableTokenCachePermissions} from '@gomomento/sdk-core/dist/src/auth/tokens/token-scope';
+import {DisposableTokenCachePermissions} from '@gomomento/sdk-core/dist/src/auth/tokens/disposable-token-scope';
 import {convert} from '../../src/internal/utils';
 
 describe('internal auth client', () => {

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -103,8 +103,12 @@ import {
   NoopMomentoLogger,
   NoopMomentoLoggerFactory,
   AllDataReadWrite,
+  PermissionScope,
+  /**
+   * @deprecated please use PermissionScope instead
+   */
   TokenScope,
-  TokenScopes,
+  PermissionScopes,
   DisposableTokenScope,
   DisposableTokenScopes,
   ExpiresIn,
@@ -153,8 +157,16 @@ export {
   StringMomentoTokenProvider,
   EnvMomentoTokenProvider,
   AllDataReadWrite,
+  PermissionScope,
+  /**
+   * @deprecated please use 'PermissionScope' instead
+   */
   TokenScope,
-  TokenScopes,
+  PermissionScopes,
+  /**
+   * @deprecated please use 'PermissionScopes' instead
+   */
+  PermissionScopes as TokenScopes,
   DisposableTokenScope,
   DisposableTokenScopes,
   CacheName,

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -11,7 +11,7 @@ import {
   CredentialProvider,
   ExpiresAt,
   ExpiresIn,
-  TokenScope,
+  PermissionScope,
   Permission,
   TopicPermission,
   CachePermission,
@@ -44,20 +44,22 @@ import {
 } from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {
-  DisposableTokenScope,
   asCachePermission,
   asPermissionsObject,
   asTopicPermission,
   isCachePermission,
   isPermissionsObject,
   isTopicPermission,
+  PredefinedScope,
+} from '@gomomento/sdk-core/dist/src/auth/tokens/permission-scope';
+import {
+  DisposableTokenScope,
   asDisposableTokenCachePermission,
   isDisposableTokenPermissionsObject,
   DisposableTokenCachePermission,
   isDisposableTokenCachePermission,
   asDisposableTokenPermissionsObject,
-  PredefinedScope,
-} from '@gomomento/sdk-core/dist/src/auth/tokens/token-scope';
+} from '@gomomento/sdk-core/dist/src/auth/tokens/disposable-token-scope';
 import {_GenerateDisposableTokenRequest} from '@gomomento/generated-types-webtext/dist/token_pb';
 import {
   ExplicitPermissions,
@@ -89,7 +91,7 @@ export class InternalWebGrpcAuthClient<
   }
 
   public async generateApiKey(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     const request = new _GenerateApiTokenRequest();
@@ -144,7 +146,7 @@ export class InternalWebGrpcAuthClient<
    * @deprecated please use `generateApiKey` instead
    */
   public generateAuthToken(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     return this.generateApiKey(scope, expiresIn);
@@ -246,7 +248,7 @@ export class InternalWebGrpcAuthClient<
 }
 
 export function permissionsFromScope(
-  scope: TokenScope | DisposableTokenScope
+  scope: PermissionScope | DisposableTokenScope
 ): Permissions {
   const result = new Permissions();
   if (scope instanceof InternalSuperUserPermissions) {

--- a/packages/client-sdk-web/test/unit/internal/auth-client.test.ts
+++ b/packages/client-sdk-web/test/unit/internal/auth-client.test.ts
@@ -16,7 +16,7 @@ import {
   Permissions,
   TopicRole,
 } from '@gomomento/sdk-core';
-import {DisposableTokenCachePermissions} from '@gomomento/sdk-core/dist/src/auth/tokens/token-scope';
+import {DisposableTokenCachePermissions} from '@gomomento/sdk-core/dist/src/auth/tokens/disposable-token-scope';
 import {convertToB64String} from '../../../src/utils/web-client-utils';
 
 describe('internal auth client', () => {

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -13,8 +13,8 @@ import {
   MomentoErrorCode,
   RefreshApiKey,
   SubscribeCallOptions,
-  TokenScope,
-  TokenScopes,
+  PermissionScope,
+  PermissionScopes,
   TopicPublish,
   TopicRole,
   TopicSubscribe,
@@ -38,7 +38,8 @@ import {v4} from 'uuid';
 import {expect} from '@jest/globals';
 import './momento-jest-matchers';
 
-const SUPER_USER_PERMISSIONS: TokenScope = new InternalSuperUserPermissions();
+const SUPER_USER_PERMISSIONS: PermissionScope =
+  new InternalSuperUserPermissions();
 
 export function runAuthClientTests(
   sessionTokenAuthClient: IAuthClient,
@@ -540,7 +541,7 @@ export function runAuthClientTests(
     it('can only read all caches', async () => {
       const readAllCachesTokenResponse =
         await sessionTokenAuthClient.generateApiKey(
-          TokenScopes.cacheReadOnly(AllCaches),
+          PermissionScopes.cacheReadOnly(AllCaches),
           ExpiresIn.seconds(60)
         );
       expect(readAllCachesTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
@@ -588,7 +589,7 @@ export function runAuthClientTests(
     it('can only read all topics', async () => {
       const readAllTopicsTokenResponse =
         await sessionTokenAuthClient.generateApiKey(
-          TokenScopes.topicSubscribeOnly(AllCaches, AllTopics),
+          PermissionScopes.topicSubscribeOnly(AllCaches, AllTopics),
           ExpiresIn.seconds(60)
         );
       expect(readAllTopicsTokenResponse).toBeInstanceOf(GenerateApiKey.Success);

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -8,16 +8,24 @@ import {
   CreateCache,
   DeleteCache,
   ExpiresIn,
-  GenerateAuthToken,
+  GenerateApiKey,
   GenerateDisposableToken,
   MomentoErrorCode,
-  RefreshAuthToken,
+  RefreshApiKey,
   SubscribeCallOptions,
   TokenScope,
   TokenScopes,
   TopicPublish,
   TopicRole,
   TopicSubscribe,
+  /**
+   * @deprecated but still included for testing backward compat
+   */
+  GenerateAuthToken,
+  /**
+   * @deprecated but still included for testing backward compat
+   */
+  RefreshAuthToken,
 } from '@gomomento/sdk-core';
 import {expectWithMessage} from './common-int-test-utils';
 import {InternalSuperUserPermissions} from '@gomomento/sdk-core/dist/src/internal/utils/auth';
@@ -44,27 +52,27 @@ export function runAuthClientTests(
 ) {
   describe('generate auth token using session token credentials', () => {
     it('should return success and generate auth token', async () => {
-      const resp = await sessionTokenAuthClient.generateAuthToken(
+      const resp = await sessionTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(10)
       );
       expectWithMessage(
-        () => expect(resp).toBeInstanceOf(GenerateAuthToken.Success),
+        () => expect(resp).toBeInstanceOf(GenerateApiKey.Success),
         `Unexpected response: ${resp.toString()}`
       );
     });
 
     it('should succeed for generating an api token that expires', async () => {
       const secondsSinceEpoch = Math.round(Date.now() / 1000);
-      const expireResponse = await sessionTokenAuthClient.generateAuthToken(
+      const expireResponse = await sessionTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(10)
       );
       const expiresIn = secondsSinceEpoch + 10;
 
-      expect(expireResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(expireResponse).toBeInstanceOf(GenerateApiKey.Success);
 
-      const expireResponseSuccess = expireResponse as GenerateAuthToken.Success;
+      const expireResponseSuccess = expireResponse as GenerateApiKey.Success;
       expect(expireResponseSuccess.is_success);
       expect(expireResponseSuccess.expiresAt.doesExpire());
       expect(expireResponseSuccess.expiresAt.epoch()).toBeWithin(
@@ -74,33 +82,94 @@ export function runAuthClientTests(
     });
 
     it('should succeed for generating an api token that never expires', async () => {
-      const neverExpiresResponse =
-        await sessionTokenAuthClient.generateAuthToken(
-          SUPER_USER_PERMISSIONS,
-          ExpiresIn.never()
-        );
-      expect(neverExpiresResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      const neverExpiresResponse = await sessionTokenAuthClient.generateApiKey(
+        SUPER_USER_PERMISSIONS,
+        ExpiresIn.never()
+      );
+      expect(neverExpiresResponse).toBeInstanceOf(GenerateApiKey.Success);
       const neverExpireResponseSuccess =
-        neverExpiresResponse as GenerateAuthToken.Success;
+        neverExpiresResponse as GenerateApiKey.Success;
       expect(neverExpireResponseSuccess.is_success);
       expect(neverExpireResponseSuccess.expiresAt.doesExpire()).toBeFalsy();
     });
 
     it('should not succeed for generating an api token that has an invalid expires', async () => {
       const invalidExpiresResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(-100)
         );
-      expect(invalidExpiresResponse).toBeInstanceOf(GenerateAuthToken.Error);
+      expect(invalidExpiresResponse).toBeInstanceOf(GenerateApiKey.Error);
       expect(
-        (invalidExpiresResponse as GenerateAuthToken.Error).errorCode()
+        (invalidExpiresResponse as GenerateApiKey.Error).errorCode()
       ).toEqual(MomentoErrorCode.INVALID_ARGUMENT_ERROR);
     });
   });
 
   describe('refresh auth token use auth token credentials', () => {
     it('should succeed for refreshing an auth token', async () => {
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
+        SUPER_USER_PERMISSIONS,
+        ExpiresIn.seconds(10)
+      );
+      expectWithMessage(() => {
+        expect(generateResponse).toBeInstanceOf(GenerateApiKey.Success);
+      }, `Unexpected response: ${generateResponse.toString()}`);
+      const generateSuccessRst = generateResponse as GenerateApiKey.Success;
+
+      const authTokenAuthClient = authTokenAuthClientFactory(
+        generateSuccessRst.apiKey
+      );
+
+      // we need to sleep for a bit here so that the timestamp on the refreshed token will be different than the
+      // one on the original token
+      const delaySecondsBeforeRefresh = 2;
+      await delay(delaySecondsBeforeRefresh * 1_000);
+
+      const refreshResponse = await authTokenAuthClient.refreshApiKey(
+        generateSuccessRst.refreshToken
+      );
+      expectWithMessage(() => {
+        expect(refreshResponse).toBeInstanceOf(RefreshApiKey.Success);
+      }, `Unexpected response: ${refreshResponse.toString()}`);
+      const refreshSuccessRst = refreshResponse as RefreshApiKey.Success;
+
+      expect(refreshSuccessRst.is_success);
+
+      const expiresAtDelta =
+        refreshSuccessRst.expiresAt.epoch() -
+        generateSuccessRst.expiresAt.epoch();
+
+      expect(expiresAtDelta).toBeGreaterThanOrEqual(delaySecondsBeforeRefresh);
+      expect(expiresAtDelta).toBeLessThanOrEqual(delaySecondsBeforeRefresh + 1);
+    });
+
+    it("should not succeed for refreshing an api token that's expired", async () => {
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
+        SUPER_USER_PERMISSIONS,
+        ExpiresIn.seconds(1)
+      );
+      const generateSuccessRst = generateResponse as GenerateApiKey.Success;
+
+      // Wait 1sec for the token to expire
+      await delay(1000);
+
+      const authTokenAuthClient = authTokenAuthClientFactory(
+        generateSuccessRst.apiKey
+      );
+
+      const refreshResponse = await authTokenAuthClient.refreshApiKey(
+        generateSuccessRst.refreshToken
+      );
+      expect(refreshResponse).toBeInstanceOf(RefreshApiKey.Error);
+      expect((refreshResponse as RefreshApiKey.Error).errorCode()).toEqual(
+        MomentoErrorCode.AUTHENTICATION_ERROR
+      );
+    });
+  });
+
+  describe('should support generating and refreshing auth token through deprecated APIs', () => {
+    it('should succeed for generating and refreshing an auth token', async () => {
       const generateResponse = await sessionTokenAuthClient.generateAuthToken(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(10)
@@ -129,6 +198,10 @@ export function runAuthClientTests(
 
       expect(refreshSuccessRst.is_success);
 
+      expect(refreshSuccessRst.authToken).not.toEqual(
+        generateSuccessRst.authToken
+      );
+
       const expiresAtDelta =
         refreshSuccessRst.expiresAt.epoch() -
         generateSuccessRst.expiresAt.epoch();
@@ -136,41 +209,20 @@ export function runAuthClientTests(
       expect(expiresAtDelta).toBeGreaterThanOrEqual(delaySecondsBeforeRefresh);
       expect(expiresAtDelta).toBeLessThanOrEqual(delaySecondsBeforeRefresh + 1);
     });
+  });
 
-    it("should not succeed for refreshing an api token that's expired", async () => {
-      const generateResponse = await sessionTokenAuthClient.generateAuthToken(
-        SUPER_USER_PERMISSIONS,
-        ExpiresIn.seconds(1)
-      );
-      const generateSuccessRst = generateResponse as GenerateAuthToken.Success;
-
-      // Wait 1sec for the token to expire
-      await delay(1000);
-
-      const authTokenAuthClient = authTokenAuthClientFactory(
-        generateSuccessRst.authToken
-      );
-
-      const refreshResponse = await authTokenAuthClient.refreshAuthToken(
-        generateSuccessRst.refreshToken
-      );
-      expect(refreshResponse).toBeInstanceOf(RefreshAuthToken.Error);
-      expect((refreshResponse as RefreshAuthToken.Error).errorCode()).toEqual(
-        MomentoErrorCode.AUTHENTICATION_ERROR
-      );
-    });
-
+  describe('generating superuser and AllDataReadWrite tokens', () => {
     it("expired token can't create cache", async () => {
-      const generateResponse = await sessionTokenAuthClient.generateAuthToken(
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(1)
       );
-      const generateSuccessRst = generateResponse as GenerateAuthToken.Success;
+      const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
       // Wait 1sec for the token to expire
       await delay(1000);
 
-      const cacheClient = cacheClientFactory(generateSuccessRst.authToken);
+      const cacheClient = cacheClientFactory(generateSuccessRst.apiKey);
 
       const createCacheRst = await cacheClient.createCache(
         'cache-should-fail-to-create'
@@ -184,118 +236,118 @@ export function runAuthClientTests(
     });
 
     it('should support generating a superuser token when authenticated via a session token', async () => {
-      const generateResponse = await sessionTokenAuthClient.generateAuthToken(
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Success);
     });
 
     it('should support generating an AllDataReadWrite token when authenticated via a session token', async () => {
-      const generateResponse = await sessionTokenAuthClient.generateAuthToken(
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
         AllDataReadWrite,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Success);
     });
 
     it('should not support generating a superuser token when authenticated via a v1 superuser token', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
-      const generateResponse = await authClient.generateAuthToken(
+      const generateResponse = await authClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Error);
-      const error = generateResponse as GenerateAuthToken.Error;
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
+      const error = generateResponse as GenerateApiKey.Error;
       expect(error.errorCode()).toEqual(MomentoErrorCode.PERMISSION_ERROR);
       expect(error.message()).toContain('Insufficient permissions');
     });
 
     it('should support generating an AllDataReadWrite token when authenticated via a v1 superuser token', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
-      const generateResponse = await authClient.generateAuthToken(
+      const generateResponse = await authClient.generateApiKey(
         AllDataReadWrite,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Success);
     });
 
     it('should not support generating a superuser token when authenticated via a v1 AllDataReadWrite token', async () => {
       const allDataReadWriteTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           AllDataReadWrite,
           ExpiresIn.seconds(10)
         );
       expect(allDataReadWriteTokenResponse).toBeInstanceOf(
-        GenerateAuthToken.Success
+        GenerateApiKey.Success
       );
 
       const authClient = authTokenAuthClientFactory(
-        (allDataReadWriteTokenResponse as GenerateAuthToken.Success).authToken
+        (allDataReadWriteTokenResponse as GenerateApiKey.Success).apiKey
       );
 
-      const generateResponse = await authClient.generateAuthToken(
+      const generateResponse = await authClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Error);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
     });
 
     it('should not support generating an AllDataReadWrite token when authenticated via a v1 AllDataReadWrite token', async () => {
       const allDataReadWriteTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           AllDataReadWrite,
           ExpiresIn.seconds(10)
         );
       expect(allDataReadWriteTokenResponse).toBeInstanceOf(
-        GenerateAuthToken.Success
+        GenerateApiKey.Success
       );
 
       const authClient = authTokenAuthClientFactory(
-        (allDataReadWriteTokenResponse as GenerateAuthToken.Success).authToken
+        (allDataReadWriteTokenResponse as GenerateApiKey.Success).apiKey
       );
 
-      const generateResponse = await authClient.generateAuthToken(
+      const generateResponse = await authClient.generateApiKey(
         AllDataReadWrite,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Error);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
     });
 
     it('should not support generating a superuser token when authenticated via a legacy token', async () => {
-      const generateResponse = await legacyTokenAuthClient.generateAuthToken(
+      const generateResponse = await legacyTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Error);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
     });
 
     it('should not support generating an AllDataReadWrite token when authenticated via a legacy token', async () => {
-      const generateResponse = await legacyTokenAuthClient.generateAuthToken(
+      const generateResponse = await legacyTokenAuthClient.generateApiKey(
         AllDataReadWrite,
         ExpiresIn.seconds(1)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Error);
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
     });
   });
 
@@ -303,14 +355,13 @@ export function runAuthClientTests(
     let allDataReadWriteClient: ICacheClient;
 
     beforeAll(async () => {
-      const generateResponse = await sessionTokenAuthClient.generateAuthToken(
+      const generateResponse = await sessionTokenAuthClient.generateApiKey(
         AllDataReadWrite,
         ExpiresIn.seconds(60)
       );
-      expect(generateResponse).toBeInstanceOf(GenerateAuthToken.Success);
-      const allDataReadWriteToken = (
-        generateResponse as GenerateAuthToken.Success
-      ).authToken;
+      expect(generateResponse).toBeInstanceOf(GenerateApiKey.Success);
+      const allDataReadWriteToken = (generateResponse as GenerateApiKey.Success)
+        .apiKey;
       allDataReadWriteClient = cacheClientFactory(allDataReadWriteToken);
     });
     it('cannot create a cache', async () => {
@@ -416,19 +467,19 @@ export function runAuthClientTests(
     });
 
     it('cannot create token with empty permission list', async () => {
-      const tokenResponse = await sessionTokenAuthClient.generateAuthToken(
+      const tokenResponse = await sessionTokenAuthClient.generateApiKey(
         {permissions: []},
         ExpiresIn.seconds(60)
       );
-      expect(tokenResponse).toBeInstanceOf(GenerateAuthToken.Error);
-      const tokenError = tokenResponse as GenerateAuthToken.Error;
+      expect(tokenResponse).toBeInstanceOf(GenerateApiKey.Error);
+      const tokenError = tokenResponse as GenerateApiKey.Error;
       expect(tokenError.errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
     });
 
     it('cannot create token with duplicate/conflicting cache permissions - all caches', async () => {
-      const tokenResponse = await sessionTokenAuthClient.generateAuthToken(
+      const tokenResponse = await sessionTokenAuthClient.generateApiKey(
         {
           permissions: [
             {role: CacheRole.ReadOnly, cache: AllCaches},
@@ -437,15 +488,15 @@ export function runAuthClientTests(
         },
         ExpiresIn.seconds(60)
       );
-      expect(tokenResponse).toBeInstanceOf(GenerateAuthToken.Error);
-      const tokenError = tokenResponse as GenerateAuthToken.Error;
+      expect(tokenResponse).toBeInstanceOf(GenerateApiKey.Error);
+      const tokenError = tokenResponse as GenerateApiKey.Error;
       expect(tokenError.errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
     });
 
     it('cannot create token with duplicate/conflicting cache permissions - cache name', async () => {
-      const tokenResponse = await sessionTokenAuthClient.generateAuthToken(
+      const tokenResponse = await sessionTokenAuthClient.generateApiKey(
         {
           permissions: [
             {role: CacheRole.ReadOnly, cache: 'i-am-groot'},
@@ -454,15 +505,15 @@ export function runAuthClientTests(
         },
         ExpiresIn.seconds(60)
       );
-      expect(tokenResponse).toBeInstanceOf(GenerateAuthToken.Error);
-      const tokenError = tokenResponse as GenerateAuthToken.Error;
+      expect(tokenResponse).toBeInstanceOf(GenerateApiKey.Error);
+      const tokenError = tokenResponse as GenerateApiKey.Error;
       expect(tokenError.errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
     });
 
     it('cannot create token with duplicate/conflicting topic permissions - cache + topic name', async () => {
-      const tokenResponse = await sessionTokenAuthClient.generateAuthToken(
+      const tokenResponse = await sessionTokenAuthClient.generateApiKey(
         {
           permissions: [
             {
@@ -479,8 +530,8 @@ export function runAuthClientTests(
         },
         ExpiresIn.seconds(60)
       );
-      expect(tokenResponse).toBeInstanceOf(GenerateAuthToken.Error);
-      const tokenError = tokenResponse as GenerateAuthToken.Error;
+      expect(tokenResponse).toBeInstanceOf(GenerateApiKey.Error);
+      const tokenError = tokenResponse as GenerateApiKey.Error;
       expect(tokenError.errorCode()).toEqual(
         MomentoErrorCode.INVALID_ARGUMENT_ERROR
       );
@@ -488,16 +539,14 @@ export function runAuthClientTests(
 
     it('can only read all caches', async () => {
       const readAllCachesTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           TokenScopes.cacheReadOnly(AllCaches),
           ExpiresIn.seconds(60)
         );
-      expect(readAllCachesTokenResponse).toBeInstanceOf(
-        GenerateAuthToken.Success
-      );
+      expect(readAllCachesTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
       const readAllCachesToken = (
-        readAllCachesTokenResponse as GenerateAuthToken.Success
-      ).authToken;
+        readAllCachesTokenResponse as GenerateApiKey.Success
+      ).apiKey;
       const cacheClient = cacheClientFactory(readAllCachesToken);
 
       // 1. Sets should fail
@@ -538,16 +587,14 @@ export function runAuthClientTests(
 
     it('can only read all topics', async () => {
       const readAllTopicsTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           TokenScopes.topicSubscribeOnly(AllCaches, AllTopics),
           ExpiresIn.seconds(60)
         );
-      expect(readAllTopicsTokenResponse).toBeInstanceOf(
-        GenerateAuthToken.Success
-      );
+      expect(readAllTopicsTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
       const readAllTopicsToken = (
-        readAllTopicsTokenResponse as GenerateAuthToken.Success
-      ).authToken;
+        readAllTopicsTokenResponse as GenerateApiKey.Success
+      ).apiKey;
       const cacheClient = cacheClientFactory(readAllTopicsToken);
 
       // Sets should fail
@@ -583,7 +630,7 @@ export function runAuthClientTests(
     });
 
     it('can read/write cache FGA_CACHE_1 and read/write all topics in cache FGA_CACHE_2', async () => {
-      const tokenResponse = await sessionTokenAuthClient.generateAuthToken(
+      const tokenResponse = await sessionTokenAuthClient.generateApiKey(
         {
           permissions: [
             {role: CacheRole.ReadWrite, cache: FGA_CACHE_1},
@@ -596,8 +643,8 @@ export function runAuthClientTests(
         },
         ExpiresIn.seconds(60)
       );
-      expect(tokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
-      const token = (tokenResponse as GenerateAuthToken.Success).authToken;
+      expect(tokenResponse).toBeInstanceOf(GenerateApiKey.Success);
+      const token = (tokenResponse as GenerateApiKey.Success).apiKey;
       const cacheClient = cacheClientFactory(token);
 
       // Read/Write on cache FGA_CACHE_1 is allowed
@@ -649,14 +696,14 @@ export function runAuthClientTests(
 
     it('can only write cache FGA_CACHE_1 and write all topics in cache FGA_CACHE_2', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -726,14 +773,14 @@ export function runAuthClientTests(
 
     it('can only read specific keys and key-prefixes from all caches', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -784,14 +831,14 @@ export function runAuthClientTests(
 
     it('can only read specific keys and key-prefixes from cache FGA_CACHE_1', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -842,14 +889,14 @@ export function runAuthClientTests(
 
     it('can only write specific keys and key-prefixes from all caches', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -906,14 +953,14 @@ export function runAuthClientTests(
 
     it('can only write specific keys and key-prefixes from cache FGA_CACHE_1', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -977,14 +1024,14 @@ export function runAuthClientTests(
 
     it('can read and write specific keys and key-prefixes from all caches', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(
@@ -1041,14 +1088,14 @@ export function runAuthClientTests(
 
     it('can read and write specific keys and key-prefixes from cache FGA_CACHE_1', async () => {
       const superUserTokenResponse =
-        await sessionTokenAuthClient.generateAuthToken(
+        await sessionTokenAuthClient.generateApiKey(
           SUPER_USER_PERMISSIONS,
           ExpiresIn.seconds(10)
         );
-      expect(superUserTokenResponse).toBeInstanceOf(GenerateAuthToken.Success);
+      expect(superUserTokenResponse).toBeInstanceOf(GenerateApiKey.Success);
 
       const authClient = authTokenAuthClientFactory(
-        (superUserTokenResponse as GenerateAuthToken.Success).authToken
+        (superUserTokenResponse as GenerateApiKey.Success).apiKey
       );
 
       const tokenResponse = await authClient.generateDisposableToken(

--- a/packages/core/src/auth/tokens/disposable-token-scope.ts
+++ b/packages/core/src/auth/tokens/disposable-token-scope.ts
@@ -1,0 +1,108 @@
+import {
+  AllCacheItems,
+  CachePermission,
+  Permission,
+  Permissions,
+  PredefinedScope,
+} from './permission-scope';
+
+export interface CacheItemKey {
+  key: string;
+}
+
+export interface CacheItemKeyPrefix {
+  keyPrefix: string;
+}
+
+export function isCacheItemKey(
+  cacheItem: CacheItemSelector
+): cacheItem is CacheItemKey {
+  if (cacheItem === AllCacheItems) {
+    return false;
+  }
+  if (typeof cacheItem === 'string') {
+    return true;
+  }
+  return 'key' in cacheItem;
+}
+
+export function isCacheItemKeyPrefix(
+  cacheItem: CacheItemSelector
+): cacheItem is CacheItemKeyPrefix {
+  if (cacheItem === AllCacheItems) {
+    return false;
+  }
+  if (typeof cacheItem === 'string') {
+    return false;
+  }
+  return 'keyPrefix' in cacheItem;
+}
+
+export type CacheItemSelector =
+  | typeof AllCacheItems
+  | CacheItemKey
+  | CacheItemKeyPrefix
+  | string;
+
+export interface DisposableTokenCachePermission extends CachePermission {
+  /**
+   * Scope the token permissions to select cache items
+   */
+  item: CacheItemSelector;
+}
+
+export function isDisposableTokenCachePermission(p: Permission): boolean {
+  return 'role' in p && 'cache' in p && 'item' in p && !('topic' in p);
+}
+
+export function asDisposableTokenCachePermission(
+  p: Permission
+): DisposableTokenCachePermission {
+  if (!isDisposableTokenCachePermission(p)) {
+    throw new Error(
+      `permission is not a DisposableTokenCachePermission object: ${JSON.stringify(
+        p
+      )}`
+    );
+  }
+  return p as DisposableTokenCachePermission;
+}
+
+export interface DisposableTokenCachePermissions {
+  permissions: Array<DisposableTokenCachePermission>;
+}
+
+export type DisposableTokenScope =
+  | Permissions
+  | PredefinedScope
+  | DisposableTokenCachePermissions;
+
+function isDisposableTokenPermissionObject(p: Permission): boolean {
+  return isDisposableTokenCachePermission(p);
+}
+
+export function isDisposableTokenPermissionsObject(
+  scope: DisposableTokenScope
+): boolean {
+  if (!('permissions' in scope)) {
+    return false;
+  }
+  const permissions = scope.permissions;
+  return permissions.every(p => isDisposableTokenPermissionObject(p));
+}
+
+export function asDisposableTokenPermissionsObject(
+  scope: DisposableTokenScope
+): DisposableTokenCachePermissions {
+  console.log(
+    `AS_DISPOSABLE_TOKEN_PERMISSIONS_OBJECT: ${JSON.stringify(scope)}`
+  );
+  if (!isDisposableTokenPermissionsObject(scope)) {
+    throw new Error(
+      `Token scope is not a DisposableTokenCachePermissions object: ${JSON.stringify(
+        scope
+      )}`
+    );
+  }
+  return scope as DisposableTokenCachePermissions;
+}

--- a/packages/core/src/auth/tokens/disposable-token-scopes.ts
+++ b/packages/core/src/auth/tokens/disposable-token-scopes.ts
@@ -1,6 +1,7 @@
-import {CacheRole, CacheSelector, DisposableTokenScope} from './token-scope';
+import {CacheRole, CacheSelector} from './permission-scope';
+import {DisposableTokenScope} from './disposable-token-scope';
 
-export * from './token-scopes';
+export * from './permission-scopes';
 
 export function cacheKeyReadWrite(
   cacheSelector: CacheSelector,

--- a/packages/core/src/auth/tokens/permission-scope.ts
+++ b/packages/core/src/auth/tokens/permission-scope.ts
@@ -103,7 +103,7 @@ function isPermissionObject(p: Permission): boolean {
   return isCachePermission(p) || isTopicPermission(p);
 }
 
-export function isPermissionsObject(scope: TokenScope): boolean {
+export function isPermissionsObject(scope: PermissionScope): boolean {
   if (!('permissions' in scope)) {
     return false;
   }
@@ -111,7 +111,7 @@ export function isPermissionsObject(scope: TokenScope): boolean {
   return permissions.every(p => isPermissionObject(p));
 }
 
-export function asPermissionsObject(scope: TokenScope): Permissions {
+export function asPermissionsObject(scope: PermissionScope): Permissions {
   if (!isPermissionsObject(scope)) {
     throw new Error(
       `Token scope is not a Permissions object: ${JSON.stringify(scope)}`
@@ -122,108 +122,12 @@ export function asPermissionsObject(scope: TokenScope): Permissions {
 
 export abstract class PredefinedScope {}
 
-export type TokenScope =
+export type PermissionScope =
   | typeof AllDataReadWrite
   | Permissions
   | PredefinedScope;
 
-export interface CacheItemKey {
-  key: string;
-}
-
-export interface CacheItemKeyPrefix {
-  keyPrefix: string;
-}
-
-export function isCacheItemKey(
-  cacheItem: CacheItemSelector
-): cacheItem is CacheItemKey {
-  if (cacheItem === AllCacheItems) {
-    return false;
-  }
-  if (typeof cacheItem === 'string') {
-    return true;
-  }
-  return 'key' in cacheItem;
-}
-
-export function isCacheItemKeyPrefix(
-  cacheItem: CacheItemSelector
-): cacheItem is CacheItemKeyPrefix {
-  if (cacheItem === AllCacheItems) {
-    return false;
-  }
-  if (typeof cacheItem === 'string') {
-    return false;
-  }
-  return 'keyPrefix' in cacheItem;
-}
-
-export type CacheItemSelector =
-  | typeof AllCacheItems
-  | CacheItemKey
-  | CacheItemKeyPrefix
-  | string;
-
-export interface DisposableTokenCachePermission extends CachePermission {
-  /**
-   * Scope the token permissions to select cache items
-   */
-  item: CacheItemSelector;
-}
-
-export function isDisposableTokenCachePermission(p: Permission): boolean {
-  return 'role' in p && 'cache' in p && 'item' in p && !('topic' in p);
-}
-
-export function asDisposableTokenCachePermission(
-  p: Permission
-): DisposableTokenCachePermission {
-  if (!isDisposableTokenCachePermission(p)) {
-    throw new Error(
-      `permission is not a DisposableTokenCachePermission object: ${JSON.stringify(
-        p
-      )}`
-    );
-  }
-  return p as DisposableTokenCachePermission;
-}
-
-export interface DisposableTokenCachePermissions {
-  permissions: Array<DisposableTokenCachePermission>;
-}
-
-export type DisposableTokenScope =
-  | Permissions
-  | PredefinedScope
-  | DisposableTokenCachePermissions;
-
-function isDisposableTokenPermissionObject(p: Permission): boolean {
-  return isDisposableTokenCachePermission(p);
-}
-
-export function isDisposableTokenPermissionsObject(
-  scope: DisposableTokenScope
-): boolean {
-  if (!('permissions' in scope)) {
-    return false;
-  }
-  const permissions = scope.permissions;
-  return permissions.every(p => isDisposableTokenPermissionObject(p));
-}
-
-export function asDisposableTokenPermissionsObject(
-  scope: DisposableTokenScope
-): DisposableTokenCachePermissions {
-  console.log(
-    `AS_DISPOSABLE_TOKEN_PERMISSIONS_OBJECT: ${JSON.stringify(scope)}`
-  );
-  if (!isDisposableTokenPermissionsObject(scope)) {
-    throw new Error(
-      `Token scope is not a DisposableTokenCachePermissions object: ${JSON.stringify(
-        scope
-      )}`
-    );
-  }
-  return scope as DisposableTokenCachePermissions;
-}
+/**
+ * @deprecated please use PermissionScope instead
+ */
+export type TokenScope = PermissionScope;

--- a/packages/core/src/auth/tokens/permission-scopes.ts
+++ b/packages/core/src/auth/tokens/permission-scopes.ts
@@ -1,24 +1,24 @@
 import {
   CacheRole,
   CacheSelector,
-  TokenScope,
+  PermissionScope,
   TopicRole,
   TopicSelector,
-} from './token-scope';
+} from './permission-scope';
 
-export function cacheReadWrite(cacheSelector: CacheSelector): TokenScope {
+export function cacheReadWrite(cacheSelector: CacheSelector): PermissionScope {
   return {
     permissions: [{role: CacheRole.ReadWrite, cache: cacheSelector}],
   };
 }
 
-export function cacheReadOnly(cacheSelector: CacheSelector): TokenScope {
+export function cacheReadOnly(cacheSelector: CacheSelector): PermissionScope {
   return {
     permissions: [{role: CacheRole.ReadOnly, cache: cacheSelector}],
   };
 }
 
-export function cacheWriteOnly(cacheSelector: CacheSelector): TokenScope {
+export function cacheWriteOnly(cacheSelector: CacheSelector): PermissionScope {
   return {
     permissions: [{role: CacheRole.WriteOnly, cache: cacheSelector}],
   };
@@ -27,7 +27,7 @@ export function cacheWriteOnly(cacheSelector: CacheSelector): TokenScope {
 export function topicSubscribeOnly(
   cacheSelector: CacheSelector,
   topicSelector: TopicSelector
-): TokenScope {
+): PermissionScope {
   return {
     permissions: [
       {
@@ -42,7 +42,7 @@ export function topicSubscribeOnly(
 export function topicPublishSubscribe(
   cacheSelector: CacheSelector,
   topicSelector: TopicSelector
-): TokenScope {
+): PermissionScope {
   return {
     permissions: [
       {
@@ -57,7 +57,7 @@ export function topicPublishSubscribe(
 export function topicPublishOnly(
   cacheSelector: CacheSelector,
   topicSelector: TopicSelector
-): TokenScope {
+): PermissionScope {
   return {
     permissions: [
       {

--- a/packages/core/src/clients/IAuthClient.ts
+++ b/packages/core/src/clients/IAuthClient.ts
@@ -1,18 +1,31 @@
 import {
   ExpiresIn,
-  GenerateAuthToken,
+  GenerateApiKey,
   GenerateDisposableToken,
-  RefreshAuthToken,
+  RefreshApiKey,
 } from '../index';
 import {DisposableTokenScope, TokenScope} from '../auth/tokens/token-scope';
 
 export interface IAuthClient {
+  generateApiKey(
+    scope: TokenScope,
+    expiresIn: ExpiresIn
+  ): Promise<GenerateApiKey.Response>;
+
+  /**
+   * @deprecated please use `generateApiKey` instead
+   */
   generateAuthToken(
     scope: TokenScope,
     expiresIn: ExpiresIn
-  ): Promise<GenerateAuthToken.Response>;
+  ): Promise<GenerateApiKey.Response>;
 
-  refreshAuthToken(refreshToken: string): Promise<RefreshAuthToken.Response>;
+  refreshApiKey(refreshToken: string): Promise<RefreshApiKey.Response>;
+
+  /**
+   * @deprecated please use `refreshApiKey` instead
+   */
+  refreshAuthToken(refreshToken: string): Promise<RefreshApiKey.Response>;
 
   generateDisposableToken(
     scope: DisposableTokenScope,

--- a/packages/core/src/clients/IAuthClient.ts
+++ b/packages/core/src/clients/IAuthClient.ts
@@ -1,14 +1,15 @@
 import {
+  DisposableTokenScope,
   ExpiresIn,
   GenerateApiKey,
   GenerateDisposableToken,
   RefreshApiKey,
 } from '../index';
-import {DisposableTokenScope, TokenScope} from '../auth/tokens/token-scope';
+import {PermissionScope} from '../auth/tokens/permission-scope';
 
 export interface IAuthClient {
   generateApiKey(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response>;
 
@@ -16,7 +17,7 @@ export interface IAuthClient {
    * @deprecated please use `generateApiKey` instead
    */
   generateAuthToken(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response>;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,25 +131,36 @@ export {
   Permission,
   Permissions,
   AllDataReadWrite,
+  PermissionScope,
+  /**
+   * @deprecated - please use PermissionScope
+   */
   TokenScope,
-  DisposableTokenScope,
   CacheName,
   isCacheName,
   TopicName,
   isTopicName,
   CacheSelector,
   TopicSelector,
-  CacheItemSelector,
   AllCaches,
   AllTopics,
   AllCacheItems,
+} from './auth/tokens/permission-scope';
+
+export {
+  DisposableTokenScope,
+  CacheItemSelector,
   CacheItemKey,
   CacheItemKeyPrefix,
   isCacheItemKey,
   isCacheItemKeyPrefix,
-} from './auth/tokens/token-scope';
+} from './auth/tokens/disposable-token-scope';
 
-export * as TokenScopes from './auth/tokens/token-scopes';
+export * as PermissionScopes from './auth/tokens/permission-scopes';
+/**
+ * @deprecated please use PermissionScopes instead
+ */
+export * as TokenScopes from './auth/tokens/permission-scopes';
 export * as DisposableTokenScopes from './auth/tokens/disposable-token-scopes';
 
 export {

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -3,12 +3,10 @@ import {
   ExpiresIn,
   RefreshApiKey,
   GenerateDisposableToken,
+  DisposableTokenScope,
 } from '../../../index';
 import {IAuthClient} from '../../../clients/IAuthClient';
-import {
-  DisposableTokenScope,
-  TokenScope,
-} from '../../../auth/tokens/token-scope';
+import {PermissionScope} from '../../../auth/tokens/permission-scope';
 
 export interface BaseAuthClientProps {
   createAuthClient: () => IAuthClient;
@@ -24,7 +22,7 @@ export abstract class AbstractAuthClient implements IAuthClient {
   /**
    * Generates a new API key, along with a refresh token to refresh the API key before expiry.
    *
-   * @param {TokenScope} scope - controls the permissions that the new key will have
+   * @param {PermissionScope} scope - controls the permissions that the new key will have
    * @param {string} expiresIn - How long the API key should be valid for in epoch timestamp.
    * @returns {Promise<GenerateApiKey.Response>} -
    * {@link GenerateApiKey.Success} containing the API key, refresh token, origin and epoch timestamp when token expires.
@@ -32,7 +30,7 @@ export abstract class AbstractAuthClient implements IAuthClient {
    * {@link GenerateApiKey.Error} on failure.
    */
   public async generateApiKey(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     return await this.authClient.generateApiKey(scope, expiresIn);
@@ -42,7 +40,7 @@ export abstract class AbstractAuthClient implements IAuthClient {
    * @deprecated please use `generateApiKey` instead
    */
   public async generateAuthToken(
-    scope: TokenScope,
+    scope: PermissionScope,
     expiresIn: ExpiresIn
   ): Promise<GenerateApiKey.Response> {
     return await this.generateApiKey(scope, expiresIn);

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -1,7 +1,7 @@
 import {
-  GenerateAuthToken,
+  GenerateApiKey,
   ExpiresIn,
-  RefreshAuthToken,
+  RefreshApiKey,
   GenerateDisposableToken,
 } from '../../../index';
 import {IAuthClient} from '../../../clients/IAuthClient';
@@ -22,36 +22,55 @@ export abstract class AbstractAuthClient implements IAuthClient {
   }
 
   /**
-   * Generates a new auth token, along with a refresh token to refresh the auth token before expiry.
+   * Generates a new API key, along with a refresh token to refresh the API key before expiry.
    *
-   * @param {TokenScope} scope - controls the permissions that the new token will have
+   * @param {TokenScope} scope - controls the permissions that the new key will have
    * @param {string} expiresIn - How long the token is valid for in epoch timestamp.
-   * @returns {Promise<GenerateAuthToken.Response>} -
-   * {@link GenerateAuthToken.Success} containing the api token, refresh token, origin and epoch timestamp when token expires.
+   * @returns {Promise<GenerateApiKey.Response>} -
+   * {@link GenerateApiKey.Success} containing the api key, refresh token, origin and epoch timestamp when token expires.
    * If the token never expires, then no refresh token will be returned and expires at timestamp will be infinite.
-   * {@link GenerateAuthToken.Error} on failure.
+   * {@link GenerateApiKey.Error} on failure.
+   */
+  public async generateApiKey(
+    scope: TokenScope,
+    expiresIn: ExpiresIn
+  ): Promise<GenerateApiKey.Response> {
+    return await this.authClient.generateApiKey(scope, expiresIn);
+  }
+
+  /**
+   * @deprecated please use `generateApiKey` instead
    */
   public async generateAuthToken(
     scope: TokenScope,
     expiresIn: ExpiresIn
-  ): Promise<GenerateAuthToken.Response> {
-    return await this.authClient.generateAuthToken(scope, expiresIn);
+  ): Promise<GenerateApiKey.Response> {
+    return await this.generateApiKey(scope, expiresIn);
   }
 
   /**
-   * Refreshes an auth token.  Returns a new set of refresh/auth tokens that will be able to be refreshed again in the future.
-   * The new auth token will be valid for the same length of time as the original token, starting from the time of refresh.
-   * The original api token will still work until its expired.
+   * Refreshes an API key.  Returns a new API key and refresh token, that will be able to be refreshed again in the future.
+   * The new API key will be valid for the same length of time as the original token, starting from the time of refresh.
+   * The original api key will still work until its expired.
    *
-   * @param {string} refreshToken - Refresh token used to refresh the api token.
-   * @returns {Promise<RefreshAuthToken.Response>} -
-   * {@link RefreshAuthToken.Success} containing the new auth token, refresh token, origin and epoch timestamp when token expires.
-   * {@link RefreshAuthToken.Error} on failure.
+   * @param {string} refreshToken - Refresh token used to refresh the API key.
+   * @returns {Promise<RefreshApiKey.Response>} -
+   * {@link RefreshApiKey.Success} containing the new auth token, refresh token, origin and epoch timestamp when token expires.
+   * {@link RefreshApiKey.Error} on failure.
+   */
+  public async refreshApiKey(
+    refreshToken: string
+  ): Promise<RefreshApiKey.Response> {
+    return await this.authClient.refreshApiKey(refreshToken);
+  }
+
+  /**
+   * @deprecated please use `refreshApiKey` instead
    */
   public async refreshAuthToken(
     refreshToken: string
-  ): Promise<RefreshAuthToken.Response> {
-    return await this.authClient.refreshAuthToken(refreshToken);
+  ): Promise<RefreshApiKey.Response> {
+    return await this.refreshApiKey(refreshToken);
   }
 
   /**

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -25,10 +25,10 @@ export abstract class AbstractAuthClient implements IAuthClient {
    * Generates a new API key, along with a refresh token to refresh the API key before expiry.
    *
    * @param {TokenScope} scope - controls the permissions that the new key will have
-   * @param {string} expiresIn - How long the token is valid for in epoch timestamp.
+   * @param {string} expiresIn - How long the API key should be valid for in epoch timestamp.
    * @returns {Promise<GenerateApiKey.Response>} -
-   * {@link GenerateApiKey.Success} containing the api key, refresh token, origin and epoch timestamp when token expires.
-   * If the token never expires, then no refresh token will be returned and expires at timestamp will be infinite.
+   * {@link GenerateApiKey.Success} containing the API key, refresh token, origin and epoch timestamp when token expires.
+   * If the API key never expires, then no refresh token will be returned and expires at timestamp will be infinite.
    * {@link GenerateApiKey.Error} on failure.
    */
   public async generateApiKey(
@@ -50,12 +50,12 @@ export abstract class AbstractAuthClient implements IAuthClient {
 
   /**
    * Refreshes an API key.  Returns a new API key and refresh token, that will be able to be refreshed again in the future.
-   * The new API key will be valid for the same length of time as the original token, starting from the time of refresh.
+   * The new API key will be valid for the same length of time as the original key, starting from the time of refresh.
    * The original api key will still work until its expired.
    *
    * @param {string} refreshToken - Refresh token used to refresh the API key.
    * @returns {Promise<RefreshApiKey.Response>} -
-   * {@link RefreshApiKey.Success} containing the new auth token, refresh token, origin and epoch timestamp when token expires.
+   * {@link RefreshApiKey.Success} containing the new API key, refresh token, origin and epoch timestamp when the API key expires.
    * {@link RefreshApiKey.Error} on failure.
    */
   public async refreshApiKey(

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -2,7 +2,7 @@ import {InvalidArgumentError} from '../../errors';
 import jwtDecode from 'jwt-decode';
 import {isBase64} from './validators';
 import {decodeFromBase64} from './string';
-import {PredefinedScope} from '../../auth/tokens/token-scope';
+import {PredefinedScope} from '../../auth/tokens/permission-scope';
 
 export interface LegacyClaims {
   /**

--- a/packages/core/src/messages/responses/generate-api-key.ts
+++ b/packages/core/src/messages/responses/generate-api-key.ts
@@ -6,10 +6,17 @@ import {ExpiresAt} from '../../utils';
 export abstract class Response extends ResponseBase {}
 
 class _Success extends Response {
-  readonly authToken: string;
+  readonly apiKey: string;
   readonly refreshToken: string;
   readonly endpoint: string;
   readonly expiresAt: ExpiresAt;
+
+  /**
+   * @deprecated Use `apiKey` instead.
+   */
+  get authToken(): string {
+    return this.apiKey;
+  }
 
   constructor(
     apiKey: string,
@@ -18,7 +25,7 @@ class _Success extends Response {
     expiresAt: ExpiresAt
   ) {
     super();
-    this.authToken = encodeToBase64(
+    this.apiKey = encodeToBase64(
       JSON.stringify({endpoint: endpoint, api_key: apiKey})
     );
     this.refreshToken = refreshToken;

--- a/packages/core/src/messages/responses/refresh-api-key.ts
+++ b/packages/core/src/messages/responses/refresh-api-key.ts
@@ -6,10 +6,18 @@ import {ExpiresAt} from '../../utils';
 export abstract class Response extends ResponseBase {}
 
 class _Success extends Response {
-  readonly authToken: string;
+  readonly apiKey: string;
   readonly refreshToken: string;
   readonly endpoint: string;
   readonly expiresAt: ExpiresAt;
+
+  /**
+   * @deprecated Use `apiKey` instead.
+   * @returns {string}
+   */
+  get authToken(): string {
+    return this.apiKey;
+  }
 
   constructor(
     apiKey: string,
@@ -18,7 +26,7 @@ class _Success extends Response {
     expiresAt: ExpiresAt
   ) {
     super();
-    this.authToken = encodeToBase64(
+    this.apiKey = encodeToBase64(
       JSON.stringify({endpoint: endpoint, api_key: apiKey})
     );
     this.refreshToken = refreshToken;

--- a/packages/core/test/unit/auth/disposable-token-scope.test.ts
+++ b/packages/core/test/unit/auth/disposable-token-scope.test.ts
@@ -6,7 +6,7 @@ import {
   CacheRole,
   DisposableTokenScope,
   DisposableTokenScopes,
-  TokenScopes,
+  PermissionScopes,
   TopicRole,
 } from '../../../src';
 
@@ -247,51 +247,54 @@ describe('DisposableTokenScope', () => {
     });
   });
 
-  describe('should support assignment from TokenScope factory functions', () => {
+  describe('should support assignment from PermissionScopes factory functions', () => {
     it('cacheReadWrite', () => {
-      let scope: DisposableTokenScope = TokenScopes.cacheReadWrite('mycache');
+      let scope: DisposableTokenScope =
+        PermissionScopes.cacheReadWrite('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheReadWrite(AllCaches);
+      scope = PermissionScopes.cacheReadWrite(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheReadWrite({name: 'mycache'});
+      scope = PermissionScopes.cacheReadWrite({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: {name: 'mycache'}}],
       });
     });
     it('cacheReadOnly', () => {
-      let scope: DisposableTokenScope = TokenScopes.cacheReadOnly('mycache');
+      let scope: DisposableTokenScope =
+        PermissionScopes.cacheReadOnly('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheReadOnly(AllCaches);
+      scope = PermissionScopes.cacheReadOnly(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheReadOnly({name: 'mycache'});
+      scope = PermissionScopes.cacheReadOnly({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: {name: 'mycache'}}],
       });
     });
     it('cacheWriteOnly', () => {
-      let scope: DisposableTokenScope = TokenScopes.cacheWriteOnly('mycache');
+      let scope: DisposableTokenScope =
+        PermissionScopes.cacheWriteOnly('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheWriteOnly(AllCaches);
+      scope = PermissionScopes.cacheWriteOnly(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheWriteOnly({name: 'mycache'});
+      scope = PermissionScopes.cacheWriteOnly({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: {name: 'mycache'}}],
       });
     });
     it('topicSubscribeOnly', () => {
-      let scope: DisposableTokenScope = TokenScopes.topicSubscribeOnly(
+      let scope: DisposableTokenScope = PermissionScopes.topicSubscribeOnly(
         'mycache',
         'mytopic'
       );
@@ -300,13 +303,13 @@ describe('DisposableTokenScope', () => {
           {role: TopicRole.SubscribeOnly, cache: 'mycache', topic: 'mytopic'},
         ],
       });
-      scope = TokenScopes.topicSubscribeOnly(AllCaches, AllTopics);
+      scope = PermissionScopes.topicSubscribeOnly(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {role: TopicRole.SubscribeOnly, cache: AllCaches, topic: AllTopics},
         ],
       });
-      scope = TokenScopes.topicSubscribeOnly(
+      scope = PermissionScopes.topicSubscribeOnly(
         {name: 'mycache'},
         {name: 'mytopic'}
       );
@@ -321,7 +324,7 @@ describe('DisposableTokenScope', () => {
       });
     });
     it('topicPublishOnly', () => {
-      let scope: DisposableTokenScope = TokenScopes.topicPublishOnly(
+      let scope: DisposableTokenScope = PermissionScopes.topicPublishOnly(
         'mycache',
         'mytopic'
       );
@@ -330,13 +333,13 @@ describe('DisposableTokenScope', () => {
           {role: TopicRole.PublishOnly, cache: 'mycache', topic: 'mytopic'},
         ],
       });
-      scope = TokenScopes.topicPublishOnly(AllCaches, AllTopics);
+      scope = PermissionScopes.topicPublishOnly(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {role: TopicRole.PublishOnly, cache: AllCaches, topic: AllTopics},
         ],
       });
-      scope = TokenScopes.topicPublishOnly(
+      scope = PermissionScopes.topicPublishOnly(
         {name: 'mycache'},
         {name: 'mytopic'}
       );
@@ -351,7 +354,7 @@ describe('DisposableTokenScope', () => {
       });
     });
     it('topicPublishSubscribe', () => {
-      let scope: DisposableTokenScope = TokenScopes.topicPublishSubscribe(
+      let scope: DisposableTokenScope = PermissionScopes.topicPublishSubscribe(
         'mycache',
         'mytopic'
       );
@@ -364,7 +367,7 @@ describe('DisposableTokenScope', () => {
           },
         ],
       });
-      scope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
+      scope = PermissionScopes.topicPublishSubscribe(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {
@@ -374,7 +377,7 @@ describe('DisposableTokenScope', () => {
           },
         ],
       });
-      scope = TokenScopes.topicPublishSubscribe(
+      scope = PermissionScopes.topicPublishSubscribe(
         {name: 'mycache'},
         {name: 'mytopic'}
       );

--- a/packages/core/test/unit/auth/permission-scope.test.ts
+++ b/packages/core/test/unit/auth/permission-scope.test.ts
@@ -3,15 +3,15 @@ import {
   AllDataReadWrite,
   AllTopics,
   CacheRole,
-  TokenScope,
-  TokenScopes,
+  PermissionScope,
+  PermissionScopes,
   TopicRole,
 } from '../../../src';
 import {InternalSuperUserPermissions} from '../../../src/internal/utils';
 
-describe('TokenScope', () => {
+describe('PermissionScope', () => {
   it('should support assignment from AllDataReadWrite constant', () => {
-    const scope: TokenScope = AllDataReadWrite;
+    const scope: PermissionScope = AllDataReadWrite;
     expect(scope).toEqual({
       permissions: [
         {role: CacheRole.ReadWrite, cache: AllCaches},
@@ -21,13 +21,13 @@ describe('TokenScope', () => {
   });
 
   it('should support assignment from PredefinedScope constant', () => {
-    const scope: TokenScope = new InternalSuperUserPermissions();
+    const scope: PermissionScope = new InternalSuperUserPermissions();
     expect(scope).toEqual(new InternalSuperUserPermissions());
   });
 
   describe('should support assignment from Permissions literal', () => {
     it('using string for cache name in a CachePermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [{role: CacheRole.ReadWrite, cache: 'my-cache'}],
       };
       expect(scope).toEqual({
@@ -35,7 +35,7 @@ describe('TokenScope', () => {
       });
     });
     it('using CacheName selector literal for cache name in a CachePermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [{role: CacheRole.ReadWrite, cache: {name: 'my-cache'}}],
       };
       expect(scope).toEqual({
@@ -43,7 +43,7 @@ describe('TokenScope', () => {
       });
     });
     it('using `AllCaches` selector in a CachePermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [{role: CacheRole.ReadWrite, cache: AllCaches}],
       };
       expect(scope).toEqual({
@@ -51,7 +51,7 @@ describe('TokenScope', () => {
       });
     });
     it('using string for cache name and topic name in a TopicPermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {
             role: TopicRole.PublishSubscribe,
@@ -71,7 +71,7 @@ describe('TokenScope', () => {
       });
     });
     it('using CacheName selector literal for cache name in a TopicPermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {
             role: TopicRole.PublishSubscribe,
@@ -91,7 +91,7 @@ describe('TokenScope', () => {
       });
     });
     it('using `AllCaches` selector in a TopicPermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {
             role: TopicRole.PublishSubscribe,
@@ -111,7 +111,7 @@ describe('TokenScope', () => {
       });
     });
     it('using TopicName selector literal for topic name in a TopicPermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {
             role: TopicRole.PublishSubscribe,
@@ -131,7 +131,7 @@ describe('TokenScope', () => {
       });
     });
     it('using `AllTopics` selector in a TopicPermission', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {
             role: TopicRole.PublishSubscribe,
@@ -151,7 +151,7 @@ describe('TokenScope', () => {
       });
     });
     it('mixing cache and topic permissions', () => {
-      const scope: TokenScope = {
+      const scope: PermissionScope = {
         permissions: [
           {role: CacheRole.ReadWrite, cache: 'mycache'},
           {
@@ -186,51 +186,51 @@ describe('TokenScope', () => {
     });
   });
 
-  describe('should support assignment from TokenScope factory functions', () => {
+  describe('should support assignment from PermissionScope factory functions', () => {
     it('cacheReadWrite', () => {
-      let scope: TokenScope = TokenScopes.cacheReadWrite('mycache');
+      let scope: PermissionScope = PermissionScopes.cacheReadWrite('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheReadWrite(AllCaches);
+      scope = PermissionScopes.cacheReadWrite(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheReadWrite({name: 'mycache'});
+      scope = PermissionScopes.cacheReadWrite({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadWrite, cache: {name: 'mycache'}}],
       });
     });
     it('cacheReadOnly', () => {
-      let scope: TokenScope = TokenScopes.cacheReadOnly('mycache');
+      let scope: PermissionScope = PermissionScopes.cacheReadOnly('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheReadOnly(AllCaches);
+      scope = PermissionScopes.cacheReadOnly(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheReadOnly({name: 'mycache'});
+      scope = PermissionScopes.cacheReadOnly({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.ReadOnly, cache: {name: 'mycache'}}],
       });
     });
     it('cacheWriteOnly', () => {
-      let scope: TokenScope = TokenScopes.cacheWriteOnly('mycache');
+      let scope: PermissionScope = PermissionScopes.cacheWriteOnly('mycache');
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: 'mycache'}],
       });
-      scope = TokenScopes.cacheWriteOnly(AllCaches);
+      scope = PermissionScopes.cacheWriteOnly(AllCaches);
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: AllCaches}],
       });
-      scope = TokenScopes.cacheWriteOnly({name: 'mycache'});
+      scope = PermissionScopes.cacheWriteOnly({name: 'mycache'});
       expect(scope).toEqual({
         permissions: [{role: CacheRole.WriteOnly, cache: {name: 'mycache'}}],
       });
     });
     it('topicSubscribeOnly', () => {
-      let scope: TokenScope = TokenScopes.topicSubscribeOnly(
+      let scope: PermissionScope = PermissionScopes.topicSubscribeOnly(
         'mycache',
         'mytopic'
       );
@@ -239,13 +239,13 @@ describe('TokenScope', () => {
           {role: TopicRole.SubscribeOnly, cache: 'mycache', topic: 'mytopic'},
         ],
       });
-      scope = TokenScopes.topicSubscribeOnly(AllCaches, AllTopics);
+      scope = PermissionScopes.topicSubscribeOnly(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {role: TopicRole.SubscribeOnly, cache: AllCaches, topic: AllTopics},
         ],
       });
-      scope = TokenScopes.topicSubscribeOnly(
+      scope = PermissionScopes.topicSubscribeOnly(
         {name: 'mycache'},
         {name: 'mytopic'}
       );
@@ -260,7 +260,7 @@ describe('TokenScope', () => {
       });
     });
     it('topicPublishOnly', () => {
-      let scope: TokenScope = TokenScopes.topicPublishOnly(
+      let scope: PermissionScope = PermissionScopes.topicPublishOnly(
         'mycache',
         'mytopic'
       );
@@ -269,13 +269,13 @@ describe('TokenScope', () => {
           {role: TopicRole.PublishOnly, cache: 'mycache', topic: 'mytopic'},
         ],
       });
-      scope = TokenScopes.topicPublishOnly(AllCaches, AllTopics);
+      scope = PermissionScopes.topicPublishOnly(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {role: TopicRole.PublishOnly, cache: AllCaches, topic: AllTopics},
         ],
       });
-      scope = TokenScopes.topicPublishOnly(
+      scope = PermissionScopes.topicPublishOnly(
         {name: 'mycache'},
         {name: 'mytopic'}
       );
@@ -290,7 +290,7 @@ describe('TokenScope', () => {
       });
     });
     it('topicPublishSubscribe', () => {
-      let scope: TokenScope = TokenScopes.topicPublishSubscribe(
+      let scope: PermissionScope = PermissionScopes.topicPublishSubscribe(
         'mycache',
         'mytopic'
       );
@@ -303,7 +303,7 @@ describe('TokenScope', () => {
           },
         ],
       });
-      scope = TokenScopes.topicPublishSubscribe(AllCaches, AllTopics);
+      scope = PermissionScopes.topicPublishSubscribe(AllCaches, AllTopics);
       expect(scope).toEqual({
         permissions: [
           {
@@ -313,7 +313,7 @@ describe('TokenScope', () => {
           },
         ],
       });
-      scope = TokenScopes.topicPublishSubscribe(
+      scope = PermissionScopes.topicPublishSubscribe(
         {name: 'mycache'},
         {name: 'mytopic'}
       );


### PR DESCRIPTION
This commit renames `generateAuthToken` and `refreshAuthToken` to `generateApiKey` and `refreshApiKey` respectively. We leave the old names in place, deprecated, to preserve backward compatibility.