### PR TITLE
feat: add token id optional field to disposable tokens

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.84.2",
+        "@gomomento/generated-types": "0.85.0",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
@@ -13374,9 +13374,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.84.2.tgz",
-      "integrity": "sha512-XLdMj82EgVXD7c3Bh72aOl7vRCVWRrHa8KvzJwYaaxT1hquLvrSsQEQd0GrHXyIJ8+XJ8W5nmFxZFqejOIn7ww==",
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.85.0.tgz",
+      "integrity": "sha512-5mVnB8naCbkTfiNtkiGmo9zsA8lKO5X8hq8/KN6yF3U3BW8eC1UEMDKpJ4Gvi2S19QB/WMcj9i3SDgYvRTdSLg==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -27738,9 +27738,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.84.2.tgz",
-      "integrity": "sha512-XLdMj82EgVXD7c3Bh72aOl7vRCVWRrHa8KvzJwYaaxT1hquLvrSsQEQd0GrHXyIJ8+XJ8W5nmFxZFqejOIn7ww==",
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.85.0.tgz",
+      "integrity": "sha512-5mVnB8naCbkTfiNtkiGmo9zsA8lKO5X8hq8/KN6yF3U3BW8eC1UEMDKpJ4Gvi2S19QB/WMcj9i3SDgYvRTdSLg==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -53,7 +53,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.84.2",
+    "@gomomento/generated-types": "0.85.0",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
     "@types/google-protobuf": "3.15.6",

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -185,7 +185,8 @@ export class InternalAuthClient implements IAuthClient {
 
   public async generateDisposableToken(
     scope: DisposableTokenScope,
-    expiresIn: ExpiresIn
+    expiresIn: ExpiresIn,
+    tokenId?: string
   ): Promise<GenerateDisposableToken.Response> {
     const tokenClient = new token.token.TokenClient(
       this.creds.getTokenEndpoint(),
@@ -212,6 +213,7 @@ export class InternalAuthClient implements IAuthClient {
       expires: expires,
       auth_token: this.creds.getAuthToken(),
       permissions: permissions,
+      token_id: tokenId,
     });
 
     return await new Promise<GenerateDisposableToken.Response>(resolve => {

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -211,10 +211,10 @@ export class InternalAuthClient implements IAuthClient {
       return new GenerateDisposableToken.Error(normalizeSdkError(err as Error));
     }
 
-    const tokenID = disposableTokenProps?.tokenID;
-    if (tokenID) {
+    const tokenId = disposableTokenProps?.tokenId;
+    if (tokenId !== undefined) {
       try {
-        validateDisposableTokenTokenID(tokenID);
+        validateDisposableTokenTokenID(tokenId);
       } catch (err) {
         return new GenerateDisposableToken.Error(
           normalizeSdkError(err as Error)
@@ -226,7 +226,7 @@ export class InternalAuthClient implements IAuthClient {
       expires: expires,
       auth_token: this.creds.getAuthToken(),
       permissions: permissions,
-      token_id: tokenID,
+      token_id: tokenId,
     });
 
     return await new Promise<GenerateDisposableToken.Response>(resolve => {

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.84.2",
+        "@gomomento/generated-types-webtext": "0.85.0",
         "@gomomento/sdk-core": "file:../core",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -13374,9 +13374,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.84.2.tgz",
-      "integrity": "sha512-s3vo7DthBaIfSmfl6DmZurrPpJfuPrKBosSY57sfqvaQdirPhBRmjedSeNTAxU7vJ4adC9Jl6vFKkuKNEMDnGw==",
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.85.0.tgz",
+      "integrity": "sha512-8GcTRR8Jx5SZvztlK47gWXJIXgip8TNeSWUUHKOJMVqSt7r1ULr9HIMr/8s8JN5ddvjx/HQrMrDzCcWT6D+ZZg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
@@ -27782,9 +27782,9 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.84.2.tgz",
-      "integrity": "sha512-s3vo7DthBaIfSmfl6DmZurrPpJfuPrKBosSY57sfqvaQdirPhBRmjedSeNTAxU7vJ4adC9Jl6vFKkuKNEMDnGw==",
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.85.0.tgz",
+      "integrity": "sha512-8GcTRR8Jx5SZvztlK47gWXJIXgip8TNeSWUUHKOJMVqSt7r1ULr9HIMr/8s8JN5ddvjx/HQrMrDzCcWT6D+ZZg==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -53,7 +53,7 @@
     "xhr2": "^0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.84.2",
+    "@gomomento/generated-types-webtext": "0.85.0",
     "@gomomento/sdk-core": "file:../core",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -216,16 +216,16 @@ export class InternalWebGrpcAuthClient<
 
     request.setPermissions(permissions);
 
-    const tokenID = disposableTokenProps?.tokenID;
-    if (tokenID) {
+    const tokenId = disposableTokenProps?.tokenId;
+    if (tokenId !== undefined) {
       try {
-        validateDisposableTokenTokenID(tokenID);
+        validateDisposableTokenTokenID(tokenId);
       } catch (err) {
         return new GenerateDisposableToken.Error(
           normalizeSdkError(err as Error)
         );
       }
-      request.setTokenId(tokenID);
+      request.setTokenId(tokenId);
     }
 
     try {

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -218,7 +218,13 @@ export class InternalWebGrpcAuthClient<
 
     const tokenID = disposableTokenProps?.tokenID;
     if (tokenID) {
-      validateDisposableTokenTokenID(tokenID);
+      try {
+        validateDisposableTokenTokenID(tokenID);
+      } catch (err) {
+        return new GenerateDisposableToken.Error(
+          normalizeSdkError(err as Error)
+        );
+      }
       request.setTokenId(tokenID);
     }
 

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -192,7 +192,8 @@ export class InternalWebGrpcAuthClient<
 
   public async generateDisposableToken(
     scope: DisposableTokenScope,
-    expiresIn: ExpiresIn
+    expiresIn: ExpiresIn,
+    tokenID?: string
   ): Promise<GenerateDisposableToken.Response> {
     const tokenClient = new token.TokenClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
@@ -212,6 +213,10 @@ export class InternalWebGrpcAuthClient<
     }
 
     request.setPermissions(permissions);
+
+    if (tokenID !== undefined) {
+      request.setTokenId(tokenID);
+    }
 
     try {
       validateDisposableTokenExpiry(expiresIn);

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -35,6 +35,7 @@ import {
   validateValidForSeconds,
   validateDisposableTokenExpiry,
   validateCacheKeyOrPrefix,
+  validateDisposableTokenTokenID,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
@@ -59,6 +60,7 @@ import {
   DisposableTokenCachePermission,
   isDisposableTokenCachePermission,
   asDisposableTokenPermissionsObject,
+  DisposableTokenProps,
 } from '@gomomento/sdk-core/dist/src/auth/tokens/disposable-token-scope';
 import {_GenerateDisposableTokenRequest} from '@gomomento/generated-types-webtext/dist/token_pb';
 import {
@@ -193,7 +195,7 @@ export class InternalWebGrpcAuthClient<
   public async generateDisposableToken(
     scope: DisposableTokenScope,
     expiresIn: ExpiresIn,
-    tokenID?: string
+    disposableTokenProps?: DisposableTokenProps
   ): Promise<GenerateDisposableToken.Response> {
     const tokenClient = new token.TokenClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
@@ -214,7 +216,9 @@ export class InternalWebGrpcAuthClient<
 
     request.setPermissions(permissions);
 
-    if (tokenID !== undefined) {
+    const tokenID = disposableTokenProps?.tokenID;
+    if (tokenID) {
+      validateDisposableTokenTokenID(tokenID);
       request.setTokenId(tokenID);
     }
 

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -845,7 +845,7 @@ export function runAuthClientTests(
           permissions: [{role: CacheRole.WriteOnly, cache: FGA_CACHE_1}],
         },
         ExpiresIn.seconds(60),
-        {tokenID: 'someTokenID'}
+        {tokenId: 'someTokenID'}
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Success);
@@ -871,7 +871,7 @@ export function runAuthClientTests(
           permissions: [{role: CacheRole.WriteOnly, cache: FGA_CACHE_1}],
         },
         ExpiresIn.seconds(60),
-        {tokenID: 't'.repeat(66)}
+        {tokenId: 't'.repeat(66)}
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Error);

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -851,8 +851,7 @@ export function runAuthClientTests(
             },
           ],
         },
-        ExpiresIn.seconds(60),
-        'randomTokenID'
+        ExpiresIn.seconds(60)
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Success);
@@ -1475,7 +1474,7 @@ export function runAuthClientTests(
             },
           ],
         },
-        ExpiresIn.seconds(60),
+        ExpiresIn.seconds(60)
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Success);

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -851,7 +851,8 @@ export function runAuthClientTests(
             },
           ],
         },
-        ExpiresIn.seconds(60)
+        ExpiresIn.seconds(60),
+        'randomTokenID'
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Success);
@@ -1474,7 +1475,7 @@ export function runAuthClientTests(
             },
           ],
         },
-        ExpiresIn.seconds(60)
+        ExpiresIn.seconds(60),
       );
       expectWithMessage(() => {
         expect(tokenResponse).toBeInstanceOf(GenerateDisposableToken.Success);

--- a/packages/core/src/auth/tokens/disposable-token-scope.ts
+++ b/packages/core/src/auth/tokens/disposable-token-scope.ts
@@ -77,6 +77,10 @@ export type DisposableTokenScope =
   | PredefinedScope
   | DisposableTokenCachePermissions;
 
+export interface DisposableTokenProps {
+  tokenID?: string;
+}
+
 function isDisposableTokenPermissionObject(p: Permission): boolean {
   return isDisposableTokenCachePermission(p);
 }

--- a/packages/core/src/auth/tokens/disposable-token-scope.ts
+++ b/packages/core/src/auth/tokens/disposable-token-scope.ts
@@ -78,7 +78,7 @@ export type DisposableTokenScope =
   | DisposableTokenCachePermissions;
 
 export interface DisposableTokenProps {
-  tokenID?: string;
+  tokenId?: string;
 }
 
 function isDisposableTokenPermissionObject(p: Permission): boolean {

--- a/packages/core/src/clients/IAuthClient.ts
+++ b/packages/core/src/clients/IAuthClient.ts
@@ -6,6 +6,7 @@ import {
   RefreshApiKey,
 } from '../index';
 import {PermissionScope} from '../auth/tokens/permission-scope';
+import {DisposableTokenProps} from '../auth/tokens/disposable-token-scope';
 
 export interface IAuthClient {
   generateApiKey(
@@ -31,6 +32,6 @@ export interface IAuthClient {
   generateDisposableToken(
     scope: DisposableTokenScope,
     expiresIn: ExpiresIn,
-    tokenID?: string
+    props?: DisposableTokenProps
   ): Promise<GenerateDisposableToken.Response>;
 }

--- a/packages/core/src/clients/IAuthClient.ts
+++ b/packages/core/src/clients/IAuthClient.ts
@@ -30,6 +30,7 @@ export interface IAuthClient {
 
   generateDisposableToken(
     scope: DisposableTokenScope,
-    expiresIn: ExpiresIn
+    expiresIn: ExpiresIn,
+    tokenID?: string
   ): Promise<GenerateDisposableToken.Response>;
 }

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../index';
 import {IAuthClient} from '../../../clients/IAuthClient';
 import {PermissionScope} from '../../../auth/tokens/permission-scope';
+import {DisposableTokenProps} from '../../../auth/tokens/disposable-token-scope';
 
 export interface BaseAuthClientProps {
   createAuthClient: () => IAuthClient;
@@ -76,6 +77,7 @@ export abstract class AbstractAuthClient implements IAuthClient {
    *
    * @param {DisposableTokenScope} scope - controls the permissions that the new token will have
    * @param {string} expiresIn - How long the token is valid for in epoch timestamp.
+   * @param {DisposableTokenProps} disposableTokenProps - Additional properties for the API
    * @returns {Promise<GenerateDisposableToken.Response>} -
    * {@link GenerateDisposableToken.Success} containing the api token, origin and epoch timestamp when token expires.
    * {@link GenerateDisposableToken.Error} on failure.
@@ -83,12 +85,12 @@ export abstract class AbstractAuthClient implements IAuthClient {
   public async generateDisposableToken(
     scope: DisposableTokenScope,
     expiresIn: ExpiresIn,
-    tokenID?: string
+    disposableTokenProps?: DisposableTokenProps
   ): Promise<GenerateDisposableToken.Response> {
     return await this.authClient.generateDisposableToken(
       scope,
       expiresIn,
-      tokenID
+      disposableTokenProps
     );
   }
 }

--- a/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
+++ b/packages/core/src/internal/clients/auth/AbstractAuthClient.ts
@@ -82,8 +82,13 @@ export abstract class AbstractAuthClient implements IAuthClient {
    */
   public async generateDisposableToken(
     scope: DisposableTokenScope,
-    expiresIn: ExpiresIn
+    expiresIn: ExpiresIn,
+    tokenID?: string
   ): Promise<GenerateDisposableToken.Response> {
-    return await this.authClient.generateDisposableToken(scope, expiresIn);
+    return await this.authClient.generateDisposableToken(
+      scope,
+      expiresIn,
+      tokenID
+    );
   }
 }

--- a/packages/core/src/internal/utils/validators.ts
+++ b/packages/core/src/internal/utils/validators.ts
@@ -145,6 +145,14 @@ export function validateDisposableTokenExpiry(expiresIn: ExpiresIn) {
   }
 }
 
+export function validateDisposableTokenTokenID(tokenID: string) {
+  if (tokenID.length > 64) {
+    throw new InvalidArgumentError(
+      'TokenID must be less than or equal to 64 characters.'
+    );
+  }
+}
+
 function isEmpty(str: string): boolean {
   return !str.trim();
 }

--- a/packages/core/src/internal/utils/validators.ts
+++ b/packages/core/src/internal/utils/validators.ts
@@ -145,8 +145,8 @@ export function validateDisposableTokenExpiry(expiresIn: ExpiresIn) {
   }
 }
 
-export function validateDisposableTokenTokenID(tokenID: string) {
-  if (tokenID.length > 64) {
+export function validateDisposableTokenTokenID(tokenId: string) {
+  if (tokenId.length > 64) {
     throw new InvalidArgumentError(
       'TokenID must be less than or equal to 64 characters.'
     );


### PR DESCRIPTION
Added token id as optional field (within an optional props) to disposable tokens API. The object `DisposableTokenScope` is encapsulated with all kinds of permission policies that we can provide, and it didn't seem clean to add a `tokenID` field there. Instead, added as a new props for that API.

PR #1 for https://github.com/momentohq/dev-eco-issue-tracker/issues/511