### PR TITLE
chore: update mvi examples

### DIFF
--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -35,7 +35,12 @@ async function example_API_CreateIndex(vectorClient: PreviewVectorIndexClient) {
 async function example_API_ListIndexes(vectorClient: PreviewVectorIndexClient) {
   const result = await vectorClient.listIndexes();
   if (result instanceof ListVectorIndexes.Success) {
-    console.log(`Indexes:\n${result.getIndexNames().join('\n')}\n\n`);
+    console.log(
+      `Indexes:\n${result
+        .getIndexes()
+        .map(index => JSON.stringify(index))
+        .join('\n')}\n\n`
+    );
   } else if (result instanceof ListVectorIndexes.Error) {
     throw new Error(`An error occurred while attempting to list caches: ${result.errorCode()}: ${result.toString()}`);
   }

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.42.0",
-        "@gomomento/sdk-core": "^1.42.0",
+        "@gomomento/sdk": "^1.47.0",
+        "@gomomento/sdk-core": "^1.47.0",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.84.2.tgz",
-      "integrity": "sha512-XLdMj82EgVXD7c3Bh72aOl7vRCVWRrHa8KvzJwYaaxT1hquLvrSsQEQd0GrHXyIJ8+XJ8W5nmFxZFqejOIn7ww==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.91.1.tgz",
+      "integrity": "sha512-4heYUA+bN1GMGQK10yRpt2gC9cdUYItAlCVthTISNT2nsq+onaZQL6gi7g574J25Cg9NlW4ilxqxhOEZDCCiiA==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -94,12 +94,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.42.1.tgz",
-      "integrity": "sha512-fdZ7IvQavwOgBZEHGOADTQjEpVA7/z44t47kyriPcOFeWl6K0d0RooM3Z5dGQc9DWyNzlpcvvWOV7b+B88LVsw==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.47.0.tgz",
+      "integrity": "sha512-K+Bw1ldll4vodE/0JsOuKyS/0XfiB0j073J48KS0x09DLg6KulxhYvDzRMgjlkGiVB1gO/EujdGXbrtr/J7v2Q==",
       "dependencies": {
-        "@gomomento/generated-types": "0.84.2",
-        "@gomomento/sdk-core": "1.42.1",
+        "@gomomento/generated-types": "0.91.1",
+        "@gomomento/sdk-core": "1.47.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -110,11 +110,11 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.42.1.tgz",
-      "integrity": "sha512-t7fTWBEffgtV8oar/SEZzjbrgrsRJnnDBblFMfsvP+aRPxgPS10WRICqVPdS9ML9nqwYRHQpy3oOwSUqhgN34Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.0.tgz",
+      "integrity": "sha512-XSWIaSPY+mq6eIyINuh9uc8Q7Xd1fPf8ql12hfD/MpDK0pit+R6eoqq/QMlRUXmioGrSGkxIHRecZjU1lLXoOA==",
       "dependencies": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       },
       "engines": {
@@ -3879,9 +3879,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.84.2.tgz",
-      "integrity": "sha512-XLdMj82EgVXD7c3Bh72aOl7vRCVWRrHa8KvzJwYaaxT1hquLvrSsQEQd0GrHXyIJ8+XJ8W5nmFxZFqejOIn7ww==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.91.1.tgz",
+      "integrity": "sha512-4heYUA+bN1GMGQK10yRpt2gC9cdUYItAlCVthTISNT2nsq+onaZQL6gi7g574J25Cg9NlW4ilxqxhOEZDCCiiA==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3890,12 +3890,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.42.1.tgz",
-      "integrity": "sha512-fdZ7IvQavwOgBZEHGOADTQjEpVA7/z44t47kyriPcOFeWl6K0d0RooM3Z5dGQc9DWyNzlpcvvWOV7b+B88LVsw==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.47.0.tgz",
+      "integrity": "sha512-K+Bw1ldll4vodE/0JsOuKyS/0XfiB0j073J48KS0x09DLg6KulxhYvDzRMgjlkGiVB1gO/EujdGXbrtr/J7v2Q==",
       "requires": {
-        "@gomomento/generated-types": "0.84.2",
-        "@gomomento/sdk-core": "1.42.1",
+        "@gomomento/generated-types": "0.91.1",
+        "@gomomento/sdk-core": "1.47.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3903,11 +3903,11 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.42.1.tgz",
-      "integrity": "sha512-t7fTWBEffgtV8oar/SEZzjbrgrsRJnnDBblFMfsvP+aRPxgPS10WRICqVPdS9ML9nqwYRHQpy3oOwSUqhgN34Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.0.tgz",
+      "integrity": "sha512-XSWIaSPY+mq6eIyINuh9uc8Q7Xd1fPf8ql12hfD/MpDK0pit+R6eoqq/QMlRUXmioGrSGkxIHRecZjU1lLXoOA==",
       "requires": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,8 +26,8 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.42.0",
-    "@gomomento/sdk-core": "^1.42.0",
+    "@gomomento/sdk": "^1.47.0",
+    "@gomomento/sdk-core": "^1.47.0",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -27,7 +27,12 @@ async function example_API_CreateIndex(vectorClient: PreviewVectorIndexClient) {
 async function example_API_ListIndexes(vectorClient: PreviewVectorIndexClient) {
   const result = await vectorClient.listIndexes();
   if (result instanceof ListVectorIndexes.Success) {
-    console.log(`Indexes:\n${result.getIndexNames().join('\n')}\n\n`);
+    console.log(
+      `Indexes:\n${result
+        .getIndexes()
+        .map(index => JSON.stringify(index))
+        .join('\n')}\n\n`
+    );
   } else if (result instanceof ListVectorIndexes.Error) {
     throw new Error(`An error occurred while attempting to list caches: ${result.errorCode()}: ${result.toString()}`);
   }

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.45.0",
+        "@gomomento/sdk-web": "^1.47.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,20 +82,20 @@
       }
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.87.0.tgz",
-      "integrity": "sha512-cXTwTaf7JFAolTjS78tSgZv+Ci/+7B6ZlPnD86wJeNUe3F1fuhz8auxQ7R75zOIXQX/0Xzj/0NQRhnIPnhEErw==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.91.1.tgz",
+      "integrity": "sha512-PomLd/UPHNYoaArjBg3us2FFGLd/xyRI0wfiMDRO795vEXAqstVdBvaqyXPL56QHR7u5ty2onaJ9pGfViQ41aQ==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.0.tgz",
-      "integrity": "sha512-FphHhFXDTsPGOlcE2YOyPrM9D6Tl5LuWyP6Ofb4KmSTExGKPLOyvHMKZClB7caHdP+wzFBF2PG4oCbIhVoc/JQ==",
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.1.tgz",
+      "integrity": "sha512-0BUVFtr1CLLo1n7GnWyjB7ggi1WO/GewI9AwW9vZV02C98c6Y9ZtY8P/QbNB0UO53DrPJY9k2oiZvyvQZj7IyA==",
       "dependencies": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       },
       "engines": {
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.45.0.tgz",
-      "integrity": "sha512-p6ZFPpPJcNJkJPe2XZLl/QtgcaCea7TvXKw4Ay1Sr7+wAk73q9LLLRfH3wlNZs3xGIYTY/HetL5rvLzCOumFHw==",
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.47.1.tgz",
+      "integrity": "sha512-EIp/oS5HDyxJjBsmqg65Cj6ZpuJ+AxKQxNm0gEA14rkHtDo+IrpXY8Tl2SzRqffl+NH4peMI0nGnrC/WYZxdpQ==",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.87.0",
-        "@gomomento/sdk-core": "1.45.0",
+        "@gomomento/generated-types-webtext": "0.91.1",
+        "@gomomento/sdk-core": "1.47.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -3308,30 +3308,30 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.87.0.tgz",
-      "integrity": "sha512-cXTwTaf7JFAolTjS78tSgZv+Ci/+7B6ZlPnD86wJeNUe3F1fuhz8auxQ7R75zOIXQX/0Xzj/0NQRhnIPnhEErw==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.91.1.tgz",
+      "integrity": "sha512-PomLd/UPHNYoaArjBg3us2FFGLd/xyRI0wfiMDRO795vEXAqstVdBvaqyXPL56QHR7u5ty2onaJ9pGfViQ41aQ==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.0.tgz",
-      "integrity": "sha512-FphHhFXDTsPGOlcE2YOyPrM9D6Tl5LuWyP6Ofb4KmSTExGKPLOyvHMKZClB7caHdP+wzFBF2PG4oCbIhVoc/JQ==",
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.1.tgz",
+      "integrity": "sha512-0BUVFtr1CLLo1n7GnWyjB7ggi1WO/GewI9AwW9vZV02C98c6Y9ZtY8P/QbNB0UO53DrPJY9k2oiZvyvQZj7IyA==",
       "requires": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.45.0.tgz",
-      "integrity": "sha512-p6ZFPpPJcNJkJPe2XZLl/QtgcaCea7TvXKw4Ay1Sr7+wAk73q9LLLRfH3wlNZs3xGIYTY/HetL5rvLzCOumFHw==",
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.47.1.tgz",
+      "integrity": "sha512-EIp/oS5HDyxJjBsmqg65Cj6ZpuJ+AxKQxNm0gEA14rkHtDo+IrpXY8Tl2SzRqffl+NH4peMI0nGnrC/WYZxdpQ==",
       "requires": {
-        "@gomomento/generated-types-webtext": "0.87.0",
-        "@gomomento/sdk-core": "1.45.0",
+        "@gomomento/generated-types-webtext": "0.91.1",
+        "@gomomento/sdk-core": "1.47.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.45.0",
+    "@gomomento/sdk-web": "^1.47.1",
     "jsdom": "22.1.0"
   }
 }


### PR DESCRIPTION
Updates the MVI Node.js and Web doc examples for the latest changes to list indexes. Bumps the dependencies in the two projects and updates list indexes response printing.
