### PR TITLE
chore: disable dependabot and add a script that updates all example deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,106 +5,123 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/cache" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
 
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/lambda-examples/topics-microservice" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/lambda-examples/simple-get/lambda/simple-get" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/mongodb-examples/simple-read-aside" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/topics" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/load-gen" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/observability" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/access-control" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/aws" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/token-vending-machine/lambda/authorizer" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/nodejs/token-vending-machine/lambda/token-vending-machine" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/web/cache" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/web/nextjs-chat" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/web/vite-chat-app" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/examples/cloudflare-workers/web-sdk" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "@gomomento/*"
+########################################################################################################################
+#
+# NOTE: we have currently disabled dependabot because it doesn't work well with repos that have multiple projects in
+# them. The current setup was resulting in us having over a dozen PRs opened every time we did a release, and
+# each PR was running all of the CI tasks via github actions every time a new commit came in to main. This was consuming
+# all of our actions and preventing user-PRs from running through CI in a timely fashion.
+#
+# When this ticket is resolved, hopefully we can re-enable dependabot:
+#
+# https://github.com/dependabot/dependabot-core/issues/2178
+#
+# In the meantime we will rely on `scripts/update-all-examples-dependencies.sh` to update dependencies.
+#
+########################################################################################################################
+#
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/cache" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/lambda-examples/topics-microservice" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/lambda-examples/simple-get/lambda/simple-get" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/mongodb-examples/simple-read-aside" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/topics" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/load-gen" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/observability" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/access-control" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/aws" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/token-vending-machine/lambda/authorizer" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/nodejs/token-vending-machine/lambda/token-vending-machine" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/web/cache" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/web/nextjs-chat" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/web/vite-chat-app" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"
+#
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/examples/cloudflare-workers/web-sdk" # Location of package manifests
+#    schedule:
+#      interval: "daily"
+#    allow:
+#      - dependency-name: "@gomomento/*"

--- a/examples/cloudflare-workers/web-sdk/package-lock.json
+++ b/examples/cloudflare-workers/web-sdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@gomomento/sdk-core": "^1.38.0",
-        "@gomomento/sdk-web": "^1.38.0",
+        "@gomomento/sdk-web": "^1.39.1",
         "xhr4sw": "^0.0.5"
       },
       "devDependencies": {
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -532,12 +532,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.38.0.tgz",
-      "integrity": "sha512-vpYJ7BgSF6eDDwM+g7nhz5Z5mtK3pP4oqXg7ipgAURcvglyyF3R8Mh9qYQLkWGc2I7QcRzYENDGoXwNVkte0nw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.39.1.tgz",
+      "integrity": "sha512-bOKf+w/8HCJWzkMgYj4buFOMT6Wkl+KOUwchNDE7lmfRLePpLwrOUGJgHTnL1QXHZ9iJCy6NnCYXCbYoXPFjBA==",
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/cloudflare-workers/web-sdk/package.json
+++ b/examples/cloudflare-workers/web-sdk/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "start": "wrangler dev",
-		"build": "tsc"
+    "build": "tsc"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@gomomento/sdk-core": "^1.38.0",
-    "@gomomento/sdk-web": "^1.38.0",
+    "@gomomento/sdk-web": "^1.39.1",
     "xhr4sw": "^0.0.5"
   }
 }

--- a/examples/nodejs/access-control/package-lock.json
+++ b/examples/nodejs/access-control/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.38.0"
+        "@gomomento/sdk": "^1.39.1"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -64,12 +64,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -2882,12 +2882,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -2895,9 +2895,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/access-control/package.json
+++ b/examples/nodejs/access-control/package.json
@@ -26,6 +26,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.38.0"
+    "@gomomento/sdk": "^1.39.1"
   }
 }

--- a/examples/nodejs/aws/package-lock.json
+++ b/examples/nodejs/aws/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.370.0",
-        "@gomomento/sdk": "^1.38.0"
+        "@gomomento/sdk": "^1.39.1"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -25,116 +25,9 @@
         "typescript": "4.4.3"
       }
     },
