### PR TITLE
fix: lint errors in batch-functions file

### DIFF
--- a/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
+++ b/packages/client-sdk-nodejs/src/batchutils/batch-functions.ts
@@ -30,7 +30,7 @@ export {
 };
 
 // Note: all promises in batch request workers have a client-side timeout deadline
-// because grpc request timeouts are baked into the cache client. The timeout can be 
+// because grpc request timeouts are baked into the cache client. The timeout can be
 // overridden using the `withClientTimeoutMillis` function.
 
 export async function batchGet(


### PR DESCRIPTION
Follow up to #916 
The [npm publishing step of the release](https://github.com/momentohq/client-sdk-javascript/actions/runs/6229546809/job/16908230746) for BatchUtils functions failed because of some lint errors 🥲