### PR TITLE
fix: extend jest timeout for common integration tests package

### DIFF
--- a/packages/common-integration-tests/jest.config.ts
+++ b/packages/common-integration-tests/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 30000,
+  testTimeout: 120000,
 };
 
 export default config;


### PR DESCRIPTION
Saw a recent failure in the sdk canary logs due to the 30 second jest timeout. 
Realized I'd missed one jest config file to update when doing #1003 to address flaky tests. 