### PR TITLE
chore: add `deploy` target for TVM to make it easier to deploy

### DIFF
--- a/examples/nodejs/token-vending-machine/README.md
+++ b/examples/nodejs/token-vending-machine/README.md
@@ -29,13 +29,6 @@ These three required configuration variables live in the [config.ts](./lambda/to
 
 ## Deploying the Token Vending Machine App
 
-First make sure to start Docker and install the dependencies in the `lambda` directory, which is where the AWS Lambda code lives.
-
-```bash
-cd lambda/token-vending-machine
-npm install
-```
-
 The source code for the CDK application lives in the `infrastructure` directory.
 To build and deploy it you will first need to install the dependencies:
 
@@ -51,7 +44,7 @@ You will also need a superuser API key generated from the [Momento Console](http
 Then run:
 
 ```
-npm run cdk -- deploy --parameters MomentoApiKey=<YOUR_MOMENTO_API_KEY>
+npm run deploy -- --parameters MomentoApiKey=<YOUR_MOMENTO_API_KEY>
 ```
 
 When the command completes, you should see something like this near the end of the output:

--- a/examples/nodejs/token-vending-machine/infrastructure/package.json
+++ b/examples/nodejs/token-vending-machine/infrastructure/package.json
@@ -10,6 +10,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
+    "deploy": "cd ../lambda/token-vending-machine && npm install && cd - && cdk deploy",
     "lint": "eslint . --ext .ts",
     "format": "eslint . --ext .ts --fix"
   },


### PR DESCRIPTION
This commit adds a `deploy` target to the token vending machine
and updates the README to use that for deploying instead of `cdk`.
The main motivation here is to automate the `npm install` step for
the lambda project, to prevent users from accidentally skipping it
and running into an error or deploying the lambda with an outdated
version of the dependencies.