-    "../../../packages/client-sdk-nodejs": {
-      "name": "@gomomento/sdk",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gomomento/generated-types": "0.68.0",
-        "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.8.17",
-        "google-protobuf": "3.21.2",
-        "jwt-decode": "3.1.2"
-      },
-      "devDependencies": {
-        "@gomomento/common-integration-tests": "file:../common-integration-tests",
-        "@types/google-protobuf": "3.15.6",
-        "@types/jest": "^27.0.2",
-        "@types/node": "14.18.3",
-        "@types/uuid": "^8.3.1",
-        "@typescript-eslint/eslint-plugin": "^5.59.9",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-config-standard": "^16.0.3",
-        "eslint-plugin-import": "^2.25.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "jest": "^29",
-        "jest-extended": "^3.2.3",
-        "prettier": "^2.4.1",
-        "ts-jest": "^29",
-        "ts-node": "^10.3.0",
-        "typescript": "^4.4.3",
-        "uuid": "8.3.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../../packages/common-integration-tests": {
-      "name": "@gomomento/common-integration-tests",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gomomento/sdk-core": "file:../core",
-        "uuid": "9.0.0"
-      },
-      "devDependencies": {
-        "@types/google-protobuf": "^3.15.5",
-        "@types/jest": "^27.0.2",
-        "@types/node": "14.18.3",
-        "@types/uuid": "9.0.1",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-config-standard": "^16.0.3",
-        "eslint-plugin-import": "^2.25.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "jest": "^29",
-        "jest-extended": "^3.2.3",
-        "prettier": "^2.4.1",
-        "ts-jest": "^29",
-        "ts-node": "^10.3.0",
-        "typescript": "^4.4.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "../../../packages/core": {
-      "name": "@gomomento/sdk-core",
-      "version": "0.0.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "jwt-decode": "3.1.2"
-      },
-      "devDependencies": {
-        "@types/google-protobuf": "^3.15.5",
-        "@types/jest": "^27.0.2",
-        "@types/node": "14.18.3",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-config-standard": "^16.0.3",
-        "eslint-plugin-import": "^2.25.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "jest": "^29",
-        "jest-extended": "^3.2.3",
-        "prettier": "^2.4.1",
-        "ts-jest": "^29",
-        "ts-node": "^10.3.0",
-        "typescript": "^4.4.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -143,16 +36,14 @@
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -166,8 +57,7 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -176,16 +66,14 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -194,8 +82,7 @@
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.370.0.tgz",
-      "integrity": "sha512-1o1mpWbI1RyzCQ4cVpHQJnm6PziAJ+ptLt4p+wlN74Z330/nnE0JkK3t9l3CxhPqCIW8VjGbTCno5IzwAXnjPw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -241,13 +128,11 @@
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
-      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -289,8 +174,7 @@
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
-      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -332,18 +216,15 @@
     },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
-      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -389,13 +270,11 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
-      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -408,13 +287,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
-      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.370.0",
         "@aws-sdk/credential-provider-process": "3.370.0",
@@ -433,13 +310,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
-      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.370.0",
         "@aws-sdk/credential-provider-ini": "3.370.0",
@@ -459,13 +334,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
-      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -479,13 +352,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
-      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sso": "3.370.0",
         "@aws-sdk/token-providers": "3.370.0",
@@ -501,13 +372,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
-      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -520,13 +389,11 @@
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
-      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/protocol-http": "^1.1.0",
@@ -539,13 +406,11 @@
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
-      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/types": "^1.1.0",
@@ -557,13 +422,11 @@
     },
     "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
-      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/protocol-http": "^1.1.0",
@@ -576,13 +439,11 @@
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
-      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.370.0",
         "@aws-sdk/types": "3.370.0",
@@ -595,13 +456,11 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
-      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -617,13 +476,11 @@
     },
     "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
-      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@aws-sdk/util-endpoints": "3.370.0",
@@ -637,13 +494,11 @@
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
-      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.370.0",
         "@aws-sdk/types": "3.370.0",
@@ -658,13 +513,11 @@
     },
     "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
@@ -675,13 +528,11 @@
     },
     "node_modules/@aws-sdk/types/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
-      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "tslib": "^2.5.0"
@@ -692,13 +543,11 @@
     },
     "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -708,13 +557,11 @@
     },
     "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
-      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/types": "^1.1.0",
@@ -724,13 +571,11 @@
     },
     "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
-      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/node-config-provider": "^1.0.1",
@@ -751,21 +596,18 @@
     },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -791,20 +633,18 @@
     },
     "node_modules/@gomomento/generated-types": {
       "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.77.0.tgz",
-      "integrity": "sha512-b6ZIoB2N3efhLOUoBxbt+qmE46lNCJErxF2A+g5RcDVgQrx143HcIMXpTghnEA4p6mmVOCQWYGsXVp0PHWz75Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -815,9 +655,8 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -828,8 +667,7 @@
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -840,8 +678,7 @@
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -907,28 +744,23 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -936,33 +768,27 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
-      "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -973,13 +799,11 @@
     },
     "node_modules/@smithy/abort-controller/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/config-resolver": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
-      "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-config-provider": "^1.0.2",
@@ -992,13 +816,11 @@
     },
     "node_modules/@smithy/config-resolver/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
-      "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^1.0.2",
         "@smithy/property-provider": "^1.0.2",
