### PR TITLE
nodejsfunction excludes aws-sdk by default

### DIFF
--- a/examples/nodejs/lambda-examples/topics-microservice/lib/topics-microservice-stack.ts
+++ b/examples/nodejs/lambda-examples/topics-microservice/lib/topics-microservice-stack.ts
@@ -21,11 +21,6 @@ export class TopicsMicroserviceStack extends Stack {
         "SECRETNAME": secretName,
         "CACHENAME": cachName
       },
-      bundling: {
-        externalModules: [
-          'aws-sdk', // Use the 'aws-sdk' available in the Lambda runtime
-        ],
-      },
       depsLockFilePath: join(__dirname, '..', 'package-lock.json'),
       runtime: Runtime.NODEJS_18_X,
       memorySize: 1024, // Increase memory to help with response times


### PR DESCRIPTION
The topics example with CDK uses aws-sdk version 3 (`@aws-sdk/*` pattern).  This is excluded by default https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.BundlingOptions.html#externalmodules 

By specifying `aws-sdk` (version 2) as an external module in the bundling options you're overriding the default external modules which actually causes esbuild to bundle aws-sdk version 3 into the lambda.

This PR removes the incorrect `aws-sdk` (version 2) SDK from external modules so that CDK/esbuild will exclude the version of aws-sdk being used in the project.

cc: CDK fan @allenheltondev 😈 