### PR TITLE
chore: tweak vector index info to string to quote string fields

### DIFF
--- a/packages/core/src/messages/vector-index-info.ts
+++ b/packages/core/src/messages/vector-index-info.ts
@@ -40,7 +40,7 @@ export class VectorIndexInfo {
   }
 
   public toString(): string {
-    return `VectorIndexInfo(${this._name}, ${this._numDimensions}, ${this._similarityMetric})`;
+    return `VectorIndexInfo('${this._name}', ${this._numDimensions}, '${this._similarityMetric}')`;
   }
 
   public equals(other: VectorIndexInfo): boolean {

--- a/packages/core/test/unit/messages/responses/vector-index-info.test.ts
+++ b/packages/core/test/unit/messages/responses/vector-index-info.test.ts
@@ -14,7 +14,7 @@ describe('vector-index-info.ts', () => {
     expect(vectorIndexInfo.numDimensions).toEqual(numDimensions);
     expect(vectorIndexInfo.similarityMetric).toEqual(similarityMetric);
     expect(vectorIndexInfo.toString()).toEqual(
-      `VectorIndexInfo(${indexName}, ${numDimensions}, ${similarityMetric})`
+      `VectorIndexInfo('${indexName}', ${numDimensions}, '${similarityMetric}')`
     );
   });
 });

--- a/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
+++ b/packages/core/test/unit/messages/responses/vector/list-vector-indexes.test.ts
@@ -15,7 +15,7 @@ describe('list-vector-indexes.ts', () => {
     ];
     const listIndexesResponse = new ListVectorIndexes.Success(indexes);
     expect(listIndexesResponse.toString()).toEqual(
-      'Success: [VectorIndexInfo(test-index, 10, INNER_PRODUCT)]'
+      "Success: [VectorIndexInfo('test-index', 10, 'INNER_PRODUCT')]"
     );
   });
 });


### PR DESCRIPTION
We add quoting on the to VectorIndexInfo string fields on `toString`
for clarity.
