### PR TITLE
chore: relax auth test expiration window for CIs under high contention

### DIFF
--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prebuild": "eslint . --ext .ts",
     "test": "jest --testPathIgnorePatterns auth-client.test.ts --reporters=jest-silent-reporter",
-    "integration-test-auth": "jest auth-client.test.ts",
+    "integration-test-auth": "jest auth-client.test.ts --reporters=jest-silent-reporter",
     "integration-test-vector": "jest vector-control-plane.test.ts vector-data-plane.test.ts --reporters=jest-silent-reporter",
     "unit-test": "jest unit --reporters=jest-silent-reporter",
     "integration-test": "jest integration --reporters=jest-silent-reporter --testPathIgnorePatterns \"auth-client.test.ts|vector-control-plane.test.ts|vector-data-plane.test.ts\"",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "prebuild": "eslint . --ext .ts",
     "test": "jest --testPathIgnorePatterns auth-client.test.ts --reporters=jest-silent-reporter",
-    "integration-test-auth": "jest auth-client.test.ts --reporters=jest-silent-reporter",
+    "integration-test-auth": "jest auth-client.test.ts",
     "integration-test-vector": "jest vector-control-plane.test.ts vector-data-plane.test.ts --reporters=jest-silent-reporter",
     "unit-test": "jest unit --reporters=jest-silent-reporter",
     "integration-test": "jest integration --reporters=jest-silent-reporter --testPathIgnorePatterns \"auth-client.test.ts|vector-control-plane.test.ts|vector-data-plane.test.ts\"",

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -75,7 +75,8 @@ function sessionCredsProvider(): CredentialProvider {
 
 export function integrationTestCacheClientProps(): CacheClientProps {
   return {
-    configuration: Configurations.Laptop.latest(),
+    configuration:
+      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
     credentialProvider: credsProvider(),
     defaultTtlSeconds: 1111,
   };

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -69,18 +69,20 @@ export function runAuthClientTests(
       const secondsSinceEpoch = Math.round(Date.now() / 1000);
       const expireResponse = await sessionTokenAuthClient.generateApiKey(
         SUPER_USER_PERMISSIONS,
-        ExpiresIn.seconds(10)
+        ExpiresIn.minutes(5)
       );
-      const expiresIn = secondsSinceEpoch + 10;
+
+      const expiresIn = secondsSinceEpoch + 300;
 
       expect(expireResponse).toBeInstanceOf(GenerateApiKey.Success);
-
       const expireResponseSuccess = expireResponse as GenerateApiKey.Success;
       expect(expireResponseSuccess.is_success);
+      console.log(expiresIn);
+      console.log(expireResponseSuccess.expiresAt.epoch());
       expect(expireResponseSuccess.expiresAt.doesExpire());
       expect(expireResponseSuccess.expiresAt.epoch()).toBeWithin(
-        expiresIn - 1,
-        expiresIn + 2
+        expiresIn - 60,
+        expiresIn + 60
       );
     });
 

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -77,8 +77,6 @@ export function runAuthClientTests(
       expect(expireResponse).toBeInstanceOf(GenerateApiKey.Success);
       const expireResponseSuccess = expireResponse as GenerateApiKey.Success;
       expect(expireResponseSuccess.is_success);
-      console.log(expiresIn);
-      console.log(expireResponseSuccess.expiresAt.epoch());
       expect(expireResponseSuccess.expiresAt.doesExpire());
       expect(expireResponseSuccess.expiresAt.epoch()).toBeWithin(
         expiresIn - 60,


### PR DESCRIPTION
For https://github.com/momentohq/dev-eco-issue-tracker/issues/536

I have been observing failed CIs on this repo since a while and the most common culprits in my observation have been:

- 9/10 times it was the test in this PR that failed. The test essentially checks that the expiration duration of a token  generated at time `x` is within `y-1` and `y+1` where `y` is the expiration time returned by the server after the API call. The window here is small even though it does succeed locally in a loop of 1000 runs. I believe the reason it fails on CIs so frequently is either:
   - Event loop contention
   - Server side delay that might happen due to several things.
   - In one of my failed CIs, the drift was as high as 23 seconds 
   
```
generate auth token using session token credentials › should succeed for generating an api token that expires

    expect(received).toBeWithin(expected)

    Expected number to be within start (inclusive) and end (exclusive):
      start: 1698452568  end: 1698452571
    Received:
      1698452594

      79 |       expect(expireResponseSuccess.is_success);
      80 |       expect(expireResponseSuccess.expiresAt.doesExpire());
    > 81 |       expect(expireResponseSuccess.expiresAt.epoch()).toBeWithin(
         |                                                       ^
      82 |         expiresIn - 1,
      83 |         expiresIn + 2
      84 |       );
```
   

Instead of testing expirationTime at a second granularity with 1 second error margin, I have changed it to test at minute granularity with 1 minute error margin. This gives some breathing room for the CIs to succeed.

- The remaining errors i have seen are due to client side timeouts. I have increased the timeout to 60 seconds from 5 seconds for similar reasons of event loop contention (just a theory).
