### PR TITLE
feat: add batch get, set, delete functions for nodejs

### DIFF
--- a/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
@@ -1,0 +1,145 @@
+import {CacheDelete, CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {CacheClient} from '../cache-client';
+import {
+  BatchDeleteRequest,
+  BatchDeleteResponse,
+  BatchGetRequest,
+  BatchGetResponse,
+  BatchSetItem,
+  BatchSetRequest,
+  BatchSetResponse,
+  defaultMaxConcurrentRequests,
+} from './batch-props';
+import {range} from '@gomomento/sdk-core/dist/src/internal/utils';
+
+export {
+  BatchDeleteRequest,
+  BatchDeleteResponse,
+  BatchGetRequest,
+  BatchGetResponse,
+  BatchSetItem,
+  BatchSetRequest,
+  BatchSetResponse,
+  defaultMaxConcurrentRequests,
+} from './batch-props';
+
+export async function batchGet(
+  request: BatchGetRequest
+): Promise<BatchGetResponse> {
+  const maxConcurrentGets = request.maxConcurrentGets
+    ? request.maxConcurrentGets
+    : Math.min(defaultMaxConcurrentRequests, request.keys.length);
+
+  const batchGetResults = range(maxConcurrentGets).map((workerId: number) =>
+    getWorker(workerId, request.cacheClient, request.cacheName, request.keys)
+  );
+  const awaitAll = await Promise.all(batchGetResults);
+
+  const batchGetResponse: BatchGetResponse = {};
+  awaitAll.forEach(responses => {
+    for (const key of Object.keys(responses)) {
+      batchGetResponse[key] = responses[key];
+    }
+  });
+  return batchGetResponse;
+}
+
+async function getWorker(
+  workerId: number,
+  cacheClient: CacheClient,
+  cacheName: string,
+  keys: Array<string>
+): Promise<Record<string, CacheGet.Response>> {
+  const responses: Record<string, CacheGet.Response> = {};
+  while (keys.length) {
+    const cacheKey = keys.pop();
+    if (cacheKey) {
+      responses[cacheKey] = await cacheClient.get(cacheName, cacheKey);
+    }
+  }
+  return Promise.resolve(responses);
+}
+
+export async function batchSet(
+  request: BatchSetRequest
+): Promise<BatchSetResponse> {
+  const maxConcurrentSets = request.maxConcurrentSets
+    ? request.maxConcurrentSets
+    : Math.min(defaultMaxConcurrentRequests, request.items.length);
+
+  const batchSetResults = range(maxConcurrentSets).map((workerId: number) =>
+    setWorker(workerId, request.cacheClient, request.cacheName, request.items)
+  );
+  const awaitAll = await Promise.all(batchSetResults);
+
+  const batchSetResponse: BatchSetResponse = {};
+  awaitAll.forEach(responses => {
+    for (const key of Object.keys(responses)) {
+      batchSetResponse[key] = responses[key];
+    }
+  });
+  return batchSetResponse;
+}
+
+async function setWorker(
+  workerId: number,
+  cacheClient: CacheClient,
+  cacheName: string,
+  items: Array<BatchSetItem>
+): Promise<Record<string, CacheSet.Response>> {
+  const responses: Record<string, CacheSet.Response> = {};
+  while (items.length) {
+    const item = items.pop();
+    if (item) {
+      responses[item.key] = await cacheClient.set(
+        cacheName,
+        item.key,
+        item.value
+      );
+    }
+  }
+  return Promise.resolve(responses);
+}
+
+export async function batchDelete(
+  request: BatchDeleteRequest
+): Promise<BatchDeleteResponse> {
+  const maxConcurrentDeletes = request.maxConcurrentDeletes
+    ? request.maxConcurrentDeletes
+    : Math.min(defaultMaxConcurrentRequests, request.keys.length);
+
+  const batchDeleteResults = range(maxConcurrentDeletes).map(
+    (workerId: number) =>
+      deleteWorker(
+        workerId,
+        request.cacheClient,
+        request.cacheName,
+        request.keys
+      )
+  );
+  const awaitAll = await Promise.all(batchDeleteResults);
+
+  const batchDeleteResponse: BatchDeleteResponse = {};
+  awaitAll.forEach(responses => {
+    for (const key of Object.keys(responses)) {
+      batchDeleteResponse[key] = responses[key];
+    }
+  });
+  return batchDeleteResponse;
+}
+
+async function deleteWorker(
+  workerId: number,
+  cacheClient: CacheClient,
+  cacheName: string,
+  keys: Array<string>
+): Promise<Record<string, CacheDelete.Response>> {
+  const responses: Record<string, CacheDelete.Response> = {};
+  while (keys.length) {
+    const cacheKey = keys.pop();
+    if (cacheKey) {
+      responses[cacheKey] = await cacheClient.delete(cacheName, cacheKey);
+    }
+  }
+  return Promise.resolve(responses);
+}

--- a/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
@@ -21,7 +21,7 @@ export {
   BatchSetRequest,
   BatchSetResponse,
   defaultMaxConcurrentRequests,
-} from './batch-props';
+};
 
 export async function batchGet(
   request: BatchGetRequest
@@ -53,7 +53,7 @@ async function getWorker(
   const responses: Record<string, CacheGet.Response> = {};
   while (keys.length) {
     const cacheKey = keys.pop();
-    if (cacheKey) {
+    if (cacheKey !== undefined) {
       responses[cacheKey] = await cacheClient.get(cacheName, cacheKey);
     }
   }
@@ -90,7 +90,7 @@ async function setWorker(
   const responses: Record<string, CacheSet.Response> = {};
   while (items.length) {
     const item = items.pop();
-    if (item) {
+    if (item !== undefined) {
       responses[item.key] = await cacheClient.set(
         cacheName,
         item.key,
@@ -137,7 +137,7 @@ async function deleteWorker(
   const responses: Record<string, CacheDelete.Response> = {};
   while (keys.length) {
     const cacheKey = keys.pop();
-    if (cacheKey) {
+    if (cacheKey !== undefined) {
       responses[cacheKey] = await cacheClient.delete(cacheName, cacheKey);
     }
   }

--- a/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
@@ -1,35 +1,22 @@
 import {CacheGet, CacheSet, CacheDelete} from '@gomomento/sdk-core';
-import {CacheClient} from '../cache-client';
 
 export const defaultMaxConcurrentRequests = 5;
+export const defaultTtlSeconds = 60;
 
-export interface BatchGetRequest {
-  cacheClient: CacheClient;
-  cacheName: string;
-  keys: Array<string>;
+export interface BatchGetOptions {
   maxConcurrentGets?: number;
 }
 
 export type BatchGetResponse = Record<string, CacheGet.Response>;
 
-export interface BatchSetItem {
-  key: string;
-  value: string;
-}
-
-export interface BatchSetRequest {
-  cacheClient: CacheClient;
-  cacheName: string;
-  items: Array<BatchSetItem>;
+export interface BatchSetOptions {
+  ttl?: number;
   maxConcurrentSets?: number;
 }
 
 export type BatchSetResponse = Record<string, CacheSet.Response>;
 
-export interface BatchDeleteRequest {
-  cacheClient: CacheClient;
-  cacheName: string;
-  keys: Array<string>;
+export interface BatchDeleteOptions {
   maxConcurrentDeletes?: number;
 }
 

--- a/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
@@ -3,21 +3,24 @@ import {CacheGet, CacheSet, CacheDelete} from '@gomomento/sdk-core';
 export const defaultMaxConcurrentRequests = 5;
 export const defaultTtlSeconds = 60;
 
-export interface BatchGetOptions {
-  maxConcurrentGets?: number;
+export interface BatchFunctionOptions {
+  maxConcurrentRequests?: number;
 }
+
+export type BatchGetOptions = BatchFunctionOptions;
 
 export type BatchGetResponse = Record<string, CacheGet.Response>;
 
-export interface BatchSetOptions {
+export type BatchSetOptions = BatchFunctionOptions;
+
+export interface BatchSetItem {
+  key: string | Uint8Array;
+  value: string | Uint8Array;
   ttl?: number;
-  maxConcurrentSets?: number;
 }
 
 export type BatchSetResponse = Record<string, CacheSet.Response>;
 
-export interface BatchDeleteOptions {
-  maxConcurrentDeletes?: number;
-}
+export type BatchDeleteOptions = BatchFunctionOptions;
 
 export type BatchDeleteResponse = Record<string, CacheDelete.Response>;

--- a/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-props.ts
@@ -1,0 +1,36 @@
+import {CacheGet, CacheSet, CacheDelete} from '@gomomento/sdk-core';
+import {CacheClient} from '../cache-client';
+
+export const defaultMaxConcurrentRequests = 5;
+
+export interface BatchGetRequest {
+  cacheClient: CacheClient;
+  cacheName: string;
+  keys: Array<string>;
+  maxConcurrentGets?: number;
+}
+
+export type BatchGetResponse = Record<string, CacheGet.Response>;
+
+export interface BatchSetItem {
+  key: string;
+  value: string;
+}
+
+export interface BatchSetRequest {
+  cacheClient: CacheClient;
+  cacheName: string;
+  items: Array<BatchSetItem>;
+  maxConcurrentSets?: number;
+}
+
+export type BatchSetResponse = Record<string, CacheSet.Response>;
+
+export interface BatchDeleteRequest {
+  cacheClient: CacheClient;
+  cacheName: string;
+  keys: Array<string>;
+  maxConcurrentDeletes?: number;
+}
+
+export type BatchDeleteResponse = Record<string, CacheDelete.Response>;

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -331,6 +331,5 @@ export {
   MomentoLoggerFactory,
   NoopMomentoLogger,
   NoopMomentoLoggerFactory,
-  // BatchUtils
   BatchUtils,
 };

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -4,6 +4,7 @@ import {PreviewVectorIndexClient} from './preview-vector-index-client';
 import * as Configurations from './config/configurations';
 import * as TopicConfigurations from './config/topic-configurations';
 import * as VectorIndexConfigurations from './config/vector-index-configurations';
+import * as BatchUtils from './batchutils/batch-functions';
 
 import {TopicClientProps} from './topic-client-props';
 import {VectorIndexConfiguration} from './config/vector-index-configuration';
@@ -330,4 +331,6 @@ export {
   MomentoLoggerFactory,
   NoopMomentoLogger,
   NoopMomentoLoggerFactory,
+  // BatchUtils
+  BatchUtils,
 };

--- a/packages/client-sdk-nodejs/test/integration/batchutils.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/batchutils.test.ts
@@ -27,11 +27,18 @@ describe('BatchUtils', () => {
   });
 
   it('batchSet happy path', async () => {
+    const items = [
+      {key: 'a', value: 'apple'},
+      {key: 'b', value: 'berry'},
+      {key: 'c', value: 'cantaloupe'},
+      {key: '1', value: 'first'},
+      {key: '2', value: 'second'},
+      {key: '3', value: 'third'},
+    ];
     const response = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third']
+      items
     );
     for (const [key, resp] of Object.entries(response)) {
       expectWithMessage(() => {
@@ -41,12 +48,18 @@ describe('BatchUtils', () => {
   });
 
   it('batchSet happy path with ttl', async () => {
+    const items = [
+      {key: 'a', value: 'apple', ttl: 3},
+      {key: 'b', value: 'berry', ttl: 3},
+      {key: 'c', value: 'cantaloupe', ttl: 3},
+      {key: '1', value: 'first', ttl: 3},
+      {key: '2', value: 'second', ttl: 3},
+      {key: '3', value: 'third', ttl: 3},
+    ];
     const response = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third'],
-      {ttl: 3}
+      items
     );
     for (const [key, resp] of Object.entries(response)) {
       expectWithMessage(() => {
@@ -72,11 +85,18 @@ describe('BatchUtils', () => {
 
   it('batchGet happy path with all hits', async () => {
     // Set some values first
+    const items = [
+      {key: 'a', value: 'apple'},
+      {key: 'b', value: 'berry'},
+      {key: 'c', value: 'cantaloupe'},
+      {key: '1', value: 'first'},
+      {key: '2', value: 'second'},
+      {key: '3', value: 'third'},
+    ];
     const setResponse = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third']
+      items
     );
     for (const [key, resp] of Object.entries(setResponse)) {
       expectWithMessage(() => {
@@ -101,11 +121,18 @@ describe('BatchUtils', () => {
 
   it('batchGet happy path with some hits and misses', async () => {
     // Set some values first
+    const items = [
+      {key: 'a', value: 'apple'},
+      {key: 'b', value: 'berry'},
+      {key: 'c', value: 'cantaloupe'},
+      {key: '1', value: 'first'},
+      {key: '2', value: 'second'},
+      {key: '3', value: 'third'},
+    ];
     const setResponse = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third']
+      items
     );
     for (const [key, resp] of Object.entries(setResponse)) {
       expectWithMessage(() => {
@@ -136,11 +163,18 @@ describe('BatchUtils', () => {
 
   it('batchDelete happy path', async () => {
     // Set some values first
+    const items = [
+      {key: 'a', value: 'apple'},
+      {key: 'b', value: 'berry'},
+      {key: 'c', value: 'cantaloupe'},
+      {key: '1', value: 'first'},
+      {key: '2', value: 'second'},
+      {key: '3', value: 'third'},
+    ];
     const setResponse = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third']
+      items
     );
     for (const [key, resp] of Object.entries(setResponse)) {
       expectWithMessage(() => {
@@ -165,11 +199,18 @@ describe('BatchUtils', () => {
 
   it('batchDelete some existing and some non-existing keys', async () => {
     // Set some values first
+    const items = [
+      {key: 'a', value: 'apple'},
+      {key: 'b', value: 'berry'},
+      {key: 'c', value: 'cantaloupe'},
+      {key: '1', value: 'first'},
+      {key: '2', value: 'second'},
+      {key: '3', value: 'third'},
+    ];
     const setResponse = await batchSet(
       cacheClient,
       integrationTestCacheName,
-      ['a', 'b', 'c', '1', '2', '3'],
-      ['apple', 'berry', 'cantaloupe', 'first', 'second', 'third']
+      items
     );
     for (const [key, resp] of Object.entries(setResponse)) {
       expectWithMessage(() => {

--- a/packages/client-sdk-nodejs/test/integration/batchutils.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/batchutils.test.ts
@@ -1,0 +1,120 @@
+import {CacheDelete, CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {
+  batchDelete,
+  batchGet,
+  batchSet,
+} from '../../src/batchutils/batch-functions';
+import {
+  BatchDeleteRequest,
+  BatchGetRequest,
+  BatchSetRequest,
+} from '../../src/batchutils/batch-props';
+import {SetupIntegrationTest} from './integration-setup';
+import {expectWithMessage} from '@gomomento/common-integration-tests';
+
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
+
+describe('BatchUtils', () => {
+  it('batchGet happy path with all misses', async () => {
+    const request: BatchGetRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      keys: ['a', 'b', 'c', '1', '2', '3'],
+    };
+    const response = await batchGet(request);
+    for (const [key, resp] of Object.entries(response)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheGet.Miss);
+      }, `expected MISS for key ${key}, received ${resp.toString()}`);
+    }
+  });
+
+  it('batchSet happy path', async () => {
+    const request: BatchSetRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      items: [
+        {key: 'a', value: 'apple'},
+        {key: 'b', value: 'berry'},
+        {key: 'c', value: 'cantaloupe'},
+        {key: '1', value: 'first'},
+        {key: '2', value: 'second'},
+        {key: '3', value: 'third'},
+      ],
+    };
+    const response = await batchSet(request);
+    for (const [key, resp] of Object.entries(response)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS for item ${key} but received ${resp.toString()}`);
+    }
+  });
+
+  it('batchGet happy path with all hits', async () => {
+    // Set some values first
+    const setRequest: BatchSetRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      items: [
+        {key: 'a', value: 'apple'},
+        {key: 'b', value: 'berry'},
+        {key: 'c', value: 'cantaloupe'},
+        {key: '1', value: 'first'},
+        {key: '2', value: 'second'},
+        {key: '3', value: 'third'},
+      ],
+    };
+    const setResponse = await batchSet(setRequest);
+    for (const [key, resp] of Object.entries(setResponse)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS for item ${key} but received ${resp.toString()}`);
+    }
+
+    const request: BatchGetRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      keys: ['a', 'b', 'c', '1', '2', '3'],
+    };
+    const response = await batchGet(request);
+    for (const [key, resp] of Object.entries(response)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT for key ${key}, received ${resp.toString()}`);
+    }
+  });
+
+  it('batchDelete happy path', async () => {
+    // Set some values first
+    const setRequest: BatchSetRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      items: [
+        {key: 'a', value: 'apple'},
+        {key: 'b', value: 'berry'},
+        {key: 'c', value: 'cantaloupe'},
+        {key: '1', value: 'first'},
+        {key: '2', value: 'second'},
+        {key: '3', value: 'third'},
+      ],
+    };
+    const setResponse = await batchSet(setRequest);
+    for (const [key, resp] of Object.entries(setResponse)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS for item ${key} but received ${resp.toString()}`);
+    }
+
+    const request: BatchDeleteRequest = {
+      cacheClient: cacheClient,
+      cacheName: integrationTestCacheName,
+      keys: ['a', 'b', 'c', '1', '2', '3'],
+    };
+    const response = await batchDelete(request);
+    for (const [key, resp] of Object.entries(response)) {
+      expectWithMessage(() => {
+        expect(resp).toBeInstanceOf(CacheDelete.Success);
+      }, `expected SUCCESS for key ${key}, received ${resp.toString()}`);
+    }
+  });
+});


### PR DESCRIPTION
Addresses [#460](https://github.com/momentohq/dev-eco-issue-tracker/issues/460) by implementing a `BatchUtils` namespace that offers the `batchGet`, `batchSet`, and `batchDelete` functions in the Nodejs SDK.