### PR TITLE
chore: re-export IMomentoCache

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -86,6 +86,7 @@ export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
 
 import {
   ICacheClient,
+  IMomentoCache,
   SubscribeCallOptions,
   CacheInfo,
   CollectionTtl,
@@ -191,6 +192,7 @@ export {ExampleAsyncMiddleware} from './config/middleware/example-async-middlewa
 
 export {
   ICacheClient,
+  IMomentoCache,
   CollectionTtl,
   ItemType,
   SortedSetOrder,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -74,6 +74,7 @@ import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/
 
 import {
   ICacheClient,
+  IMomentoCache,
   SubscribeCallOptions,
   CacheInfo,
   CollectionTtl,
@@ -145,6 +146,7 @@ export {
 
 export {
   ICacheClient,
+  IMomentoCache,
   CollectionTtl,
   ItemType,
   SortedSetOrder,


### PR DESCRIPTION
This re-exports `IMomentoCache` from the top level `index.ts` files. This type is needed to mock the library in third party unit tests.
