### PR TITLE
feat: leaderboard bug bash fixes, updated response classes

### DIFF
--- a/packages/core/src/clients/ILeaderboard.ts
+++ b/packages/core/src/clients/ILeaderboard.ts
@@ -13,24 +13,26 @@ import {
 } from '../utils/cache-call-options';
 
 export interface ILeaderboard {
-  leaderboardUpsert(
-    elements: Map<number, number>
+  upsert(
+    elements: Record<number, number> | Map<number, number>
   ): Promise<LeaderboardUpsert.Response>;
-  leaderboardFetchByScore(
+  fetchByScore(
     options?: LeaderboardFetchByScoreCallOptions
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardFetchByRank(
+  fetchByRank(
+    startRank: number,
+    endRank: number,
     options?: LeaderboardFetchByRankCallOptions
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardGetRank(
+  getRank(
     ids: Array<number>,
     options?: LeaderboardGetRankCallOptions
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardLength(): Promise<LeaderboardLength.Response>;
-  leaderboardRemoveElements(
+  length(): Promise<LeaderboardLength.Response>;
+  removeElements(
     ids: Array<number>
   ): Promise<LeaderboardRemoveElements.Response>;
-  leaderboardDelete(): Promise<LeaderboardDelete.Response>;
+  delete(): Promise<LeaderboardDelete.Response>;
 }
 export {
   LeaderboardFetchByRankCallOptions,

--- a/packages/core/src/internal/clients/leaderboard/AbstractLeaderboard.ts
+++ b/packages/core/src/internal/clients/leaderboard/AbstractLeaderboard.ts
@@ -38,10 +38,10 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * {@link LeaderboardUpsert.Success} on success.
    * {@link LeaderboardUpsert.Error} on failure.
    */
-  public async leaderboardUpsert(
-    elements: Map<number, number>
+  public async upsert(
+    elements: Record<number, number> | Map<number, number>
   ): Promise<LeaderboardUpsert.Response> {
-    return await this.dataClient.leaderboardUpsert(
+    return await this.dataClient.upsert(
       this.cacheName,
       this.leaderboardName,
       elements
@@ -66,14 +66,13 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * @param {number} [options.count] - The maximum number of elements to return.
    * Defaults to 8192, which is the maximum that can be fetched at a time.
    * @returns {Promise<LeaderboardFetch.Response>} -
-   * {@link LeaderboardFetch.Found} containing the requested elements.
-   * {@link LeaderboardFetch.NotFound} when requested elements were not found.
+   * {@link LeaderboardFetch.Success} containing the requested elements.
    * {@link LeaderboardFetch.Error} on failure.
    */
-  public async leaderboardFetchByScore(
+  public async fetchByScore(
     options?: LeaderboardFetchByScoreCallOptions
   ): Promise<LeaderboardFetch.Response> {
-    return await this.dataClient.leaderboardFetchByScore(
+    return await this.dataClient.fetchByScore(
       this.cacheName,
       this.leaderboardName,
       options?.minScore,
@@ -89,28 +88,31 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * Note: can fetch a maximum of 8192 elements at a time and rank
    * is 0-based (index begins at 0).
    *
-   * @param {LeaderboardFetchByRankOptions} options
-   * @param {number} [options.startRank] - The rank of the first element to
-   * fetch. Defaults to 0. This rank is inclusive, ie the element at this rank
-   * will be fetched.
-   * @param {number} [options.endRank] - The rank of the last element to fetch.
+   * @param {number} [startRank] - The rank of the first element to
+   * fetch. This rank is inclusive, ie the element at this rank
+   * will be fetched. Ranks can be used to manually paginate through the leaderboard
+   * in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc).
+   * @param {number} [endRank] - The rank of the last element to fetch.
    * This rank is exclusive, ie the element at this rank will not be fetched.
-   * Defaults to startRank + 8192 in order to fetch the maximum 8192 elements per request.
+   * Ranks can be used to manually paginate through the leaderboard
+   * in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc).
+   * @param {LeaderboardFetchByRankOptions} options
    * @param {LeaderboardOrder} [options.order] - The order to fetch the elements in.
    * Defaults to ascending, meaning 0 is the lowest-scoring rank.
    * @returns {Promise<LeaderboardFetch.Response>} -
-   * {@link LeaderboardFetch.Found} containing the requested elements.
-   * {@link LeaderboardFetch.NotFound} when requested elements were not found.
+   * {@link LeaderboardFetch.Success} containing the requested elements.
    * {@link LeaderboardFetch.Error} on failure.
    */
-  public async leaderboardFetchByRank(
+  public async fetchByRank(
+    startRank: number,
+    endRank: number,
     options?: LeaderboardFetchByRankCallOptions
   ): Promise<LeaderboardFetch.Response> {
-    return await this.dataClient.leaderboardFetchByRank(
+    return await this.dataClient.fetchByRank(
       this.cacheName,
       this.leaderboardName,
-      options?.startRank,
-      options?.endRank,
+      startRank,
+      endRank,
       options?.order
     );
   }
@@ -124,15 +126,14 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * @param {LeaderboardOrder} [options.order] - The order to fetch the elements in.
    * Defaults to ascending, meaning 0 is the lowest-scoring rank.
    * @returns {Promise<LeaderboardFetch.Response>}
-   * {@link LeaderboardFetch.Found} containing the requested elements.
-   * {@link LeaderboardFetch.NotFound} when requested elements were not found.
+   * {@link LeaderboardFetch.Success} containing the requested elements.
    * {@link LeaderboardFetch.Error} on failure.
    */
-  public async leaderboardGetRank(
+  public async getRank(
     ids: Array<number>,
     options?: LeaderboardGetRankCallOptions
   ): Promise<LeaderboardFetch.Response> {
-    return await this.dataClient.leaderboardGetRank(
+    return await this.dataClient.getRank(
       this.cacheName,
       this.leaderboardName,
       ids,
@@ -147,11 +148,8 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * {@link LeaderboardLength.Success} containing the length if the leaderboard exists.
    * {@link LeaderboardLength.Error} on failure.
    */
-  public async leaderboardLength(): Promise<LeaderboardLength.Response> {
-    return await this.dataClient.leaderboardLength(
-      this.cacheName,
-      this.leaderboardName
-    );
+  public async length(): Promise<LeaderboardLength.Response> {
+    return await this.dataClient.length(this.cacheName, this.leaderboardName);
   }
 
   /**
@@ -163,10 +161,10 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * {@link LeaderboardRemoveElements.Success} if the elements were successfully removed.
    * {@link LeaderboardRemoveElements.Error} on failure.
    */
-  public async leaderboardRemoveElements(
+  public async removeElements(
     ids: Array<number>
   ): Promise<LeaderboardRemoveElements.Response> {
-    return await this.dataClient.leaderboardRemoveElements(
+    return await this.dataClient.removeElements(
       this.cacheName,
       this.leaderboardName,
       ids
@@ -180,10 +178,7 @@ export abstract class AbstractLeaderboard implements ILeaderboard {
    * {@link LeaderboardDelete.Success} on success.
    * {@link LeaderboardDelete.Error} on failure.
    */
-  public async leaderboardDelete(): Promise<LeaderboardDelete.Response> {
-    return await this.dataClient.leaderboardDelete(
-      this.cacheName,
-      this.leaderboardName
-    );
+  public async delete(): Promise<LeaderboardDelete.Response> {
+    return await this.dataClient.delete(this.cacheName, this.leaderboardName);
   }
 }

--- a/packages/core/src/internal/clients/leaderboard/ILeaderboardDataClient.ts
+++ b/packages/core/src/internal/clients/leaderboard/ILeaderboardDataClient.ts
@@ -8,12 +8,12 @@ import {
 import {LeaderboardOrder} from '../../../utils';
 
 export interface ILeaderboardDataClient {
-  leaderboardUpsert(
+  upsert(
     cacheName: string,
     leaderboardName: string,
-    elements: Map<number, number>
+    elements: Record<number, number> | Map<number, number>
   ): Promise<LeaderboardUpsert.Response>;
-  leaderboardFetchByScore(
+  fetchByScore(
     cacheName: string,
     leaderboardName: string,
     minScore?: number,
@@ -22,29 +22,29 @@ export interface ILeaderboardDataClient {
     offset?: number,
     count?: number
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardFetchByRank(
+  fetchByRank(
     cacheName: string,
     leaderboardName: string,
-    startRank?: number,
-    endRank?: number,
+    startRank: number,
+    endRank: number,
     order?: LeaderboardOrder
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardGetRank(
+  getRank(
     cacheName: string,
     leaderboardName: string,
     ids: Array<number>,
     order?: LeaderboardOrder
   ): Promise<LeaderboardFetch.Response>;
-  leaderboardLength(
+  length(
     cacheName: string,
     leaderboardName: string
   ): Promise<LeaderboardLength.Response>;
-  leaderboardRemoveElements(
+  removeElements(
     cacheName: string,
     leaderboardName: string,
     ids: Array<number>
   ): Promise<LeaderboardRemoveElements.Response>;
-  leaderboardDelete(
+  delete(
     cacheName: string,
     leaderboardName: string
   ): Promise<LeaderboardDelete.Response>;

--- a/packages/core/src/messages/responses/leaderboard/leaderboard-fetch.ts
+++ b/packages/core/src/messages/responses/leaderboard/leaderboard-fetch.ts
@@ -1,19 +1,13 @@
 import {SdkError} from '../../../errors';
 import {_RankedElement} from '../grpc-response-types';
-import {
-  ResponseBase,
-  ResponseError,
-  ResponseNotFound,
-  ResponseFound,
-} from '../response-base';
+import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
 
 /**
  * Parent response type for a leaderboard fetch by rank or by score request.  The
  * response object is resolved to a type-safe object of one of
  * the following subtypes:
  *
- * - {Found}
- * - {NotFound}
+ * - {Success}
  * - {Error}
  *
  * `instanceof` type guards can be used to operate on the appropriate subtype.
@@ -29,7 +23,7 @@ import {
  */
 export abstract class Response extends ResponseBase {}
 
-class _Found extends Response {
+class _Success extends Response {
   private readonly _elements: _RankedElement[];
 
   constructor(elements: _RankedElement[]) {
@@ -53,16 +47,9 @@ class _Found extends Response {
 }
 
 /**
- * Indicates a Successful leaderboard fetch by rank or by score request.
+ * Indicates a Successful leaderboard fetch request.
  */
-export class Found extends ResponseFound(_Found) {}
-
-class _NotFound extends Response {}
-
-/**
- * Indicates that the requested data was not available in the cache.
- */
-export class NotFound extends ResponseNotFound(_NotFound) {}
+export class Success extends ResponseSuccess(_Success) {}
 
 class _Error extends Response {
   constructor(protected _innerException: SdkError) {

--- a/packages/core/src/messages/responses/leaderboard/leaderboard-length.ts
+++ b/packages/core/src/messages/responses/leaderboard/leaderboard-length.ts
@@ -1,18 +1,12 @@
 import {SdkError} from '../../../errors';
-import {
-  ResponseBase,
-  ResponseError,
-  ResponseFound,
-  ResponseNotFound,
-} from '../response-base';
+import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
 
 /**
  * Parent response type for a leaderboard length request.  The
  * response object is resolved to a type-safe object of one of
  * the following subtypes:
  *
- * - {Found}
- * - {NotFound}
+ * - {Success}
  * - {Error}
  *
  * `instanceof` type guards can be used to operate on the appropriate subtype.
@@ -28,7 +22,7 @@ import {
  */
 export abstract class Response extends ResponseBase {}
 
-class _Found extends Response {
+class _Success extends Response {
   private readonly _length: number;
   constructor(length: number) {
     super();
@@ -51,14 +45,7 @@ class _Found extends Response {
 /**
  * Indicates a successful leaderboard length request.
  */
-export class Found extends ResponseFound(_Found) {}
-
-class _NotFound extends Response {}
-
-/**
- * Indicates that the requested data was not available in the cache.
- */
-export class NotFound extends ResponseNotFound(_NotFound) {}
+export class Success extends ResponseSuccess(_Success) {}
 
 class _Error extends Response {
   constructor(protected _innerException: SdkError) {

--- a/packages/core/src/utils/cache-call-options.ts
+++ b/packages/core/src/utils/cache-call-options.ts
@@ -138,20 +138,6 @@ export interface LeaderboardGetRankCallOptions {
 
 export interface LeaderboardFetchByRankCallOptions {
   /**
-   * The rank of the first element to return, inclusive.
-   * If the rank is not specified, defaults to 0.
-   * Ranks can be used to manually paginate through the leaderboard
-   * in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc)
-   */
-  startRank?: number;
-  /**
-   * The rank of the last element to return, exclusive.
-   * If the rank is not specified, defaults to 8192.
-   * Ranks can be used to manually paginate through the leaderboard
-   * in batches of 8192 elements (e.g. request 0-8192, then 8192-16384, etc)
-   */
-  endRank?: number;
-  /**
    * The order in which to return the elements.
    * If the order is not specified, the elements are returned in ascending order.
    * If descending order is used, the start and end ranks are interpreted as if


### PR DESCRIPTION
[Ticket #468](https://github.com/momentohq/dev-eco-issue-tracker/issues/468). Addresses feedback we got from the bug bash.

Changes include:
* Removes the `Found` and `NotFound` response classes which were confusing. 
    * `Error` is returned when the cache is not found and thus the request failed. 
    * `Success` is returned when the cache was found, but does not necessarily mean that requested elements were found (e.g. fetching data from empty or non-existent leaderboards will return length=0 or elements=[] rather than `NotFound` now).
* Removes the `leaderboard` prefixes from the Leaderboard methods.
    * E.g. `leaderboardUpsert` --> `upsert`
* Upsert can now accept elements of type `Record<number, number> | Map<number, number>` instead of just `Map<number, number>`.
* `fetchByRank` now requires `startRank` and `endRank` for pagination through leaderboards.

Will fast follow to update the nodejs example and doc example snippets after this is released. Those haven't made it into the dev docs yet.