### PR TITLE
chore: build in the same way on PRs and releases

### DIFF
--- a/scripts/update-package-versions.sh
+++ b/scripts/update-package-versions.sh
@@ -58,8 +58,6 @@ pushd ${ROOT_DIR}/packages/${PACKAGE}
     echo "New package.json:"
     cat package.json
     echo ""
-    npm ci
-    npm run build
-    npm run lint
-    npm run test
 popd
+
+${ROOT_DIR}/scripts/build-and-test-package.sh ${PACKAGE}


### PR DESCRIPTION
Run build-and-test-package.sh for each package being released instead of manually calling the build, lint, and test commands. This builds the release packages in the same way that pr packages are built.

Part of https://github.com/momentohq/dev-eco-issue-tracker/issues/546
Both scripts ran `npm run lint` already, so I don't know how the release job was failing on lint if a pr didn't, but this makes them use the same code at least.