@@ -1012,13 +834,11 @@
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/eventstream-codec": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
-      "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.1",
@@ -1028,13 +848,11 @@
     },
     "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
-      "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/querystring-builder": "^1.0.2",
@@ -1045,13 +863,11 @@
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/hash-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
-      "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-buffer-from": "^1.0.2",
@@ -1064,13 +880,11 @@
     },
     "node_modules/@smithy/hash-node/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/invalid-dependency": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
-      "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1078,13 +892,11 @@
     },
     "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1094,13 +906,11 @@
     },
     "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/middleware-content-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
-      "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/types": "^1.1.1",
@@ -1112,13 +922,11 @@
     },
     "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
-      "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -1132,13 +940,11 @@
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/middleware-retry": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
-      "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/service-error-classification": "^1.0.3",
@@ -1154,13 +960,11 @@
     },
     "node_modules/@smithy/middleware-retry/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/middleware-serde": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
-      "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1171,13 +975,11 @@
     },
     "node_modules/@smithy/middleware-serde/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/middleware-stack": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
-      "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1187,13 +989,11 @@
     },
     "node_modules/@smithy/middleware-stack/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
-      "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/shared-ini-file-loader": "^1.0.2",
@@ -1206,13 +1006,11 @@
     },
     "node_modules/@smithy/node-config-provider/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
-      "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^1.0.2",
         "@smithy/protocol-http": "^1.1.1",
@@ -1226,13 +1024,11 @@
     },
     "node_modules/@smithy/node-http-handler/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/property-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
-      "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1243,13 +1039,11 @@
     },
     "node_modules/@smithy/property-provider/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/protocol-http": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
-      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1260,13 +1054,11 @@
     },
     "node_modules/@smithy/protocol-http/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
-      "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-uri-escape": "^1.0.2",
@@ -1278,13 +1070,11 @@
     },
     "node_modules/@smithy/querystring-builder/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/querystring-parser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
-      "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1295,21 +1085,18 @@
     },
     "node_modules/@smithy/querystring-parser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
-      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
-      "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
@@ -1320,13 +1107,11 @@
     },
     "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/signature-v4": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
-      "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/eventstream-codec": "^1.0.2",
         "@smithy/is-array-buffer": "^1.0.2",
@@ -1343,13 +1128,11 @@
     },
     "node_modules/@smithy/signature-v4/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/smithy-client": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
-      "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-stack": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -1362,13 +1145,11 @@
     },
     "node_modules/@smithy/smithy-client/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/types": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
-      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1378,13 +1159,11 @@
     },
     "node_modules/@smithy/types/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/url-parser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
-      "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -1393,13 +1172,11 @@
     },
     "node_modules/@smithy/url-parser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-base64": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
-      "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
@@ -1410,26 +1187,22 @@
     },
     "node_modules/@smithy/util-base64/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
-      "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-body-length-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
-      "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1439,13 +1212,11 @@
     },
     "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
-      "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^1.0.2",
         "tslib": "^2.5.0"
@@ -1456,13 +1227,11 @@
     },
     "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-config-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
-      "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1472,13 +1241,11 @@
     },
     "node_modules/@smithy/util-config-provider/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
-      "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -1491,13 +1258,11 @@
     },
     "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
-      "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^1.0.2",
         "@smithy/credential-provider-imds": "^1.0.2",
@@ -1512,13 +1277,11 @@
     },
     "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
-      "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1528,13 +1291,11 @@
     },
     "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-middleware": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
-      "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1544,13 +1305,11 @@
     },
     "node_modules/@smithy/util-middleware/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-retry": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
-      "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
@@ -1561,13 +1320,11 @@
     },
     "node_modules/@smithy/util-retry/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-stream": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
-      "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^1.0.2",
         "@smithy/node-http-handler": "^1.0.3",
@@ -1584,13 +1341,11 @@
     },
     "node_modules/@smithy/util-stream/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
-      "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1600,13 +1355,11 @@
     },
     "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@smithy/util-utf8": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
-      "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
@@ -1617,13 +1370,11 @@
     },
     "node_modules/@smithy/util-utf8/node_modules/tslib": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "license": "0BSD"
     },
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -2057,8 +1808,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -2072,12 +1821,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2101,8 +1850,6 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -2117,6 +1864,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2159,8 +1907,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2262,8 +2009,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.21.2",
@@ -2351,8 +2097,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2820,8 +2565,6 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "funding": [
         {
           "type": "paypal",
@@ -2832,6 +2575,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -2936,8 +2680,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3050,8 +2793,7 @@
     },
     "node_modules/google-protobuf": {
       "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -3140,8 +2882,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -3155,7 +2895,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -3300,8 +3041,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3472,8 +3212,7 @@
     },
     "node_modules/jwt-decode": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3489,8 +3228,7 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3499,8 +3237,7 @@
     },
     "node_modules/long": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3721,9 +3458,8 @@
     },
     "node_modules/protobufjs": {
       "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3798,8 +3534,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3942,8 +3677,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4026,8 +3760,7 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -4167,8 +3900,7 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4236,8 +3968,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4257,8 +3988,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -4270,8 +4000,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4287,8 +4016,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4297,8 +4025,6 @@
   "dependencies": {
     "@aws-crypto/crc32": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -4307,16 +4033,12 @@
     },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "requires": {
         "tslib": "^1.11.1"
       }
     },
     "@aws-crypto/sha256-browser": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
