### PR TITLE
chore: re-export vector index request types

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -77,6 +77,9 @@ import * as RefreshApiKey from '@gomomento/sdk-core/dist/src/messages/responses/
 
 import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/responses/generate-disposable-token';
 
+// VectorClient Request Types
+export {ALL_VECTOR_METADATA, VectorSimilarityMetric} from '@gomomento/sdk-core';
+
 // VectorClient Response Types
 export {vector, VectorIndexItem} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -130,6 +130,9 @@ import {
 
 import {VectorIndexConfiguration} from './config/vector-index-configuration';
 
+// VectorClient Request Types
+export {ALL_VECTOR_METADATA, VectorSimilarityMetric} from '@gomomento/sdk-core';
+
 // VectorClient Response Types
 export {vector, VectorIndexItem} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';


### PR DESCRIPTION
`ALL_VECTOR_METADATA` and `SimilarityMetric` were not re-exported from the
libraries in the previous commit. This commit re-exports them from the sdk libraries.
