### PR TITLE
fix: experimental metrics middleware should use the grpc message constructor name in emitted metrics instead of MiddlewareMessage

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
@@ -108,7 +108,7 @@ export abstract class ExperimentalMetricsMiddlewareRequestHandler
 
   onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
     this.requestSize = request.messageLength();
-    this.requestType = request.constructor.name;
+    this.requestType = request._grpcMessage.constructor.name;
     this.requestBodyTime = new Date().getTime();
     return Promise.resolve(request);
   }

--- a/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
@@ -29,7 +29,10 @@ export class MiddlewareMessage {
   }
 
   messageLength(): number {
-    return this._grpcMessage.serializeBinary().length;
+    if (this._grpcMessage !== null && this._grpcMessage !== undefined) {
+      return this._grpcMessage.serializeBinary().length;
+    }
+    return 0;
   }
 }
 

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -200,6 +200,7 @@ export {
 
 export {ExperimentalRequestLoggingMiddleware} from './config/middleware/experimental-request-logging-middleware';
 export {ExperimentalMetricsCsvMiddleware} from './config/middleware/experimental-metrics-csv-middleware';
+export {ExperimentalMetricsLoggingMiddleware} from './config/middleware/experimental-metrics-logging-middleware';
 export {ExampleAsyncMiddleware} from './config/middleware/example-async-middleware';
 
 export {

--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -61,7 +61,6 @@ export function middlewaresInterceptor(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             next: (message: any) => void
           ): void {
-            if (message !== undefined && message !== null) {
               applyMiddlewareHandlers(
                 'onResponseBody',
                 reversedMiddlewareRequestHandlers,
@@ -71,7 +70,6 @@ export function middlewaresInterceptor(
                 new MiddlewareMessage(message as Message),
                 (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
               );
-            }
           },
           onReceiveStatus: function (
             status: StatusObject,
@@ -100,7 +98,6 @@ export function middlewaresInterceptor(
       // unfortunately grpc uses `any` in their type defs for these
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sendMessage: function (message: any, next: (message: any) => void): void {
-        if (message !== undefined && message !== null) {
           applyMiddlewareHandlers(
             'onRequestBody',
             middlewareRequestHandlers,
@@ -109,9 +106,9 @@ export function middlewaresInterceptor(
             new MiddlewareMessage(message as Message),
             (m: MiddlewareMessage) => next(m._grpcMessage)
           );
-        }
       },
     };
+    console.log("\nCompleted creating the requester");
     return new InterceptingCall(nextCall(options), requester);
   };
 }

--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -61,15 +61,15 @@ export function middlewaresInterceptor(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             next: (message: any) => void
           ): void {
-              applyMiddlewareHandlers(
-                'onResponseBody',
-                reversedMiddlewareRequestHandlers,
-                (h: MiddlewareRequestHandler) =>
-                  (request: MiddlewareMessage | null) =>
-                    h.onResponseBody(request),
-                new MiddlewareMessage(message as Message),
-                (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
-              );
+            applyMiddlewareHandlers(
+              'onResponseBody',
+              reversedMiddlewareRequestHandlers,
+              (h: MiddlewareRequestHandler) =>
+                (request: MiddlewareMessage | null) =>
+                  h.onResponseBody(request),
+              new MiddlewareMessage(message as Message),
+              (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
+            );
           },
           onReceiveStatus: function (
             status: StatusObject,
@@ -98,17 +98,16 @@ export function middlewaresInterceptor(
       // unfortunately grpc uses `any` in their type defs for these
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sendMessage: function (message: any, next: (message: any) => void): void {
-          applyMiddlewareHandlers(
-            'onRequestBody',
-            middlewareRequestHandlers,
-            (h: MiddlewareRequestHandler) => (request: MiddlewareMessage) =>
-              h.onRequestBody(request),
-            new MiddlewareMessage(message as Message),
-            (m: MiddlewareMessage) => next(m._grpcMessage)
-          );
+        applyMiddlewareHandlers(
+          'onRequestBody',
+          middlewareRequestHandlers,
+          (h: MiddlewareRequestHandler) => (request: MiddlewareMessage) =>
+            h.onRequestBody(request),
+          new MiddlewareMessage(message as Message),
+          (m: MiddlewareMessage) => next(m._grpcMessage)
+        );
       },
     };
-    console.log("\nCompleted creating the requester");
     return new InterceptingCall(nextCall(options), requester);
   };
 }

--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -61,15 +61,17 @@ export function middlewaresInterceptor(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             next: (message: any) => void
           ): void {
-            applyMiddlewareHandlers(
-              'onResponseBody',
-              reversedMiddlewareRequestHandlers,
-              (h: MiddlewareRequestHandler) =>
-                (request: MiddlewareMessage | null) =>
-                  h.onResponseBody(request),
-              new MiddlewareMessage(message as Message),
-              (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
-            );
+            if (message != undefined && message != null) {
+              applyMiddlewareHandlers(
+                'onResponseBody',
+                reversedMiddlewareRequestHandlers,
+                (h: MiddlewareRequestHandler) =>
+                  (request: MiddlewareMessage | null) =>
+                    h.onResponseBody(request),
+                new MiddlewareMessage(message as Message),
+                (msg: MiddlewareMessage | null) => next(msg?._grpcMessage)
+              );
+            }
           },
           onReceiveStatus: function (
             status: StatusObject,
@@ -98,14 +100,16 @@ export function middlewaresInterceptor(
       // unfortunately grpc uses `any` in their type defs for these
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sendMessage: function (message: any, next: (message: any) => void): void {
-        applyMiddlewareHandlers(
-          'onRequestBody',
-          middlewareRequestHandlers,
-          (h: MiddlewareRequestHandler) => (request: MiddlewareMessage) =>
-            h.onRequestBody(request),
-          new MiddlewareMessage(message as Message),
-          (m: MiddlewareMessage) => next(m._grpcMessage)
-        );
+        if (message != undefined && message != null) {
+          applyMiddlewareHandlers(
+            'onRequestBody',
+            middlewareRequestHandlers,
+            (h: MiddlewareRequestHandler) => (request: MiddlewareMessage) =>
+              h.onRequestBody(request),
+            new MiddlewareMessage(message as Message),
+            (m: MiddlewareMessage) => next(m._grpcMessage)
+          );
+        }
       },
     };
     return new InterceptingCall(nextCall(options), requester);

--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -61,7 +61,7 @@ export function middlewaresInterceptor(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             next: (message: any) => void
           ): void {
-            if (message != undefined && message != null) {
+            if (message !== undefined && message !== null) {
               applyMiddlewareHandlers(
                 'onResponseBody',
                 reversedMiddlewareRequestHandlers,
@@ -100,7 +100,7 @@ export function middlewaresInterceptor(
       // unfortunately grpc uses `any` in their type defs for these
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sendMessage: function (message: any, next: (message: any) => void): void {
-        if (message != undefined && message != null) {
+        if (message !== undefined && message !== null) {
           applyMiddlewareHandlers(
             'onRequestBody',
             middlewareRequestHandlers,


### PR DESCRIPTION
Part of the CloudWatch metrics example work (see #970) in order to use requestType as a dimension on the dashboard graphs.

Also exports ExperimentalMetricsLoggingMiddleware at the top-level of the Node.js SDK and adds null and undefined checks for metrics messages (was running into issues with some middleware messages being undefined while working on #970).

Before this change:

>   [2023-10-30T22:05:13.777Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): 
>   {
>     "numActiveRequestsAtStart":1,
>     "numActiveRequestsAtFinish":1,
>     **"requestType":"MiddlewareMessage"**,
>     "status":0,"startTime":1698703513758,
>     "requestBodyTime":1698703513759,
>     "endTime":1698703513776,
>     "duration":18,
>     "requestSize":13,
>     "responseSize":9,
>     "connectionID":"1"
>   }
> 

After:

> [2023-10-30T22:17:17.087Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): 
> {
> "numActiveRequestsAtStart":1,
> "numActiveRequestsAtFinish":1,
> **"requestType":"_GetRequest"**,
> "status":0,
> "startTime":1698704237069,
> "requestBodyTime":1698704237070,
> "endTime":1698704237087,
> "duration":18,
> "requestSize":13,
> "responseSize":9,
> "connectionID":"3"
> }