@@ -4330,8 +4052,6 @@
     },
     "@aws-crypto/sha256-js": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
@@ -4340,16 +4060,12 @@
     },
     "@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "requires": {
         "tslib": "^1.11.1"
       }
     },
     "@aws-crypto/util": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "requires": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -4358,8 +4074,6 @@
     },
     "@aws-sdk/client-secrets-manager": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.370.0.tgz",
-      "integrity": "sha512-1o1mpWbI1RyzCQ4cVpHQJnm6PziAJ+ptLt4p+wlN74Z330/nnE0JkK3t9l3CxhPqCIW8VjGbTCno5IzwAXnjPw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -4401,16 +4115,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/client-sso": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
-      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -4448,16 +4158,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/client-sso-oidc": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
-      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -4495,16 +4201,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/client-sts": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
-      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -4546,16 +4248,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-env": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
-      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -4564,16 +4262,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-ini": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
-      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.370.0",
         "@aws-sdk/credential-provider-process": "3.370.0",
@@ -4588,16 +4282,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-node": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
-      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.370.0",
         "@aws-sdk/credential-provider-ini": "3.370.0",
@@ -4613,16 +4303,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-process": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
-      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -4632,16 +4318,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-sso": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
-      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
       "requires": {
         "@aws-sdk/client-sso": "3.370.0",
         "@aws-sdk/token-providers": "3.370.0",
@@ -4653,16 +4335,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
-      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -4671,16 +4349,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-host-header": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
-      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/protocol-http": "^1.1.0",
@@ -4689,16 +4363,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-logger": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
-      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/types": "^1.1.0",
@@ -4706,16 +4376,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
-      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/protocol-http": "^1.1.0",
@@ -4724,16 +4390,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
-      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
       "requires": {
         "@aws-sdk/middleware-signing": "3.370.0",
         "@aws-sdk/types": "3.370.0",
@@ -4742,16 +4404,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-signing": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
-      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/property-provider": "^1.0.1",
@@ -4763,16 +4421,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/middleware-user-agent": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
-      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@aws-sdk/util-endpoints": "3.370.0",
@@ -4782,16 +4436,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/token-providers": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
-      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
       "requires": {
         "@aws-sdk/client-sso-oidc": "3.370.0",
         "@aws-sdk/types": "3.370.0",
@@ -4802,63 +4452,47 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/types": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
       "requires": {
         "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/util-endpoints": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
-      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/util-locate-window": {
       "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/util-user-agent-browser": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
-      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/types": "^1.1.0",
@@ -4867,16 +4501,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/util-user-agent-node": {
       "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
-      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
       "requires": {
         "@aws-sdk/types": "3.370.0",
         "@smithy/node-config-provider": "^1.0.1",
@@ -4885,24 +4515,18 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "requires": {
         "tslib": "^2.3.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
@@ -4923,20 +4547,16 @@
     },
     "@gomomento/generated-types": {
       "version": "0.77.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.77.0.tgz",
-      "integrity": "sha512-b6ZIoB2N3efhLOUoBxbt+qmE46lNCJErxF2A+g5RcDVgQrx143HcIMXpTghnEA4p6mmVOCQWYGsXVp0PHWz75Q==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       }
     },
     "@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -4944,9 +4564,7 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -4954,8 +4572,6 @@
     },
     "@grpc/grpc-js": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -4963,8 +4579,6 @@
     },
     "@grpc/proto-loader": {
       "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.9.tgz",
-      "integrity": "sha512-YJsOehVXzgurc+lLAxYnlSMc1p/Gu6VAvnfx0ATi2nzvr0YZcjhmZDeY8SeAKv1M7zE3aEJH0Xo9mK1iZ8GYoQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -5006,79 +4620,53 @@
       }
     },
     "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "version": "1.1.2"
     },
     "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "version": "1.1.2"
     },
     "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "version": "2.0.4"
     },
     "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "version": "1.1.0"
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
       }
     },
     "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "version": "1.0.2"
     },
     "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "version": "1.1.0"
     },
     "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "version": "1.1.2"
     },
     "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "version": "1.1.0"
     },
     "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "version": "1.1.0"
     },
     "@smithy/abort-controller": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.0.2.tgz",
