### PR TITLE
chore: export IMomentoCache

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,8 @@ export {
   IncrementOptions,
 } from './clients/ICacheClient';
 
+export {IMomentoCache} from './clients/IMomentoCache';
+
 export {IVectorIndexClient, SearchOptions} from './clients/IVectorIndexClient';
 
 export {


### PR DESCRIPTION
While `ICacheClient` is exported, this interface also depends on the
name `IMomentoCache`, which is not exported. We export that here.
