### PR TITLE
chore: bump timeout/deadline for web sdk integ tests

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -88,7 +88,7 @@ function momentoClientForTesting(): CacheClient {
 
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
-    configuration: Configurations.Laptop.latest(),
+    configuration: Configurations.Laptop.latest().withClientTimeoutMillis(60000),
     credentialProvider: sessionCredsProvider(),
     defaultTtlSeconds: 1111,
   });

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -66,7 +66,7 @@ function sessionCredsProvider(): CredentialProvider {
 }
 
 export const IntegrationTestCacheClientProps: CacheClientProps = {
-  configuration: Configurations.Laptop.latest(),
+  configuration: Configurations.Laptop.latest().withClientTimeoutMillis(60000),
   credentialProvider: credsProvider(),
   defaultTtlSeconds: 1111,
 };
@@ -77,7 +77,8 @@ function momentoClientForTesting(): CacheClient {
 
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
-    configuration: Configurations.Laptop.latest(),
+    configuration:
+      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
     credentialProvider: sessionCredsProvider(),
     defaultTtlSeconds: 1111,
   });


### PR DESCRIPTION
Follow up for https://github.com/momentohq/client-sdk-javascript/pull/995 to web-sdk tests as well