### PR TITLE
feat: support `apiKey` in CredentialProvider.fromString

### DIFF
--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -107,7 +107,15 @@ abstract class CredentialProviderBase implements CredentialProvider {
   }
 }
 
-export interface StringMomentoTokenProviderProps
+export interface StringMomentoApiKeyProviderProps
+  extends CredentialProviderProps {
+  /**
+   * apiKey the momento API key
+   */
+  apiKey: string;
+}
+
+export interface StringMomentoAuthTokenProviderProps
   extends CredentialProviderProps {
   /**
    * authToken the momento auth token
@@ -115,13 +123,17 @@ export interface StringMomentoTokenProviderProps
   authToken: string;
 }
 
+export type StringMomentoTokenProviderProps =
+  | StringMomentoApiKeyProviderProps
+  | StringMomentoAuthTokenProviderProps;
+
 /**
  * Reads and parses a momento auth token stored in a String
  * @export
  * @class StringMomentoTokenProvider
  */
 export class StringMomentoTokenProvider extends CredentialProviderBase {
-  private readonly authToken: string;
+  private readonly apiKey: string;
   private readonly allEndpoints: AllEndpoints;
   private readonly endpointsOverridden: boolean;
 
@@ -130,8 +142,16 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
    */
   constructor(props: StringMomentoTokenProviderProps) {
     super();
-    const decodedToken = decodeAuthToken(props.authToken);
-    this.authToken = decodedToken.authToken;
+    let key: string;
+    if ('authToken' in props) {
+      key = props.authToken;
+    } else if ('apiKey' in props) {
+      key = props.apiKey;
+    } else {
+      throw new Error('Missing required property: authToken or apiKey');
+    }
+    const decodedToken = decodeAuthToken(key);
+    this.apiKey = decodedToken.authToken;
     if (props.endpointOverrides === undefined) {
       this.endpointsOverridden = false;
       if (decodedToken.controlEndpoint === undefined) {
@@ -177,7 +197,7 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
   }
 
   getAuthToken(): string {
-    return this.authToken;
+    return this.apiKey;
   }
 
   getCacheEndpoint(): string {

--- a/packages/core/test/unit/auth/credential-provider.test.ts
+++ b/packages/core/test/unit/auth/credential-provider.test.ts
@@ -23,7 +23,7 @@ const testCacheEndpoint = 'cache-endpoint.not.a.domain';
 describe('StringMomentoTokenProvider', () => {
   it('parses a valid legacy token', () => {
     const authProvider = CredentialProvider.fromString({
-      authToken: fakeTestLegacyToken,
+      apiKey: fakeTestLegacyToken,
     });
     expect(authProvider.getAuthToken()).toEqual(fakeTestLegacyToken);
     expect(authProvider.getControlEndpoint()).toEqual(testControlEndpoint);
@@ -31,6 +31,19 @@ describe('StringMomentoTokenProvider', () => {
   });
 
   it('parses a valid v1 auth token', () => {
+    const authProvider = CredentialProvider.fromString({
+      apiKey: base64EncodedFakeV1AuthToken,
+    });
+    expect(authProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);
+    expect(authProvider.getControlEndpoint()).toEqual(
+      `control.${decodedV1Token.endpoint}`
+    );
+    expect(authProvider.getCacheEndpoint()).toEqual(
+      `cache.${decodedV1Token.endpoint}`
+    );
+  });
+
+  it('supports the old "authToken" option', () => {
     const authProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
     });
@@ -45,7 +58,7 @@ describe('StringMomentoTokenProvider', () => {
 
   it('supports overriding endpoints by specifying a base endpoint', () => {
     const legacyAuthProvider = CredentialProvider.fromString({
-      authToken: fakeTestLegacyToken,
+      apiKey: fakeTestLegacyToken,
       endpointOverrides: {
         baseEndpoint: 'base.foo',
       },
@@ -58,7 +71,7 @@ describe('StringMomentoTokenProvider', () => {
     expect(legacyAuthProvider.areEndpointsOverridden()).toEqual(true);
 
     const v1AuthProvider = CredentialProvider.fromString({
-      authToken: base64EncodedFakeV1AuthToken,
+      apiKey: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
         baseEndpoint: 'base.foo',
       },
@@ -73,7 +86,7 @@ describe('StringMomentoTokenProvider', () => {
 
   it('supports overriding all endpoints explicitly', () => {
     const legacyAuthProvider = CredentialProvider.fromString({
-      authToken: fakeTestLegacyToken,
+      apiKey: fakeTestLegacyToken,
       endpointOverrides: {
         controlEndpoint: 'control.foo',
         cacheEndpoint: 'cache.foo',
@@ -88,7 +101,7 @@ describe('StringMomentoTokenProvider', () => {
     expect(legacyAuthProvider.areEndpointsOverridden()).toEqual(true);
 
     const v1AuthProvider = CredentialProvider.fromString({
-      authToken: base64EncodedFakeV1AuthToken,
+      apiKey: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
         controlEndpoint: 'control.foo',
         cacheEndpoint: 'cache.foo',
@@ -106,7 +119,7 @@ describe('StringMomentoTokenProvider', () => {
 
   it('parses a session token with endpoint overrides', () => {
     const sessionTokenProvider = CredentialProvider.fromString({
-      authToken: fakeSessionToken,
+      apiKey: fakeSessionToken,
       endpointOverrides: {
         controlEndpoint: 'control.foo',
         cacheEndpoint: 'cache.foo',
@@ -125,7 +138,7 @@ describe('StringMomentoTokenProvider', () => {
   it('fails to parse a session token with no endpoint overrides', () => {
     expect(() =>
       CredentialProvider.fromString({
-        authToken: fakeSessionToken,
+        apiKey: fakeSessionToken,
       })
     ).toThrowError('unable to determine control endpoint');
   });


### PR DESCRIPTION
Prior to this commit the options for `CredentialProvider.fromString`
required users to specify an `authToken` option. This commit modifies
the options type so that it supports either `authToken` or `apiKey`.
