### PR TITLE
chore: improve toString for IndexInfo and members

### DIFF
--- a/packages/common-integration-tests/src/vector-control-plane.ts
+++ b/packages/common-integration-tests/src/vector-control-plane.ts
@@ -13,6 +13,7 @@ import {
   ListVectorIndexes,
   MomentoErrorCode,
   VectorSimilarityMetric,
+  VectorIndexInfo,
 } from '@gomomento/sdk-core';
 
 export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
@@ -76,50 +77,47 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
 
     it.each([
       {
-        indexName: testIndexName(),
-        numDimensions: 10,
-        similarityMetric: VectorSimilarityMetric.INNER_PRODUCT,
+        indexInfo: new VectorIndexInfo(
+          testIndexName(),
+          10,
+          VectorSimilarityMetric.INNER_PRODUCT
+        ),
       },
       {
-        indexName: testIndexName(),
-        numDimensions: 20,
-        similarityMetric: VectorSimilarityMetric.EUCLIDEAN_SIMILARITY,
+        indexInfo: new VectorIndexInfo(
+          testIndexName(),
+          20,
+          VectorSimilarityMetric.EUCLIDEAN_SIMILARITY
+        ),
       },
       {
-        indexName: testIndexName(),
-        numDimensions: 30,
-        similarityMetric: VectorSimilarityMetric.COSINE_SIMILARITY,
+        indexInfo: new VectorIndexInfo(
+          testIndexName(),
+          30,
+          VectorSimilarityMetric.COSINE_SIMILARITY
+        ),
       },
-    ])(
-      'should create and list an index',
-      async ({indexName, numDimensions, similarityMetric}) => {
-        await WithIndex(
-          vectorClient,
-          indexName,
-          numDimensions,
-          similarityMetric,
-          async () => {
-            const listResponse = await vectorClient.listIndexes();
-            expectWithMessage(() => {
-              expect(listResponse).toBeInstanceOf(ListVectorIndexes.Success);
-            }, `expected SUCCESS but got ${listResponse.toString()}`);
-            if (listResponse instanceof ListVectorIndexes.Success) {
-              listResponse.getIndexes().forEach(indexInfo => {
-                if (indexInfo.name === indexName) {
-                  expect(indexInfo.numDimensions).toEqual(numDimensions);
-                  expect(indexInfo.similarityMetric).toEqual(similarityMetric);
-                }
-              });
-              expect(
-                listResponse
-                  .getIndexes()
-                  .map(indexInfo => indexInfo.name === indexName)
-              ).toBeTruthy();
-            }
+    ])('should create and list an index', async ({indexInfo}) => {
+      await WithIndex(
+        vectorClient,
+        indexInfo.name,
+        indexInfo.numDimensions,
+        indexInfo.similarityMetric,
+        async () => {
+          const listResponse = await vectorClient.listIndexes();
+          expectWithMessage(() => {
+            expect(listResponse).toBeInstanceOf(ListVectorIndexes.Success);
+          }, `expected SUCCESS but got ${listResponse.toString()}`);
+          if (listResponse instanceof ListVectorIndexes.Success) {
+            expect(
+              listResponse
+                .getIndexes()
+                .map(thisIndexInfo => thisIndexInfo.equals(indexInfo))
+            ).toBeTruthy();
           }
-        );
-      }
-    );
+        }
+      );
+    });
 
     it('should delete an index', async () => {
       const indexName = testIndexName();

--- a/packages/core/src/internal/clients/vector/IVectorIndexControlClient.ts
+++ b/packages/core/src/internal/clients/vector/IVectorIndexControlClient.ts
@@ -12,19 +12,19 @@ export enum VectorSimilarityMetric {
    * The cosine similarity between two vectors, ie the cosine of the angle between them.
    * Bigger is better. Ranges from -1 to 1.
    */
-  COSINE_SIMILARITY,
+  COSINE_SIMILARITY = 'COSINE_SIMILARITY',
 
   /**
    * The inner product between two vectors, ie the sum of the element-wise products.
    * Bigger is better. Ranges from 0 to infinity.
    */
-  INNER_PRODUCT,
+  INNER_PRODUCT = 'INNER_PRODUCT',
 
   /**
    * The Euclidean distance squared between two vectors, ie the sum of squared differences between each element.
    * Smaller is better. Ranges from 0 to infinity.
    */
-  EUCLIDEAN_SIMILARITY,
+  EUCLIDEAN_SIMILARITY = 'EUCLIDEAN_SIMILARITY',
 }
 
 export interface IVectorIndexControlClient {

--- a/packages/core/src/messages/responses/vector/list-vector-indexes.ts
+++ b/packages/core/src/messages/responses/vector/list-vector-indexes.ts
@@ -39,8 +39,8 @@ class _Success extends Response {
   }
 
   public override toString() {
-    const indexes = this.indexes.map(indexInfo => indexInfo.getName());
-    return super.toString() + ': ' + indexes.join(', ');
+    const indexes = this.indexes.map(indexInfo => indexInfo.toString());
+    return super.toString() + ': [' + indexes.join(', ') + ']';
   }
 }
 

--- a/packages/core/src/messages/vector-index-info.ts
+++ b/packages/core/src/messages/vector-index-info.ts
@@ -38,4 +38,16 @@ export class VectorIndexInfo {
   public get similarityMetric(): VectorSimilarityMetric {
     return this._similarityMetric;
   }
+
+  public toString(): string {
+    return `VectorIndexInfo(${this._name}, ${this._numDimensions}, ${this._similarityMetric})`;
+  }
+
+  public equals(other: VectorIndexInfo): boolean {
+    return (
+      this._name === other._name &&
+      this._numDimensions === other._numDimensions &&
+      this._similarityMetric === other._similarityMetric
+    );
+  }
 }

--- a/packages/core/test/unit/messages/responses/vector-index-info.test.ts
+++ b/packages/core/test/unit/messages/responses/vector-index-info.test.ts
@@ -1,0 +1,20 @@
+import {VectorSimilarityMetric, VectorIndexInfo} from '../../../../src';
+
+describe('vector-index-info.ts', () => {
+  it('should correctly instantiate a VectorIndexInfo object', () => {
+    const indexName = 'test-index';
+    const numDimensions = 10;
+    const similarityMetric = VectorSimilarityMetric.INNER_PRODUCT;
+    const vectorIndexInfo = new VectorIndexInfo(
+      indexName,
+      numDimensions,
+      similarityMetric
+    );
+    expect(vectorIndexInfo.name).toEqual(indexName);
+    expect(vectorIndexInfo.numDimensions).toEqual(numDimensions);
+    expect(vectorIndexInfo.similarityMetric).toEqual(similarityMetric);
+    expect(vectorIndexInfo.toString()).toEqual(
+      `VectorIndexInfo(${indexName}, ${numDimensions}, ${similarityMetric})`
+    );
+  });
+});

--- a/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
+++ b/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
@@ -1,0 +1,21 @@
+import {
+  VectorSimilarityMetric,
+  VectorIndexInfo,
+  ListVectorIndexes,
+} from '../../../../../src';
+
+describe('list-vector-indexes.ts', () => {
+  it('should correctly print a ListVectorIndexes.Success object', () => {
+    const indexes = [
+      new VectorIndexInfo(
+        'test-index',
+        10,
+        VectorSimilarityMetric.INNER_PRODUCT
+      ),
+    ];
+    const listIndexesResponse = new ListVectorIndexes.Success(indexes);
+    expect(listIndexesResponse.toString()).toEqual(
+      `Success: [VectorIndexInfo(test-index, 10, INNER_PRODUCT)]`
+    );
+  });
+});

--- a/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
+++ b/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
@@ -15,7 +15,7 @@ describe('list-vector-indexes.ts', () => {
     ];
     const listIndexesResponse = new ListVectorIndexes.Success(indexes);
     expect(listIndexesResponse.toString()).toEqual(
-      `Success: [VectorIndexInfo(test-index, 10, INNER_PRODUCT)]`
+      'Success: [VectorIndexInfo(test-index, 10, INNER_PRODUCT)]'
     );
   });
 });


### PR DESCRIPTION
This adds sensible toString implementations for
VectorSimilarityMetric, VectorIndexInfo, and
ListVectorIndexes.Success.

We also update the integration tests in light of this and add unit
tests for the to string and equals implementations on the messages.
