### PR TITLE
chore: rename env vars and handle endpoints with or without https prefix

### DIFF
--- a/examples/cloudflare-workers/http-api/README.md
+++ b/examples/cloudflare-workers/http-api/README.md
@@ -27,7 +27,7 @@ npm install
 1. Cloudflare uses a file called wrangler.toml to configure the development and publishing of a worker. More information about Cloudflare configuration can be found [on their website](https://developers.cloudflare.com/workers/wrangler/configuration/). In the example directory, update the `wrangler.toml` file with the cache name and HTTP endpoint as they appeared in the Momento Console. Note that we need to explicitly uncomment the below 3 lines by removing the `#` sign and with the updated data.
 ```bash
 [vars]
-MOMENTO_REST_ENDPOINT = "myEndpoint"
+MOMENTO_HTTP_ENDPOINT = "myEndpoint"
 MOMENTO_CACHE_NAME =  "myCache"
 ```
 1. Update the `.dev.vars` file in the example directory with the Momento API key. Since this is a secret key, we don’t store it as an environment variable, instead storing it as a Cloudflare secret.

--- a/examples/cloudflare-workers/http-api/src/worker.ts
+++ b/examples/cloudflare-workers/http-api/src/worker.ts
@@ -13,7 +13,11 @@ class MomentoFetcher {
 	private readonly baseurl: string;
 	constructor(key: string, endpoint: string) {
 		this.apiKey = key;
-		this.baseurl = `${endpoint}/cache`;
+		if (!endpoint.startsWith('https://')) {
+			this.baseurl = `https://${endpoint}/cache`;
+		} else {
+			this.baseurl = `${endpoint}/cache`;
+		}
 	}
 
 	async get(cacheName: string, key: string) {
@@ -58,7 +62,7 @@ class MomentoFetcher {
 
 export interface Env {
 	MOMENTO_API_KEY: string;
-	MOMENTO_REST_ENDPOINT: string;
+	MOMENTO_HTTP_ENDPOINT: string;
 	MOMENTO_CACHE_NAME: string;
 }
 
@@ -74,11 +78,11 @@ export default {
 			throw new Error('MOMENTO_CACHE_NAME must be set in wrangler.toml file. See README for more details')
 		}
 
-		if (env.MOMENTO_REST_ENDPOINT === undefined) {
-			throw new Error('MOMENTO_REST_ENDPOINT must be set in wrangler.toml file. See README for more details')
+		if (env.MOMENTO_HTTP_ENDPOINT === undefined) {
+			throw new Error('MOMENTO_HTTP_ENDPOINT must be set in wrangler.toml file. See README for more details')
 		}
 
-		const client = new MomentoFetcher(env.MOMENTO_API_KEY, env.MOMENTO_REST_ENDPOINT);
+		const client = new MomentoFetcher(env.MOMENTO_API_KEY, env.MOMENTO_HTTP_ENDPOINT);
 		const cache = env.MOMENTO_CACHE_NAME;
 		const key = "key";
 		const value = "value";

--- a/examples/cloudflare-workers/http-api/wrangler.toml
+++ b/examples/cloudflare-workers/http-api/wrangler.toml
@@ -1,6 +1,7 @@
 name = "momento-cloudflare-worker-http"
 main = "src/worker.ts"
 compatibility_date = "2023-07-10"
+keep_vars = true
 
 # [vars]
 # MOMENTO_HTTP_ENDPOINT = "REPLACE ME"

--- a/examples/cloudflare-workers/http-api/wrangler.toml
+++ b/examples/cloudflare-workers/http-api/wrangler.toml
@@ -3,5 +3,5 @@ main = "src/worker.ts"
 compatibility_date = "2023-07-10"
 
 # [vars]
-# MOMENTO_REST_ENDPOINT = "REPLACE ME"
+# MOMENTO_HTTP_ENDPOINT = "REPLACE ME"
 # MOMENTO_CACHE_NAME = "REPLACE ME"


### PR DESCRIPTION
Made some minor changes to make this example compatible with future Cloudflare integration
- Rename `MOMENTO_REST_ENDPOINT` to `MOMENTO_HTTP_ENDPOINT`
- If `MOMENTO_HTTP_ENDPOINT` doesn't start with `https://`, add it.
- Preserve environment variables added via UI when doing a deploy