### PR TITLE
fix: github deprecated set-output command

### DIFF
--- a/.github/workflows/on-push-to-release-branch.yml
+++ b/.github/workflows/on-push-to-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Output release
         id: release
-        run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
+        run: echo "release=${{ steps.semrel.outputs.version }}" >> $GITHUB_OUTPUT
   publish_javascript:
     # The type of runner that the job will run on
     runs-on: macos-latest


### PR DESCRIPTION
Issue: https://github.com/momentohq/dev-eco-issue-tracker/issues/560

[GitHub recommends](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) using the `$GITHUB_OUTPUT` environment variable instead.