### PR TITLE
fix: re-exports vector response types

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -78,6 +78,7 @@ import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/
 
 // VectorClient Response Types
 export {vector, VectorIndexItem} from '@gomomento/sdk-core';
+export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
 
 import {
   ICacheClient,


### PR DESCRIPTION
The previous commit mistakenly deleted this line, which we re-add.
