### PR TITLE
chore: code cleanup, standardize logging

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -78,27 +78,28 @@ export class CacheControlClient {
     } catch (err) {
       return new CreateCache.Error(normalizeSdkError(err as Error));
     }
-    this.logger.info(`Creating cache: ${name}`);
+    this.logger.debug(`Creating cache: ${name}`);
     const request = new grpcControl._CreateCacheRequest({
       cache_name: name,
     });
     return await new Promise<CreateCache.Response>(resolve => {
-      this.clientWrapper.getClient().CreateCache(
-        request,
-        {interceptors: this.interceptors},
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            if (err.code === Status.ALREADY_EXISTS) {
-              resolve(new CreateCache.AlreadyExists());
+      this.clientWrapper
+        .getClient()
+        .CreateCache(
+          request,
+          {interceptors: this.interceptors},
+          (err, _resp) => {
+            if (err) {
+              if (err.code === Status.ALREADY_EXISTS) {
+                resolve(new CreateCache.AlreadyExists());
+              } else {
+                resolve(new CreateCache.Error(cacheServiceErrorMapper(err)));
+              }
             } else {
-              resolve(new CreateCache.Error(cacheServiceErrorMapper(err)));
+              resolve(new CreateCache.Success());
             }
-          } else {
-            resolve(new CreateCache.Success());
           }
-        }
-      );
+        );
     });
   }
 
@@ -111,20 +112,21 @@ export class CacheControlClient {
     const request = new grpcControl._DeleteCacheRequest({
       cache_name: name,
     });
-    this.logger.info(`Deleting cache: ${name}`);
+    this.logger.debug(`Deleting cache: ${name}`);
     return await new Promise<DeleteCache.Response>(resolve => {
-      this.clientWrapper.getClient().DeleteCache(
-        request,
-        {interceptors: this.interceptors},
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
-          if (err) {
-            resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
-          } else {
-            resolve(new DeleteCache.Success());
+      this.clientWrapper
+        .getClient()
+        .DeleteCache(
+          request,
+          {interceptors: this.interceptors},
+          (err, _resp) => {
+            if (err) {
+              resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
+            } else {
+              resolve(new DeleteCache.Success());
+            }
           }
-        }
-      );
+        );
     });
   }
 
@@ -134,7 +136,7 @@ export class CacheControlClient {
     } catch (err) {
       return new CacheFlush.Error(normalizeSdkError(err as Error));
     }
-    this.logger.trace(`Flushing cache: ${cacheName}`);
+    this.logger.debug(`Flushing cache: ${cacheName}`);
     return await this.sendFlushCache(cacheName);
   }
 

--- a/packages/client-sdk-web/.eslintrc.json
+++ b/packages/client-sdk-web/.eslintrc.json
@@ -47,7 +47,16 @@
         // async without await is often an error and in other uses it obfuscates
         // the intent of the developer. Functions are async when they want to await.
         "require-await": "error",
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "caughtErrorsIgnorePattern": "^_"
+          }
+        ]
     },
     "settings": {
         "import/resolver": {

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -70,7 +70,7 @@ export class CacheControlClient<
     } catch (err) {
       return new CreateCache.Error(normalizeSdkError(err as Error));
     }
-    this.logger.info(`Creating cache: ${name}`);
+    this.logger.debug(`Creating cache: ${name}`);
     const request = new _CreateCacheRequest();
     request.setCacheName(name);
 
@@ -78,8 +78,7 @@ export class CacheControlClient<
       this.clientWrapper.createCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
+        (err, _resp) => {
           if (err) {
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateCache.AlreadyExists());
@@ -102,13 +101,12 @@ export class CacheControlClient<
     }
     const request = new _DeleteCacheRequest();
     request.setCacheName(name);
-    this.logger.info(`Deleting cache: ${name}`);
+    this.logger.debug(`Deleting cache: ${name}`);
     return await new Promise<DeleteCache.Response>(resolve => {
       this.clientWrapper.deleteCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        (err, resp) => {
+        (err, _resp) => {
           if (err) {
             resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
           } else {
@@ -138,7 +136,6 @@ export class CacheControlClient<
       this.clientWrapper.flushCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (resp) {
             resolve(new CacheFlush.Success());

--- a/packages/common-integration-tests/.eslintrc.json
+++ b/packages/common-integration-tests/.eslintrc.json
@@ -47,7 +47,16 @@
         // async without await is often an error and in other uses it obfuscates
         // the intent of the developer. Functions are async when they want to await.
         "require-await": "error",
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "caughtErrorsIgnorePattern": "^_"
+          }
+        ]
     },
     "settings": {
         "import/resolver": {

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -47,7 +47,16 @@
         // async without await is often an error and in other uses it obfuscates
         // the intent of the developer. Functions are async when they want to await.
         "require-await": "error",
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "caughtErrorsIgnorePattern": "^_"
+          }
+        ]
     },
     "settings": {
         "import/resolver": {


### PR DESCRIPTION
I noticed there were some places in our control plane clients where we where logging `this.logger.info` and other places where we were logging `this.logger.debug`. This commit just consolidates these. Also adds new eslint rule to ignore unused variables that start with `_`