### PR TITLE
chore: throw when env vars not set and update readme to be more clear

### DIFF
--- a/examples/cloudflare-workers/http-api/src/worker.ts
+++ b/examples/cloudflare-workers/http-api/src/worker.ts
@@ -64,6 +64,16 @@ export interface Env {
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+
+		if (env.MOMENTO_API_KEY === undefined) {
+			throw new Error('MOMENTO_API_KEY should be set in .dev.vars for local development, and should' +
+				' be uploaded to Cloudflare secrets through NPX if you are testing your worker. See README for more details')
+		}
+
+		if (env.MOMENTO_CACHE_NAME === undefined) {
+			throw new Error('MOMENTO_CACHE_NAME should be set in wrangler.toml file. See README for more details')
+		}
+
 		const client = new MomentoFetcher(env.MOMENTO_API_KEY, env.MOMENTO_REST_ENDPOINT);
 		const cache = env.MOMENTO_CACHE_NAME;
 		const key = "key";

--- a/examples/cloudflare-workers/web-sdk/README.md
+++ b/examples/cloudflare-workers/web-sdk/README.md
@@ -23,8 +23,6 @@ npm install
 
 - Next, if you don't have one already, create a cache inside the [Momento console](https://console.gomomento.com/caches).
 
-- Cloudflare uses a file called wrangler.toml to configure the development and publishing of a worker. More information about Cloudflare configuration can be found [on their website](https://developers.cloudflare.com/workers/wrangler/configuration/). In the example directory, update the `wrangler.toml` file and set the `MOMENTO_CACHE` environment variable to match the name of the cache you created earlier.
-
 
 ### Setting up Momento Authentication
 - In the Momento console, generate an [API key for your cache](https://console.gomomento.com/tokens), making sure to choose the same AWS region you used to create the cache. You'll want to use a `Fine-Grained Access Key` with read/write permissions for the cache you created.
@@ -32,6 +30,8 @@ npm install
 - Copy the `API key` value from the API key generation screen for use in the next two steps.
    ![API Key generation results](https://assets.website-files.com/628fadb065a50abf13a11485/64b97cb50d9a0db6b03c40e8_JZLnsjtwN5RaGx83NX424WKmvauAuqcUD3YeWLx2LFFIwLiXHupq1XF3MOyggObfaC8LE1fQUN4b-9nDTOwGYUHugfZYqYTK92HybD2X1OsuRF-DxmJKekTWgV0SY0LzWpE9vvA0To8sGmNXkG-geQ.png)
 - Update the `.dev.vars` file in the example directory with the Momento API key. Since this is a secret key, we don’t store it as an environment variable, instead storing it as a Cloudflare secret.
+- Cloudflare uses a file called wrangler.toml to configure the development and publishing of a worker. More information about Cloudflare configuration can be found [on their website](https://developers.cloudflare.com/workers/wrangler/configuration/). In the example directory, update the `wrangler.toml` file and set the `MOMENTO_CACHE` environment variable to match the name of the cache you created earlier. Note that
+	you'll also need to uncomment two lines including line that has `[vars]` in it.
 - Start the development server:
 
 ### Running locally

--- a/examples/cloudflare-workers/web-sdk/src/worker.ts
+++ b/examples/cloudflare-workers/web-sdk/src/worker.ts
@@ -82,6 +82,15 @@ export interface Env {
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 
+		if (env.MOMENTO_API_KEY === undefined) {
+			throw new Error('MOMENTO_API_KEY should be set in .dev.vars for local development, and should' +
+				' be uploaded to Cloudflare secrets through NPX if you are testing your worker. See README for more details')
+		}
+
+		if (env.MOMENTO_CACHE_NAME === undefined) {
+			throw new Error('MOMENTO_CACHE_NAME should be set in wrangler.toml file. See README for more details')
+		}
+
 		console.log(`Creating cache client`);
 		const momento = new CacheClient({
 			configuration: Configurations.Laptop.v1(),


### PR DESCRIPTION
Cloudflare reported a bug coming out of the `web-sdk` 

```
Error when setting value in cache! Unknown error has occurred: Cannot read properties of undefined (reading 'trim')
[mf:err] Error: Error setting key key: Unknown error has occurred: Cannot read properties of undefined (reading 'trim')
    at MomentoFetcher.set (/Users/gift/Code/demos/client-sdk-javascript/examples/cloudflare-workers/web-sdk/src/worker.ts:58:10)
    at async Object.fetch (/Users/gift/Code/demos/client-sdk-javascript/examples/cloudflare-workers/web-sdk/src/worker.ts:104:3)
```

This happens if I do not provide a cache name through the `wrangler.toml` file. Changed examples to throw on missing env vars and updated README to be more clear.