### PR TITLE
chore: rename publisherId to tokenId in topic item

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -186,13 +186,13 @@ export class PubsubClient extends AbstractPubsubClient {
         if (resp.item.value.text) {
           options.onItem(
             new TopicItem(resp.item.value.text, {
-              publisherId: resp.item.publisher_id,
+              tokenId: resp.item.publisher_id,
             })
           );
         } else if (resp.item.value.binary) {
           options.onItem(
             new TopicItem(resp.item.value.binary, {
-              publisherId: resp.item.publisher_id,
+              tokenId: resp.item.publisher_id,
             })
           );
         } else {

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -176,9 +176,9 @@ export class PubsubClient<
         const publisherId = resp.getItem()?.getPublisherId();
         const itemBinary = resp.getItem()?.getValue()?.getBinary();
         if (itemText) {
-          options.onItem(new TopicItem(itemText, {publisherId: publisherId}));
+          options.onItem(new TopicItem(itemText, {tokenId: publisherId}));
         } else if (itemBinary) {
-          options.onItem(new TopicItem(itemBinary, {publisherId: publisherId}));
+          options.onItem(new TopicItem(itemBinary, {tokenId: publisherId}));
         } else {
           this.logger.error(
             'Received subscription item with unknown type; topic: %s',

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -902,9 +902,9 @@ export function runAuthClientTests(
       await sleep(2000);
 
       expect(receivedValues[0].valueString()).toEqual('humans landed on Mars!');
-      expect(receivedValues[0].publisherId()).toEqual('myTokenID');
+      expect(receivedValues[0].tokenId()).toEqual('myTokenID');
       expect(receivedValues[0].toString()).toEqual(
-        'TopicItem: humans landed on Mars!; Publisher ID: myTokenID'
+        'TopicItem: humans landed on Mars!; Token Id: myTokenID'
       );
       done = true;
 

--- a/packages/core/src/messages/responses/topic-item.ts
+++ b/packages/core/src/messages/responses/topic-item.ts
@@ -1,7 +1,7 @@
 import {truncateString} from '../../internal/utils';
 
 export interface TopicItemOptions {
-  publisherId?: string;
+  tokenId?: string;
 }
 
 /**
@@ -13,11 +13,11 @@ export interface TopicItemOptions {
  */
 export class TopicItem {
   private readonly _value: string | Uint8Array;
-  private readonly _publisherId?: string;
+  private readonly _tokenId?: string;
 
   constructor(_value: string | Uint8Array, options?: TopicItemOptions) {
     this._value = _value;
-    this._publisherId = options?.publisherId;
+    this._tokenId = options?.tokenId;
   }
 
   /**
@@ -48,16 +48,16 @@ export class TopicItem {
    * Optionally returns the publisher ID from the steam if it exists.
    * @returns string | undefined
    */
-  public publisherId(): string | undefined {
-    return this._publisherId;
+  public tokenId(): string | undefined {
+    return this._tokenId;
   }
 
   public toString(): string {
     const displayValue = truncateString(this.value().toString());
     let displayString = `${this.constructor.name}: ${displayValue}`;
 
-    if (this._publisherId !== undefined) {
-      displayString += `; Publisher ID: ${this._publisherId}`;
+    if (this._tokenId !== undefined) {
+      displayString += `; Token Id: ${this._tokenId}`;
     }
 
     return displayString;


### PR DESCRIPTION
Renaming publisherId to tokenId in SDK as the generateToken API uses this terminology and to be clear to users.