### PR TITLE
chore: increase jest timeout limit

### DIFF
--- a/packages/client-sdk-nodejs/jest.config.ts
+++ b/packages/client-sdk-nodejs/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 30000,
+  testTimeout: 120000,
 };
 
 export default config;

--- a/packages/client-sdk-web/jest.config.ts
+++ b/packages/client-sdk-web/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 30000,
+  testTimeout: 120000,
   setupFiles: ['<rootDir>/jest.setup.js']
 };
 


### PR DESCRIPTION
Caused a couple of failures [[1](https://github.com/momentohq/client-sdk-javascript/actions/runs/6738387984/job/18317859420), [2](https://github.com/momentohq/client-sdk-javascript/actions/runs/6711852943/job/18240833612)] recently, including failing while publishing the web SDK to npmjs.

Increases the jest timeout so that each test can run for up to 2 minutes instead of 30 seconds. If the timeout should be increased or decreased, let me know.

