### PR TITLE
chore: removing core dependencies from examples package json

### DIFF
--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -74,8 +74,6 @@ import {
   TopicConfigurations,
   PreviewLeaderboardClient,
   LeaderboardConfigurations,
-} from '@gomomento/sdk';
-import {
   ILeaderboard,
   LeaderboardDelete,
   LeaderboardFetch,
@@ -83,7 +81,7 @@ import {
   LeaderboardOrder,
   LeaderboardRemoveElements,
   LeaderboardUpsert,
-} from '@gomomento/sdk-core';
+} from '@gomomento/sdk';
 
 function retrieveApiKeyFromYourSecretsManager(): string {
   // this is not a valid API key but conforms to the syntax requirements.

--- a/examples/nodejs/cache/leaderboard.ts
+++ b/examples/nodejs/cache/leaderboard.ts
@@ -4,8 +4,6 @@ import {
   CredentialProvider,
   CacheClient,
   Configurations,
-} from '@gomomento/sdk';
-import {
   CreateCache,
   LeaderboardDelete,
   LeaderboardFetch,
@@ -13,7 +11,7 @@ import {
   LeaderboardOrder,
   LeaderboardRemoveElements,
   LeaderboardUpsert,
-} from '@gomomento/sdk-core';
+} from '@gomomento/sdk';
 
 async function main() {
   const cacheClient = await CacheClient.create({

--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.43.0",
-        "@gomomento/sdk-core": "^1.43.0"
+        "@gomomento/sdk": "^1.45.7"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -70,12 +69,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.45.6",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.6.tgz",
-      "integrity": "sha512-y1ybs7X0TElWRE/cRIuxbXK7Hj1XBjJMhNHWF0ugg5hRvEhXAwU4kUB+6NsKrCgjXeuqGQomc1ZjtRwJJZrh8w==",
+      "version": "1.45.7",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.7.tgz",
+      "integrity": "sha512-wCNjulaN7Dg9CfY9xM8bUC9DHpLpcvaWP5FZfVnGlxWrTFkc5RR2UBBcCzeb8EoL2iGn29LnNs6voblQdtI1bg==",
       "dependencies": {
         "@gomomento/generated-types": "0.87.0",
-        "@gomomento/sdk-core": "1.45.6",
+        "@gomomento/sdk-core": "1.45.7",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -86,9 +85,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.45.6",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.6.tgz",
-      "integrity": "sha512-TXqq41MUkitdAuur1GwC9JZT5x2+Bi3dezv+gfg7kTqr6wwRxKT12rRCxLtCOdvh0snfXOF+WjdDvKsGmddlOA==",
+      "version": "1.45.7",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.7.tgz",
+      "integrity": "sha512-rjq8Ko8URbRhlV/Vw1oY5fuhjmT/ujbf2zQ2c/s1IYrGpbci217hPOdraS5h9hc/uqZ1cR5rPhppSJb5MBeQCQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"
@@ -3387,12 +3386,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.45.6",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.6.tgz",
-      "integrity": "sha512-y1ybs7X0TElWRE/cRIuxbXK7Hj1XBjJMhNHWF0ugg5hRvEhXAwU4kUB+6NsKrCgjXeuqGQomc1ZjtRwJJZrh8w==",
+      "version": "1.45.7",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.7.tgz",
+      "integrity": "sha512-wCNjulaN7Dg9CfY9xM8bUC9DHpLpcvaWP5FZfVnGlxWrTFkc5RR2UBBcCzeb8EoL2iGn29LnNs6voblQdtI1bg==",
       "requires": {
         "@gomomento/generated-types": "0.87.0",
-        "@gomomento/sdk-core": "1.45.6",
+        "@gomomento/sdk-core": "1.45.7",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3400,9 +3399,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.45.6",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.6.tgz",
-      "integrity": "sha512-TXqq41MUkitdAuur1GwC9JZT5x2+Bi3dezv+gfg7kTqr6wwRxKT12rRCxLtCOdvh0snfXOF+WjdDvKsGmddlOA==",
+      "version": "1.45.7",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.7.tgz",
+      "integrity": "sha512-rjq8Ko8URbRhlV/Vw1oY5fuhjmT/ujbf2zQ2c/s1IYrGpbci217hPOdraS5h9hc/uqZ1cR5rPhppSJb5MBeQCQ==",
       "requires": {
         "buffer": "^6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -32,8 +32,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.43.0",
-    "@gomomento/sdk-core": "^1.43.0"
+    "@gomomento/sdk": "^1.45.7"
   },
   "engines": {
     "node": ">=10.4.0"


### PR DESCRIPTION
Bumped examples release and removed `core` dependency