-      "integrity": "sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/config-resolver": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.0.2.tgz",
-      "integrity": "sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-config-provider": "^1.0.2",
@@ -5087,16 +4675,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/credential-provider-imds": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz",
-      "integrity": "sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==",
       "requires": {
         "@smithy/node-config-provider": "^1.0.2",
         "@smithy/property-provider": "^1.0.2",
@@ -5106,16 +4690,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/eventstream-codec": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz",
-      "integrity": "sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^1.1.1",
@@ -5124,16 +4704,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/fetch-http-handler": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz",
-      "integrity": "sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==",
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/querystring-builder": "^1.0.2",
@@ -5143,16 +4719,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/hash-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.0.2.tgz",
-      "integrity": "sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-buffer-from": "^1.0.2",
@@ -5161,47 +4733,35 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/invalid-dependency": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz",
-      "integrity": "sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/is-array-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/middleware-content-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz",
-      "integrity": "sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==",
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/types": "^1.1.1",
@@ -5209,16 +4769,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/middleware-endpoint": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz",
-      "integrity": "sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==",
       "requires": {
         "@smithy/middleware-serde": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -5228,16 +4784,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/middleware-retry": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz",
-      "integrity": "sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==",
       "requires": {
         "@smithy/protocol-http": "^1.1.1",
         "@smithy/service-error-classification": "^1.0.3",
@@ -5249,47 +4801,35 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/middleware-serde": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz",
-      "integrity": "sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/middleware-stack": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz",
-      "integrity": "sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/node-config-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz",
-      "integrity": "sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==",
       "requires": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/shared-ini-file-loader": "^1.0.2",
@@ -5298,16 +4838,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/node-http-handler": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz",
-      "integrity": "sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==",
       "requires": {
         "@smithy/abort-controller": "^1.0.2",
         "@smithy/protocol-http": "^1.1.1",
@@ -5317,48 +4853,36 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/property-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.0.2.tgz",
-      "integrity": "sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/protocol-http": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
-      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/querystring-builder": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz",
-      "integrity": "sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "@smithy/util-uri-escape": "^1.0.2",
@@ -5366,53 +4890,39 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/querystring-parser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz",
-      "integrity": "sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/service-error-classification": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz",
-      "integrity": "sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA=="
+      "version": "1.0.3"
     },
     "@smithy/shared-ini-file-loader": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz",
-      "integrity": "sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==",
       "requires": {
         "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/signature-v4": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.0.2.tgz",
-      "integrity": "sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==",
       "requires": {
         "@smithy/eventstream-codec": "^1.0.2",
         "@smithy/is-array-buffer": "^1.0.2",
@@ -5425,16 +4935,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/smithy-client": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.0.4.tgz",
-      "integrity": "sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==",
       "requires": {
         "@smithy/middleware-stack": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -5443,31 +4949,23 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/types": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
-      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/url-parser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.0.2.tgz",
-      "integrity": "sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==",
       "requires": {
         "@smithy/querystring-parser": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -5475,93 +4973,69 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-base64": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.0.2.tgz",
-      "integrity": "sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==",
       "requires": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-body-length-browser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz",
-      "integrity": "sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-body-length-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz",
-      "integrity": "sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-buffer-from": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz",
-      "integrity": "sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==",
       "requires": {
         "@smithy/is-array-buffer": "^1.0.2",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-config-provider": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz",
-      "integrity": "sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-defaults-mode-browser": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz",
-      "integrity": "sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==",
       "requires": {
         "@smithy/property-provider": "^1.0.2",
         "@smithy/types": "^1.1.1",
@@ -5570,16 +5044,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-defaults-mode-node": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz",
-      "integrity": "sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==",
       "requires": {
         "@smithy/config-resolver": "^1.0.2",
         "@smithy/credential-provider-imds": "^1.0.2",
@@ -5590,62 +5060,46 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-hex-encoding": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz",
-      "integrity": "sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-middleware": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.0.2.tgz",
-      "integrity": "sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-retry": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.0.4.tgz",
-      "integrity": "sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==",
       "requires": {
         "@smithy/service-error-classification": "^1.0.3",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-stream": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.0.2.tgz",
-      "integrity": "sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==",
       "requires": {
         "@smithy/fetch-http-handler": "^1.0.2",
         "@smithy/node-http-handler": "^1.0.3",
@@ -5658,47 +5112,35 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-uri-escape": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz",
-      "integrity": "sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==",
       "requires": {
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@smithy/util-utf8": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.0.2.tgz",
-      "integrity": "sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==",
       "requires": {
         "@smithy/util-buffer-from": "^1.0.2",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+          "version": "2.6.0"
         }
       }
     },
     "@types/google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "version": "3.15.6"
     },
     "@types/json-schema": {
       "version": "7.0.12",
@@ -5923,14 +5365,10 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "version": "1.5.1"
     },
     "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "version": "2.11.0"
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5949,8 +5387,6 @@
     },
     "buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -5978,8 +5414,6 @@
     },
     "cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -6042,9 +5476,7 @@
       }
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "8.0.0"
     },
     "es-abstract": {
       "version": "1.21.2",
@@ -6112,9 +5544,7 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "version": "3.1.1"
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -6416,8 +5846,6 @@
     },
     "fast-xml-parser": {
       "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -6489,9 +5917,7 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "version": "2.0.5"
     },
     "get-intrinsic": {
       "version": "1.2.1",
@@ -6557,9 +5983,7 @@
       }
     },
     "google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "version": "3.21.2"
     },
     "gopd": {
       "version": "1.0.1",
@@ -6606,9 +6030,7 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "version": "1.2.1"
     },
     "ignore": {
       "version": "5.2.4",
@@ -6694,9 +6116,7 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "version": "3.0.0"
     },
     "is-glob": {
       "version": "4.0.3",
@@ -6794,9 +6214,7 @@
       }
     },
     "jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "3.1.2"
     },
     "levn": {
       "version": "0.4.1",
@@ -6807,18 +6225,14 @@
       }
     },
     "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+      "version": "4.3.0"
     },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
     },
     "long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.2.3"
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -6948,8 +6362,6 @@
     },
     "protobufjs": {
       "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6987,9 +6399,7 @@
       "dev": true
     },
     "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+      "version": "2.1.1"
     },
     "resolve": {
       "version": "1.22.2",
@@ -7064,8 +6474,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7114,9 +6522,7 @@
       "dev": true
     },
     "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "version": "1.0.5"
     },
     "supports-color": {
       "version": "7.2.0",
@@ -7202,9 +6608,7 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "8.3.2"
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -7246,8 +6650,6 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7259,9 +6661,7 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "version": "5.0.8"
     },
     "yallist": {
       "version": "4.0.0",
@@ -7269,8 +6669,6 @@
     },
     "yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -7282,9 +6680,7 @@
       }
     },
     "yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+      "version": "21.1.1"
     }
   }
 }

