### PR TITLE
chore: update mvi api snippets to add searchAndFetchVectors

### DIFF
--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -6,6 +6,7 @@ import {
   PreviewVectorIndexClient,
   VectorIndexConfigurations,
   VectorSearch,
+  VectorSearchAndFetchVectors,
   VectorUpsertItemBatch,
   ALL_VECTOR_METADATA,
 } from '@gomomento/sdk';
@@ -95,6 +96,18 @@ async function example_API_Search(vectorClient: PreviewVectorIndexClient) {
   }
 }
 
+async function example_API_SearchAndFetchVectors(vectorClient: PreviewVectorIndexClient) {
+  const result = await vectorClient.searchAndFetchVectors('test-index', [1.0, 2.0], {
+    topK: 3,
+    metadataFields: ALL_VECTOR_METADATA,
+  });
+  if (result instanceof VectorSearchAndFetchVectors.Success) {
+    console.log(`Found ${result.hits().length} matches`);
+  } else if (result instanceof VectorSearchAndFetchVectors.Error) {
+    throw new Error(`An error occurred searching index test-index: ${result.errorCode()}: ${result.toString()}`);
+  }
+}
+
 async function main() {
   const vectorClient = new PreviewVectorIndexClient({
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
@@ -108,6 +121,7 @@ async function main() {
   await example_API_ListIndexes(vectorClient);
   await example_API_UpsertItemBatch(vectorClient);
   await example_API_Search(vectorClient);
+  await example_API_SearchAndFetchVectors(vectorClient);
   await example_API_DeleteItemBatch(vectorClient);
   await example_API_DeleteIndex(vectorClient);
 }

--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -7,8 +7,8 @@ import {
   VectorIndexConfigurations,
   VectorSearch,
   VectorUpsertItemBatch,
+  ALL_VECTOR_METADATA,
 } from '@gomomento/sdk';
-import {ALL_VECTOR_METADATA} from '@gomomento/sdk-core';
 
 function example_API_InstantiateVectorClient() {
   new PreviewVectorIndexClient({

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.47.0",
-        "@gomomento/sdk-core": "^1.47.0",
+        "@gomomento/sdk": "^1.48.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -83,9 +82,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.91.1.tgz",
-      "integrity": "sha512-4heYUA+bN1GMGQK10yRpt2gC9cdUYItAlCVthTISNT2nsq+onaZQL6gi7g574J25Cg9NlW4ilxqxhOEZDCCiiA==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.94.1.tgz",
+      "integrity": "sha512-ntivJkgYoPr2PT+TmP/svBReaDQoN0qdgtslQ11VbnlhPSBsz1oD4Z5l45EYtluLTAzMyGjsxbcC8LWjFlNXEQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -94,12 +93,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.47.0.tgz",
-      "integrity": "sha512-K+Bw1ldll4vodE/0JsOuKyS/0XfiB0j073J48KS0x09DLg6KulxhYvDzRMgjlkGiVB1gO/EujdGXbrtr/J7v2Q==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.48.1.tgz",
+      "integrity": "sha512-QEYg7WxL61WwPx8BfzNLHgh+JmSjo9P5tgXI2VUIAmiXPmn7JKP7pNKNPNttK+oaqMz3HYc21lgFfwdiPyMW0g==",
       "dependencies": {
-        "@gomomento/generated-types": "0.91.1",
-        "@gomomento/sdk-core": "1.47.0",
+        "@gomomento/generated-types": "0.94.1",
+        "@gomomento/sdk-core": "1.48.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -110,9 +109,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.0.tgz",
-      "integrity": "sha512-XSWIaSPY+mq6eIyINuh9uc8Q7Xd1fPf8ql12hfD/MpDK0pit+R6eoqq/QMlRUXmioGrSGkxIHRecZjU1lLXoOA==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
+      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -3879,9 +3878,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.91.1.tgz",
-      "integrity": "sha512-4heYUA+bN1GMGQK10yRpt2gC9cdUYItAlCVthTISNT2nsq+onaZQL6gi7g574J25Cg9NlW4ilxqxhOEZDCCiiA==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.94.1.tgz",
+      "integrity": "sha512-ntivJkgYoPr2PT+TmP/svBReaDQoN0qdgtslQ11VbnlhPSBsz1oD4Z5l45EYtluLTAzMyGjsxbcC8LWjFlNXEQ==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3890,12 +3889,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.47.0.tgz",
-      "integrity": "sha512-K+Bw1ldll4vodE/0JsOuKyS/0XfiB0j073J48KS0x09DLg6KulxhYvDzRMgjlkGiVB1gO/EujdGXbrtr/J7v2Q==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.48.1.tgz",
+      "integrity": "sha512-QEYg7WxL61WwPx8BfzNLHgh+JmSjo9P5tgXI2VUIAmiXPmn7JKP7pNKNPNttK+oaqMz3HYc21lgFfwdiPyMW0g==",
       "requires": {
-        "@gomomento/generated-types": "0.91.1",
-        "@gomomento/sdk-core": "1.47.0",
+        "@gomomento/generated-types": "0.94.1",
+        "@gomomento/sdk-core": "1.48.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -3903,9 +3902,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.0.tgz",
-      "integrity": "sha512-XSWIaSPY+mq6eIyINuh9uc8Q7Xd1fPf8ql12hfD/MpDK0pit+R6eoqq/QMlRUXmioGrSGkxIHRecZjU1lLXoOA==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
+      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,8 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.47.0",
-    "@gomomento/sdk-core": "^1.47.0",
+    "@gomomento/sdk": "^1.48.1",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -73,9 +73,9 @@ async function example_API_UpsertItemBatch(vectorClient: PreviewVectorIndexClien
 
 async function example_API_DeleteItemBatch(vectorClient: PreviewVectorIndexClient) {
   const result = await vectorClient.deleteItemBatch('test-index', ['example_item_1', 'example_item_2']);
-  if (result instanceof VectorUpsertItemBatch.Success) {
+  if (result instanceof VectorDeleteItemBatch.Success) {
     console.log('Successfully deleted items');
-  } else if (result instanceof VectorUpsertItemBatch.Error) {
+  } else if (result instanceof VectorDeleteItemBatch.Error) {
     throw new Error(`An error occurred while deleting items: ${result.errorCode()}: ${result.toString()}`);
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -4,6 +4,8 @@ import {
   ListVectorIndexes,
   PreviewVectorIndexClient,
   VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorDeleteItemBatch,
   VectorUpsertItemBatch,
   ALL_VECTOR_METADATA,
   Configurations,
@@ -87,6 +89,18 @@ async function example_API_Search(vectorClient: PreviewVectorIndexClient) {
   }
 }
 
+async function example_API_SearchAndFetchVectors(vectorClient: PreviewVectorIndexClient) {
+  const result = await vectorClient.searchAndFetchVectors('test-index', [1.0, 2.0], {
+    topK: 3,
+    metadataFields: ALL_VECTOR_METADATA,
+  });
+  if (result instanceof VectorSearchAndFetchVectors.Success) {
+    console.log(`Found ${result.hits().length} matches`);
+  } else if (result instanceof VectorSearchAndFetchVectors.Error) {
+    throw new Error(`An error occurred searching index test-index: ${result.errorCode()}: ${result.toString()}`);
+  }
+}
+
 async function main() {
   // Because the Momento Web SDK is intended for use in a browser, we use the JSDom library to set up an environment
   // that will allow us to use it in a node.js program.
@@ -99,6 +113,7 @@ async function main() {
   await example_API_ListIndexes(vectorClient);
   await example_API_UpsertItemBatch(vectorClient);
   await example_API_Search(vectorClient);
+  await example_API_SearchAndFetchVectors(vectorClient);
   await example_API_DeleteItemBatch(vectorClient);
   await example_API_DeleteIndex(vectorClient);
 }

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.47.1",
+        "@gomomento/sdk-web": "^1.48.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,18 +82,18 @@
       }
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.91.1.tgz",
-      "integrity": "sha512-PomLd/UPHNYoaArjBg3us2FFGLd/xyRI0wfiMDRO795vEXAqstVdBvaqyXPL56QHR7u5ty2onaJ9pGfViQ41aQ==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.94.1.tgz",
+      "integrity": "sha512-tpmRuN5VEtDbPi3ZL2nOg+7Cw+XfWhEUuuk8I/7vJ93kiIdCvHhumo3A8G1vtWMqNvFCZS0U67aKPhHq+mYGwg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.47.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.1.tgz",
-      "integrity": "sha512-0BUVFtr1CLLo1n7GnWyjB7ggi1WO/GewI9AwW9vZV02C98c6Y9ZtY8P/QbNB0UO53DrPJY9k2oiZvyvQZj7IyA==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
+      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.47.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.47.1.tgz",
-      "integrity": "sha512-EIp/oS5HDyxJjBsmqg65Cj6ZpuJ+AxKQxNm0gEA14rkHtDo+IrpXY8Tl2SzRqffl+NH4peMI0nGnrC/WYZxdpQ==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.48.1.tgz",
+      "integrity": "sha512-MvVCemITnKg+t2j/c5e2C4RItu3vJtKHL0DMgwguR9TjkWiKZHIxsTXk/yIhqgWRxGDP20SN5YBEwPjos5ct7Q==",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.91.1",
-        "@gomomento/sdk-core": "1.47.1",
+        "@gomomento/generated-types-webtext": "0.94.1",
+        "@gomomento/sdk-core": "1.48.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -3308,30 +3308,30 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.91.1.tgz",
-      "integrity": "sha512-PomLd/UPHNYoaArjBg3us2FFGLd/xyRI0wfiMDRO795vEXAqstVdBvaqyXPL56QHR7u5ty2onaJ9pGfViQ41aQ==",
+      "version": "0.94.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.94.1.tgz",
+      "integrity": "sha512-tpmRuN5VEtDbPi3ZL2nOg+7Cw+XfWhEUuuk8I/7vJ93kiIdCvHhumo3A8G1vtWMqNvFCZS0U67aKPhHq+mYGwg==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.47.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.47.1.tgz",
-      "integrity": "sha512-0BUVFtr1CLLo1n7GnWyjB7ggi1WO/GewI9AwW9vZV02C98c6Y9ZtY8P/QbNB0UO53DrPJY9k2oiZvyvQZj7IyA==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
+      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.47.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.47.1.tgz",
-      "integrity": "sha512-EIp/oS5HDyxJjBsmqg65Cj6ZpuJ+AxKQxNm0gEA14rkHtDo+IrpXY8Tl2SzRqffl+NH4peMI0nGnrC/WYZxdpQ==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.48.1.tgz",
+      "integrity": "sha512-MvVCemITnKg+t2j/c5e2C4RItu3vJtKHL0DMgwguR9TjkWiKZHIxsTXk/yIhqgWRxGDP20SN5YBEwPjos5ct7Q==",
       "requires": {
-        "@gomomento/generated-types-webtext": "0.91.1",
-        "@gomomento/sdk-core": "1.47.1",
+        "@gomomento/generated-types-webtext": "0.94.1",
+        "@gomomento/sdk-core": "1.48.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.47.1",
+    "@gomomento/sdk-web": "^1.48.1",
     "jsdom": "22.1.0"
   }
 }


### PR DESCRIPTION
Include doc API snippets in Web and Node.js for `searchAndFetchVectors`.

In the Node.js project, there was an extraneous dependency on sdk-core, which we remove.