### PR TITLE
fix: import/export permission roles from web-sdk

### DIFF
--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -122,6 +122,7 @@ import {
   TopicSelector,
   AllCaches,
   AllTopics,
+  CacheRole, TopicRole
 } from '@gomomento/sdk-core';
 
 import {Configuration} from './config/configuration';
@@ -169,6 +170,8 @@ export {
   EnvMomentoTokenProvider,
   AllDataReadWrite,
   PermissionScope,
+  CacheRole,
+  TopicRole,
   /**
    * @deprecated please use 'PermissionScope' instead
    */

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -122,7 +122,8 @@ import {
   TopicSelector,
   AllCaches,
   AllTopics,
-  CacheRole, TopicRole
+  CacheRole, 
+  TopicRole,
 } from '@gomomento/sdk-core';
 
 import {Configuration} from './config/configuration';


### PR DESCRIPTION
## PR Description:
- import and export TopicRole, CacheRole from web-sdk such that they can be consumed from the sdk-web rather than sd-core in the console