--- a/examples/nodejs/aws/package.json
+++ b/examples/nodejs/aws/package.json
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.370.0",
-    "@gomomento/sdk": "^1.38.0"
+    "@gomomento/sdk": "^1.39.1"
   }
 }

--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.37.0"
+        "@gomomento/sdk": "^1.39.1"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -162,12 +162,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -2984,12 +2984,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -2997,9 +2997,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -30,6 +30,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.37.0"
+    "@gomomento/sdk": "^1.39.1"
   }
 }

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "^1.38.0",
+        "@gomomento/sdk": "^1.39.1",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1069,12 +1069,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -5331,12 +5331,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -5344,9 +5344,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
+++ b/examples/nodejs/lambda-examples/simple-get/lambda/simple-get/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "^1.38.0",
+    "@gomomento/sdk": "^1.39.1",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.352.0",
         "@aws-sdk/client-secrets-manager": "^3.352.0",
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "aws-cdk-lib": "^2.85.0",
         "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
@@ -666,12 +666,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3175,12 +3175,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3188,9 +3188,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/lambda-examples/topics-microservice/package.json
+++ b/examples/nodejs/lambda-examples/topics-microservice/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.352.0",
     "@aws-sdk/client-secrets-manager": "^3.352.0",
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "aws-cdk-lib": "^2.85.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",

--- a/examples/nodejs/load-gen/package-lock.json
+++ b/examples/nodejs/load-gen/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "hdr-histogram-js": "3.0.0"
       },
       "devDependencies": {
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3120,12 +3120,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3133,9 +3133,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/load-gen/package.json
+++ b/examples/nodejs/load-gen/package.json
@@ -27,7 +27,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "hdr-histogram-js": "3.0.0"
   }
 }

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.369.0",
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "mongodb": "^5.5.0"
       },
       "devDependencies": {
@@ -1258,12 +1258,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -8131,12 +8131,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -8144,9 +8144,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/mongodb-examples/simple-read-aside/package.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.369.0",
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "mongodb": "^5.5.0"
   },
   "devDependencies": {

--- a/examples/nodejs/observability/package-lock.json
+++ b/examples/nodejs/observability/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "@opentelemetry/api": "1.4.1",
         "@opentelemetry/exporter-prometheus": "0.39.1",
         "@opentelemetry/exporter-zipkin": "1.13.0",
@@ -80,12 +80,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3769,12 +3769,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3782,9 +3782,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/observability/package.json
+++ b/examples/nodejs/observability/package.json
@@ -29,7 +29,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "@opentelemetry/api": "1.4.1",
     "@opentelemetry/exporter-prometheus": "0.39.1",
     "@opentelemetry/exporter-zipkin": "1.13.0",

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1068,12 +1068,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.352.0",
-        "@gomomento/sdk": "^1.37.0",
+        "@gomomento/sdk": "^1.39.1",
         "aws-lambda": "1.0.7"
       },
       "devDependencies": {
@@ -1068,12 +1068,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.352.0",
-    "@gomomento/sdk": "^1.37.0",
+    "@gomomento/sdk": "^1.39.1",
     "aws-lambda": "1.0.7"
   }
 }

