### PR TITLE
chore: update generated types and consume searchhit score change

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.91.1",
+        "@gomomento/generated-types": "0.94.1",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
@@ -42,6 +42,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -73,6 +74,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1029,9 +1031,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.91.1.tgz",
-      "integrity": "sha512-4heYUA+bN1GMGQK10yRpt2gC9cdUYItAlCVthTISNT2nsq+onaZQL6gi7g574J25Cg9NlW4ilxqxhOEZDCCiiA==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.94.1.tgz",
+      "integrity": "sha512-ntivJkgYoPr2PT+TmP/svBReaDQoN0qdgtslQ11VbnlhPSBsz1oD4Z5l45EYtluLTAzMyGjsxbcC8LWjFlNXEQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -51,7 +51,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.91.1",
+    "@gomomento/generated-types": "0.94.1",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
     "@types/google-protobuf": "3.15.6",

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -273,7 +273,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               new VectorSearch.Success(
                 resp.hits.map(hit => ({
                   id: hit.id,
-                  score: hit.distance,
+                  score: hit.score,
                   metadata: hit.metadata.reduce((acc, metadata) => {
                     const field = metadata.field;
                     switch (metadata.value) {

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.91.1",
+        "@gomomento/generated-types-webtext": "0.94.1",
         "@gomomento/sdk-core": "file:../core",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -42,6 +42,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -73,6 +74,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1029,9 +1031,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.91.1.tgz",
-      "integrity": "sha512-PomLd/UPHNYoaArjBg3us2FFGLd/xyRI0wfiMDRO795vEXAqstVdBvaqyXPL56QHR7u5ty2onaJ9pGfViQ41aQ==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.94.1.tgz",
+      "integrity": "sha512-tpmRuN5VEtDbPi3ZL2nOg+7Cw+XfWhEUuuk8I/7vJ93kiIdCvHhumo3A8G1vtWMqNvFCZS0U67aKPhHq+mYGwg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -51,7 +51,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.91.1",
+    "@gomomento/generated-types-webtext": "0.94.1",
     "@gomomento/sdk-core": "file:../core",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -256,7 +256,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               new VectorSearch.Success(
                 resp.getHitsList().map(hit => ({
                   id: hit.getId(),
-                  score: hit.getDistance(),
+                  score: hit.getScore(),
                   metadata: hit.getMetadataList().reduce((acc, metadata) => {
                     const field = metadata.getField();
                     switch (metadata.getValueCase()) {


### PR DESCRIPTION
Updates generated types in Web SDK and Node JS packages and consumes the name change in `SearchHit` from `distance` to `score`.
