### PR TITLE
fix: export VectorIndexItem from core and sdks

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -77,7 +77,7 @@ import * as RefreshApiKey from '@gomomento/sdk-core/dist/src/messages/responses/
 import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/responses/generate-disposable-token';
 
 // VectorClient Response Types
-export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
+export {vector, VectorIndexItem} from '@gomomento/sdk-core';
 
 import {
   ICacheClient,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -131,7 +131,7 @@ import {
 import {VectorIndexConfiguration} from './config/vector-index-configuration';
 
 // VectorClient Response Types
-export {vector} from '@gomomento/sdk-core';
+export {vector, VectorIndexItem} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
 
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ import * as GenerateDisposableToken from './messages/responses/generate-disposab
 // VectorClient Response Types
 export * as vector from './messages/responses/vector';
 export * from './messages/responses/vector';
+export {VectorIndexItem} from './messages/vector-index';
 
 import {CacheInfo} from './messages/cache-info';
 import {


### PR DESCRIPTION
Previously, the type `VectorIndexItem` was not exported from sdk-core,
hence could not be re-exported from the SDKs. Because of this,
application code could not make use of the `VectorIndexItem`
type. This PR exports the type accordingly.