--- a/examples/nodejs/topics/package-lock.json
+++ b/examples/nodejs/topics/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.38.0"
+        "@gomomento/sdk": "^1.39.1"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -57,12 +57,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3091,12 +3091,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.38.0.tgz",
-      "integrity": "sha512-8FFNgVRIvIL2KTvn5YE2zJ/Hlp5c9+gkKL/YJag8UTTiqtwnq9VeWU/PcrTJw5vxXZ4TvUl18UaGGuk3jghefA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "requires": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3104,9 +3104,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/topics/package.json
+++ b/examples/nodejs/topics/package.json
@@ -27,6 +27,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.38.0"
+    "@gomomento/sdk": "^1.39.1"
   }
 }

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "1.26.2",
+        "@gomomento/sdk": "^1.26.2",
         "jsdom": "22.1.0"
       },
       "devDependencies": {

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "1.26.2",
+    "@gomomento/sdk": "^1.26.2",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/cache/package-lock.json
+++ b/examples/web/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.38.0",
+        "@gomomento/sdk-web": "^1.39.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -94,12 +94,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.38.0.tgz",
-      "integrity": "sha512-vpYJ7BgSF6eDDwM+g7nhz5Z5mtK3pP4oqXg7ipgAURcvglyyF3R8Mh9qYQLkWGc2I7QcRzYENDGoXwNVkte0nw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.39.1.tgz",
+      "integrity": "sha512-bOKf+w/8HCJWzkMgYj4buFOMT6Wkl+KOUwchNDE7lmfRLePpLwrOUGJgHTnL1QXHZ9iJCy6NnCYXCbYoXPFjBA==",
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -3216,21 +3216,21 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.38.0.tgz",
-      "integrity": "sha512-vpYJ7BgSF6eDDwM+g7nhz5Z5mtK3pP4oqXg7ipgAURcvglyyF3R8Mh9qYQLkWGc2I7QcRzYENDGoXwNVkte0nw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.39.1.tgz",
+      "integrity": "sha512-bOKf+w/8HCJWzkMgYj4buFOMT6Wkl+KOUwchNDE7lmfRLePpLwrOUGJgHTnL1QXHZ9iJCy6NnCYXCbYoXPFjBA==",
       "requires": {
         "@gomomento/generated-types-webtext": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/web/cache/package.json
+++ b/examples/web/cache/package.json
@@ -29,7 +29,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.38.0",
+    "@gomomento/sdk-web": "^1.39.1",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/nextjs-chat/package-lock.json
+++ b/examples/web/nextjs-chat/package-lock.json
@@ -8,8 +8,8 @@
       "name": "momento-nextjs-chat",
       "version": "0.1.0",
       "dependencies": {
-        "@gomomento/sdk": "^1.37.0",
-        "@gomomento/sdk-web": "^1.38.0",
+        "@gomomento/sdk": "^1.39.1",
+        "@gomomento/sdk-web": "^1.39.1",
         "autoprefixer": "10.4.14",
         "next": "13.4.8",
         "next-auth": "^4.22.3",
@@ -143,12 +143,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.37.0.tgz",
-      "integrity": "sha512-QgOewUjgMcvaqFi89i4I8QUp6cZD2Fc85X8MKIbW4GEbzc8bS2Yg46xz9NHNk61cU+5I3yx6k1mkGKepoPYuKw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.39.1.tgz",
+      "integrity": "sha512-jLr6VD6iIkJhhiG+wNZRs3/zpUZWhOm9XPrpGEGleyUyW20hwqwOaB7bCycV+8QaF64AnQBtxWoYjJ3NsyNc9Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.77.0",
-        "@gomomento/sdk-core": "1.37.0",
+        "@gomomento/sdk-core": "1.39.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.37.0.tgz",
-      "integrity": "sha512-UwtiSx/xYXpiJJcVUJwWKtSKhvT59gKvDUR4rbGeZviORfT6tXgtdThFtTBhAtUYhEjCLyq8XjlOhhVj/XwAjQ==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -171,26 +171,14 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.38.0.tgz",
-      "integrity": "sha512-vpYJ7BgSF6eDDwM+g7nhz5Z5mtK3pP4oqXg7ipgAURcvglyyF3R8Mh9qYQLkWGc2I7QcRzYENDGoXwNVkte0nw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.39.1.tgz",
+      "integrity": "sha512-bOKf+w/8HCJWzkMgYj4buFOMT6Wkl+KOUwchNDE7lmfRLePpLwrOUGJgHTnL1QXHZ9iJCy6NnCYXCbYoXPFjBA==",
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
-        "jwt-decode": "3.1.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@gomomento/sdk-web/node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
-      "dependencies": {
-        "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
       },
       "engines": {

--- a/examples/web/nextjs-chat/package.json
+++ b/examples/web/nextjs-chat/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.37.0",
-    "@gomomento/sdk-web": "^1.38.0",
+    "@gomomento/sdk": "^1.39.1",
+    "@gomomento/sdk-web": "^1.39.1",
     "autoprefixer": "10.4.14",
     "next": "13.4.8",
     "next-auth": "^4.22.3",

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "1.26.2",
+        "@gomomento/sdk-web": "^1.26.2",
         "jsdom": "22.1.0"
       },
       "devDependencies": {

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "1.26.2",
+    "@gomomento/sdk-web": "^1.26.2",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vite-chat-app/package-lock.json
+++ b/examples/web/vite-chat-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.378.0",
-        "@gomomento/sdk-web": "^1.38.0",
+        "@gomomento/sdk-web": "^1.39.1",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.38.0.tgz",
-      "integrity": "sha512-kmrIxIUsiYt2Egj9UlonmMz0frl8dc1PaVpP4bYPRYE2k0hW3eO/7UFq7wzJVVCchydM41UNiaaaMkM9IZOQWA==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.39.1.tgz",
+      "integrity": "sha512-+xYvFnqS4MA+lJFQcmMyTFXTr1brlAxY6g6o2cFzyHoyXDpK1m0Ss7NXHVyX2oDcn8Ptpmu68L/yLqdiVsquoA==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -1492,12 +1492,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.38.0.tgz",
-      "integrity": "sha512-vpYJ7BgSF6eDDwM+g7nhz5Z5mtK3pP4oqXg7ipgAURcvglyyF3R8Mh9qYQLkWGc2I7QcRzYENDGoXwNVkte0nw==",
+      "version": "1.39.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.39.1.tgz",
+      "integrity": "sha512-bOKf+w/8HCJWzkMgYj4buFOMT6Wkl+KOUwchNDE7lmfRLePpLwrOUGJgHTnL1QXHZ9iJCy6NnCYXCbYoXPFjBA==",
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.77.0",
-        "@gomomento/sdk-core": "1.38.0",
+        "@gomomento/sdk-core": "1.39.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/web/vite-chat-app/package.json
+++ b/examples/web/vite-chat-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.378.0",
-    "@gomomento/sdk-web": "^1.38.0",
+    "@gomomento/sdk-web": "^1.39.1",
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/scripts/update-all-examples-dependencies.sh
+++ b/scripts/update-all-examples-dependencies.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -x
+set -e
+
+ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )
+
+pushd ${ROOT_DIR}/examples
+    example_dirs=$(find . -name package.json |grep -v node_modules)
+    while IFS= read -r line; do
+       example_dir=$(dirname $line)
+       echo "DIR: ${example_dir}"
+       pushd $example_dir
+          has_node_sdk=$(grep '"@gomomento/sdk"' package.json || true)
+          if [ "$has_node_sdk" == "" ]
+          then
+             echo "do not need to upgrade node sdk"
+          else
+             echo "need to upgrade node sdk"
+             npm install @gomomento/sdk
+          fi
+          has_web_sdk=$(grep '"@gomomento/sdk-web"' package.json || true)
+          if [ "$has_web_sdk" == "" ]
+          then
+             echo "do not need to upgrade web sdk"
+          else
+             echo "need to upgrade web sdk"
+             npm install @gomomento/sdk-web
+          fi
+       popd
+    done <<< "$example_dirs"
+popd


### PR DESCRIPTION
This commit disables dependabot for now; it was unsustainable for this
repo with all of the example projects. We can try to enable it again
once they address https://github.com/dependabot/dependabot-core/issues/2178 .

For now we add a script that updates all the example dependency versions.
We can run this by hand after releases, or add a new cron-type Action that
runs it once a day and generates a PR if it produces a diff.
