### PR TITLE
fix: import structure so dist folder has correct folder heirarchy

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -12,12 +12,12 @@
         "@gomomento/generated-types": "0.96.0",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
-        "@types/google-protobuf": "3.15.10",
         "@types/jest": "27.5.2",
         "@types/node": "14.18.3",
         "@types/uuid": "8.3.4",
@@ -1686,8 +1686,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.10",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
-      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g==",
-      "dev": true
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -31,7 +31,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
-    "@types/google-protobuf": "3.15.10",
     "@types/jest": "27.5.2",
     "@types/node": "14.18.3",
     "@types/uuid": "8.3.4",
@@ -55,6 +54,7 @@
     "@gomomento/generated-types": "0.96.0",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
+    "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"
   },

--- a/packages/client-sdk-nodejs/src/topic-client.ts
+++ b/packages/client-sdk-nodejs/src/topic-client.ts
@@ -3,7 +3,7 @@ import {MomentoLogger} from '.';
 import {PubsubClient} from './internal/pubsub-client';
 import {TopicClientProps} from './topic-client-props';
 import {IPubsubClient} from '@gomomento/sdk-core/dist/src/internal/clients';
-import {IWebhookClient} from '../../core/src/internal/clients/pubsub/IWebhookClient';
+import {IWebhookClient} from '@gomomento/sdk-core/dist/src/internal/clients/pubsub/IWebhookClient';
 import {WebhookClient} from './internal/webhook-client';
 
 /**

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -45,7 +45,6 @@
       }
     },
     "../common-integration-tests": {
-      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -77,7 +76,6 @@
       }
     },
     "../core": {
-      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2842,9 +2840,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.582",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
-      "integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA==",
+      "version": "1.4.583",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.583.tgz",
+      "integrity": "sha512-93y1gcONABZ7uqYe/JWDVQP/Pj/sQSunF0HVAPdlg/pfBnOyBMLlQUxWvkqcljJg1+W6cjvPuYD+r1Th9Tn8mA==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/packages/client-sdk-web/src/topic-client.ts
+++ b/packages/client-sdk-web/src/topic-client.ts
@@ -3,7 +3,7 @@ import {PubsubClient} from './internal/pubsub-client';
 import {TopicClientProps} from './topic-client-props';
 import {IPubsubClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {AbstractTopicClient} from '@gomomento/sdk-core/dist/src/internal/clients/pubsub/AbstractTopicClient';
-import {IWebhookClient} from '../../core/src/internal/clients/pubsub/IWebhookClient';
+import {IWebhookClient} from '@gomomento/sdk-core/dist/src/internal/clients/pubsub/IWebhookClient';
 import {WebhookClient} from './internal/webhook-client';
 
 /**


### PR DESCRIPTION
We are seeing issues installing the lastest nodejs `1.50.4` sdk. On main, when building the nodejs sdk, the dist output looks like

```
dist
├── client-sdk-web
│   ├── package.json
│   ├── src
│   └── test
└── core
    └── src
```

It is expecting 

```
dist/src/index.js
```
This is resulting in an error `Unable to resolve path to module '@gomomento/sdk'` when trying to install the sdk.

It looks like this has to do with some of our imports for the webhooks client coming from `../core/...` vs `@gomoment-core/dist/...`. 

I have tested this change locally on my box, `npm pack` the sdks, installing them in examples, and making sure they will work. I will fast follow this with a pr that will add some steps to our build to ensure that the `dist` folder has the correct folder structure. But I want to get this out first 