### PR TITLE
fix: don't run npm run format during ci

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -9,7 +9,6 @@ echo "building package: ${1}"
 
 pushd ${ROOT_DIR}/packages/${1}
     npm ci
-    npm run format
     npm run build
     npm run lint
 popd


### PR DESCRIPTION
`npm run format` can modify the files in a pr, but does not commit this modification. When we go to publish the package, if the lint check is not passing then the publish will fail. We should commit these lint fixes