### PR TITLE
chore: update mvi examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,7 @@ jobs:
           pushd examples/nodejs/vector-index
             npm ci
             npm run build
-            # TODO re-enable once we update the example to use the new SDK
-            #npm run validate-examples
+            npm run validate-examples
           popd
           pushd examples/nodejs/rate-limiter
             npm ci
@@ -213,8 +212,7 @@ jobs:
           pushd examples/web/vector-index
             npm ci
             npm run build
-            # TODO re-enable once we update the example to use the new SDK
-            #npm run validate-examples
+            npm run validate-examples
           popd
 
       - name: Send CI failure mail

--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -39,7 +39,7 @@ async function example_API_ListIndexes(vectorClient: PreviewVectorIndexClient) {
     console.log(
       `Indexes:\n${result
         .getIndexes()
-        .map(index => JSON.stringify(index))
+        .map(index => index.toString())
         .join('\n')}\n\n`
     );
   } else if (result instanceof ListVectorIndexes.Error) {

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.48.1",
+        "@gomomento/sdk": "^1.51.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.94.1.tgz",
-      "integrity": "sha512-ntivJkgYoPr2PT+TmP/svBReaDQoN0qdgtslQ11VbnlhPSBsz1oD4Z5l45EYtluLTAzMyGjsxbcC8LWjFlNXEQ==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.96.0.tgz",
+      "integrity": "sha512-o4bTdJ/PIkvEMZU4IHcrOGyiAxAnrkHZKFlIDmcmEki2zIvpj7Pqkp+7TqQ6BIH6gVo+IOmTecP56HADVUdM9g==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -93,14 +93,14 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.48.1.tgz",
-      "integrity": "sha512-QEYg7WxL61WwPx8BfzNLHgh+JmSjo9P5tgXI2VUIAmiXPmn7JKP7pNKNPNttK+oaqMz3HYc21lgFfwdiPyMW0g==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.51.1.tgz",
+      "integrity": "sha512-VldUEt9c2LZahGvqSlebkxHnVqFkv+cjk7d6riOqD26NnwyCBhjZ5wH92OWvEfssQKpGTz5CWkRqZpHC0q0UZA==",
       "dependencies": {
-        "@gomomento/generated-types": "0.94.1",
-        "@gomomento/sdk-core": "1.48.1",
+        "@gomomento/generated-types": "0.96.0",
+        "@gomomento/sdk-core": "1.51.1",
         "@grpc/grpc-js": "1.9.0",
-        "@types/google-protobuf": "3.15.6",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
-      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.51.1.tgz",
+      "integrity": "sha512-u6x5Gpi+sVYNcyRpEfoSJJ3YTTyLG6889QkPo3Z/e6hjNQD51h1Xf52eG1P9numzWWixlStEXIJp3H4hqsZ2vA==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@types/google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "version": "3.15.10",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -3878,9 +3878,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.94.1.tgz",
-      "integrity": "sha512-ntivJkgYoPr2PT+TmP/svBReaDQoN0qdgtslQ11VbnlhPSBsz1oD4Z5l45EYtluLTAzMyGjsxbcC8LWjFlNXEQ==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.96.0.tgz",
+      "integrity": "sha512-o4bTdJ/PIkvEMZU4IHcrOGyiAxAnrkHZKFlIDmcmEki2zIvpj7Pqkp+7TqQ6BIH6gVo+IOmTecP56HADVUdM9g==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3889,22 +3889,22 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.48.1.tgz",
-      "integrity": "sha512-QEYg7WxL61WwPx8BfzNLHgh+JmSjo9P5tgXI2VUIAmiXPmn7JKP7pNKNPNttK+oaqMz3HYc21lgFfwdiPyMW0g==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.51.1.tgz",
+      "integrity": "sha512-VldUEt9c2LZahGvqSlebkxHnVqFkv+cjk7d6riOqD26NnwyCBhjZ5wH92OWvEfssQKpGTz5CWkRqZpHC0q0UZA==",
       "requires": {
-        "@gomomento/generated-types": "0.94.1",
-        "@gomomento/sdk-core": "1.48.1",
+        "@gomomento/generated-types": "0.96.0",
+        "@gomomento/sdk-core": "1.51.1",
         "@grpc/grpc-js": "1.9.0",
-        "@types/google-protobuf": "3.15.6",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
-      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.51.1.tgz",
+      "integrity": "sha512-u6x5Gpi+sVYNcyRpEfoSJJ3YTTyLG6889QkPo3Z/e6hjNQD51h1Xf52eG1P9numzWWixlStEXIJp3H4hqsZ2vA==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -4049,9 +4049,9 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
     },
     "@types/google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "version": "3.15.10",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "@types/json-schema": {
       "version": "7.0.12",

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.48.1",
+    "@gomomento/sdk": "^1.51.1",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -32,7 +32,7 @@ async function example_API_ListIndexes(vectorClient: PreviewVectorIndexClient) {
     console.log(
       `Indexes:\n${result
         .getIndexes()
-        .map(index => JSON.stringify(index))
+        .map(index => index.toString())
         .join('\n')}\n\n`
     );
   } else if (result instanceof ListVectorIndexes.Error) {

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.48.1",
+        "@gomomento/sdk-web": "^1.51.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,18 +82,18 @@
       }
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.94.1.tgz",
-      "integrity": "sha512-tpmRuN5VEtDbPi3ZL2nOg+7Cw+XfWhEUuuk8I/7vJ93kiIdCvHhumo3A8G1vtWMqNvFCZS0U67aKPhHq+mYGwg==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.96.0.tgz",
+      "integrity": "sha512-P5j1i3ZFWido7XSX7RtXo486om6StBYkjjqDTYi3c8r/hzZikLC69mjQey3SY5RCbvWTeMdVl1rK6bI8qhh17Q==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
-      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.51.1.tgz",
+      "integrity": "sha512-u6x5Gpi+sVYNcyRpEfoSJJ3YTTyLG6889QkPo3Z/e6hjNQD51h1Xf52eG1P9numzWWixlStEXIJp3H4hqsZ2vA==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.48.1.tgz",
-      "integrity": "sha512-MvVCemITnKg+t2j/c5e2C4RItu3vJtKHL0DMgwguR9TjkWiKZHIxsTXk/yIhqgWRxGDP20SN5YBEwPjos5ct7Q==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.51.1.tgz",
+      "integrity": "sha512-40c9GG3XNB0o5keJdPIppv5zyRsZevJ6DQsIMA83q8f5PO2CJ2KdPSFFCuAXHQ7RTU+jwYatVSErrIyrz1ecYA==",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.94.1",
-        "@gomomento/sdk-core": "1.48.1",
+        "@gomomento/generated-types-webtext": "0.96.0",
+        "@gomomento/sdk-core": "1.51.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -3308,30 +3308,30 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.94.1.tgz",
-      "integrity": "sha512-tpmRuN5VEtDbPi3ZL2nOg+7Cw+XfWhEUuuk8I/7vJ93kiIdCvHhumo3A8G1vtWMqNvFCZS0U67aKPhHq+mYGwg==",
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.96.0.tgz",
+      "integrity": "sha512-P5j1i3ZFWido7XSX7RtXo486om6StBYkjjqDTYi3c8r/hzZikLC69mjQey3SY5RCbvWTeMdVl1rK6bI8qhh17Q==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.48.1.tgz",
-      "integrity": "sha512-kuVo17loBcdLxo7hM7nFTzljruz7E3rMGaOSQdtXYTItE4JLi/HU7odFF/dyswqJpdG2Te2tKIuNBqKGWdD1dA==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.51.1.tgz",
+      "integrity": "sha512-u6x5Gpi+sVYNcyRpEfoSJJ3YTTyLG6889QkPo3Z/e6hjNQD51h1Xf52eG1P9numzWWixlStEXIJp3H4hqsZ2vA==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.48.1.tgz",
-      "integrity": "sha512-MvVCemITnKg+t2j/c5e2C4RItu3vJtKHL0DMgwguR9TjkWiKZHIxsTXk/yIhqgWRxGDP20SN5YBEwPjos5ct7Q==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.51.1.tgz",
+      "integrity": "sha512-40c9GG3XNB0o5keJdPIppv5zyRsZevJ6DQsIMA83q8f5PO2CJ2KdPSFFCuAXHQ7RTU+jwYatVSErrIyrz1ecYA==",
       "requires": {
-        "@gomomento/generated-types-webtext": "0.94.1",
-        "@gomomento/sdk-core": "1.48.1",
+        "@gomomento/generated-types-webtext": "0.96.0",
+        "@gomomento/sdk-core": "1.51.1",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.48.1",
+    "@gomomento/sdk-web": "^1.51.1",
     "jsdom": "22.1.0"
   }
 }


### PR DESCRIPTION
Update MVI examples to consume latest SDKs and pretty print index info. Re-enables running vector index examples in CI.