### PR TITLE
fix: expiration.test.ts date.now()

### DIFF
--- a/packages/core/test/unit/utils/expiration.test.ts
+++ b/packages/core/test/unit/utils/expiration.test.ts
@@ -47,9 +47,7 @@ describe('Expiration', () => {
     });
 
     test('expiresAt.fromEpoch', () => {
-      const currentDate = new Date();
-      currentDate.setSeconds(currentDate.getSeconds() + 100);
-      const expiresAtEpoch = currentDate.getSeconds() / 1000;
+      const expiresAtEpoch = Date.now() / 1000;
       const expiresIn = ExpiresAt.fromEpoch(expiresAtEpoch);
 
       expect(expiresIn.doesExpire()).toBe(true);


### PR DESCRIPTION
`(new Date()).getSeconds()` returns the seconds of the date object. So can be any number between 0 and 59. `Date.now()` returns the epoch milliseconds. If we happened to get unlucky when the test ran and the seconds were at 0, then when we add 60 seconds to the date object, then seconds would still be 0, and our test would fail since our `expiresIn` would not expire