### PR TITLE
feat: add mvi methods for get item (metadata)? batch

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.96.0",
+        "@gomomento/generated-types": "0.97.1",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
@@ -133,30 +133,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
+        "@babel/helpers": "^7.23.5",
+        "@babel/parser": "^7.23.5",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -172,12 +172,12 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -265,12 +265,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.3",
+        "@babel/types": "^7.23.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -421,32 +421,32 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -529,9 +529,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -732,12 +732,12 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -816,19 +816,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/parser": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -837,12 +837,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -930,12 +930,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -1029,9 +1029,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.96.0.tgz",
-      "integrity": "sha512-o4bTdJ/PIkvEMZU4IHcrOGyiAxAnrkHZKFlIDmcmEki2zIvpj7Pqkp+7TqQ6BIH6gVo+IOmTecP56HADVUdM9g==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
+      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -1641,9 +1641,9 @@
       "dev": true
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.4.tgz",
-      "integrity": "sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -1747,9 +1747,9 @@
       "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg=="
     },
     "node_modules/@types/semver": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -1765,9 +1765,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.31.tgz",
-      "integrity": "sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "dev": true,
       "funding": [
         {
@@ -2432,9 +2432,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
       "bin": {
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001566",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
       "dev": true,
       "funding": [
         {
@@ -2828,9 +2828,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.588",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.588.tgz",
-      "integrity": "sha512-soytjxwbgcCu7nh5Pf4S2/4wa6UIu+A3p03U2yVr53qGxi1/VTR3ENI+p50v+UxqqZAfl48j3z55ud7VHIOr9w==",
+      "version": "1.4.604",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.604.tgz",
+      "integrity": "sha512-JAJ4lyLJYudlgJPYJicimU9R+qZ/3iyeyQS99bfT7PWi7psYWeN84lPswTjpHxQueU34PKxM/IJzQS6poYlovQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4983,12 +4983,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -5792,9 +5792,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/nopt": {
@@ -5870,13 +5870,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -7298,9 +7298,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -51,7 +51,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.96.0",
+    "@gomomento/generated-types": "0.97.1",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -9,6 +9,7 @@ import {
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorIndexMetadata,
   VectorIndexItem,
   VectorUpsertItemBatch,
   VectorIndexStoredItem,
@@ -268,7 +269,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   private static deserializeMetadata(
     metadata: vectorindex._Metadata[],
     errorCallback: () => void
-  ): Record<string, string | number | boolean | Array<string>> {
+  ): VectorIndexMetadata {
     return metadata.reduce((acc, metadata) => {
       const field = metadata.field;
       switch (metadata.value) {
@@ -292,7 +293,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           break;
       }
       return acc;
-    }, {} as Record<string, string | number | boolean | Array<string>>);
+    }, {} as VectorIndexMetadata);
   }
 
   private async sendSearch(
@@ -550,7 +551,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
                       break;
                   }
                   return acc;
-                }, {} as Record<string, Record<string, string | number | boolean | Array<string>>>)
+                }, {} as Record<string, VectorIndexMetadata>)
               )
             );
           } else {

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -1,6 +1,5 @@
 import {version} from '../../package.json';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
-import {VectorIndexItem} from '@gomomento/sdk-core/dist/src/messages/vector-index';
 import {
   CredentialProvider,
   InvalidArgumentError,
@@ -10,7 +9,9 @@ import {
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorIndexItem,
   VectorUpsertItemBatch,
+  VectorIndexStoredItem,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
 } from '@gomomento/sdk-core';
@@ -476,7 +477,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
                       break;
                   }
                   return acc;
-                }, {} as Record<string, VectorIndexItem>)
+                }, {} as Record<string, VectorIndexStoredItem>)
               )
             );
           } else {

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -432,6 +432,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemBatchRequest({
       index_name: indexName,
       ids: ids,
+      metadata_fields: VectorIndexDataClient.prepareMetadataRequest({
+        metadataFields: ALL_VECTOR_METADATA,
+      }),
     });
     return await new Promise(resolve => {
       this.client.GetItemBatch(
@@ -505,6 +508,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemMetadataBatchRequest({
       index_name: indexName,
       ids: ids,
+      metadata_fields: VectorIndexDataClient.prepareMetadataRequest({
+        metadataFields: ALL_VECTOR_METADATA,
+      }),
     });
     return await new Promise(resolve => {
       this.client.GetItemMetadataBatch(

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.96.0",
+        "@gomomento/generated-types-webtext": "0.97.1",
         "@gomomento/sdk-core": "file:../core",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -30,7 +30,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "jest": "29.7.0",
-        "jest-ci-spec-reporter": "^1.0.3",
+        "jest-ci-spec-reporter": "1.0.3",
         "jest-environment-jsdom": "^29.7.0",
         "jest-extended": "4.0.2",
         "prettier": "2.8.8",
@@ -45,6 +45,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -76,6 +77,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1032,9 +1034,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.96.0.tgz",
-      "integrity": "sha512-P5j1i3ZFWido7XSX7RtXo486om6StBYkjjqDTYi3c8r/hzZikLC69mjQey3SY5RCbvWTeMdVl1rK6bI8qhh17Q==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.97.1.tgz",
+      "integrity": "sha512-7Rjz2gPwyRo3L/bnU5eo0a0g7LjijF3pDDkN4yParUOO+DMbuRe4LTBtuvMVU3p1rmp6Y2LXr/9o7av8MW9wWg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -56,7 +56,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.96.0",
+    "@gomomento/generated-types-webtext": "0.97.1",
     "@gomomento/sdk-core": "file:../core",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -421,6 +421,11 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemBatchRequest();
     request.setIndexName(indexName);
     request.setIdsList(ids);
+    request.setMetadataFields(
+      VectorIndexDataClient.prepareMetadataRequest({
+        metadataFields: ALL_VECTOR_METADATA,
+      })
+    );
 
     return await new Promise(resolve => {
       this.client.getItemBatch(
@@ -499,6 +504,11 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemMetadataBatchRequest();
     request.setIndexName(indexName);
     request.setIdsList(ids);
+    request.setMetadataFields(
+      VectorIndexDataClient.prepareMetadataRequest({
+        metadataFields: ALL_VECTOR_METADATA,
+      })
+    );
 
     return await new Promise(resolve => {
       this.client.getItemMetadataBatch(

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -7,6 +7,7 @@ import {
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorIndexMetadata,
   VectorIndexItem,
   VectorUpsertItemBatch,
   VectorIndexStoredItem,
@@ -241,7 +242,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   private static deserializeMetadata(
     metadata: vectorindex._Metadata[],
     errorCallback: () => void
-  ): Record<string, string | number | boolean | Array<string>> {
+  ): VectorIndexMetadata {
     return metadata.reduce((acc, metadata) => {
       const field = metadata.getField();
       switch (metadata.getValueCase()) {
@@ -265,7 +266,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           break;
       }
       return acc;
-    }, {} as Record<string, string | number | boolean | Array<string>>);
+    }, {} as VectorIndexMetadata);
   }
 
   private async sendSearch(
@@ -555,7 +556,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
                         break;
                     }
                     return acc;
-                  }, {} as Record<string, Record<string, string | number | boolean | Array<string>>>)
+                  }, {} as Record<string, VectorIndexMetadata>)
               )
             );
           } else {

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -1,14 +1,15 @@
 import {VectorIndexClient} from '@gomomento/generated-types-webtext/dist/VectorindexServiceClientPb';
 import * as vectorindex from '@gomomento/generated-types-webtext/dist/vectorindex_pb';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
-import {VectorIndexItem} from '@gomomento/sdk-core/dist/src/messages/vector-index';
 import {
   MomentoLogger,
   SearchOptions,
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorIndexItem,
   VectorUpsertItemBatch,
+  VectorIndexStoredItem,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
   InvalidArgumentError,
@@ -472,7 +473,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
                       break;
                   }
                   return acc;
-                }, {} as Record<string, VectorIndexItem>)
+                }, {} as Record<string, VectorIndexStoredItem>)
               )
             );
           } else {

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1114,6 +1114,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
           test_item_1: {
             key1: 'value1',
           },
+          test_item_2: {},
         },
       },
     ])(

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1103,6 +1103,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
           test_item_2: {
             id: 'test_item_2',
             vector: [3.0, 4.0],
+            metadata: {},
           },
         },
       },
@@ -1118,7 +1119,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         },
       },
     ])(
-      'should get item metadata',
+      'should get items and get item metadata',
       async ({getMethodName, ids, expectedResponse, hits}) => {
         const indexName = testIndexName();
         await WithIndex(

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1051,7 +1051,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         hits: {},
       },
       {
-        getMethodName: 'getItemMetdataBatch',
+        getMethodName: 'getItemMetadataBatch',
         ids: [],
         expectedResponse: VectorGetItemMetadataBatch.Success,
         hits: {},

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -8,6 +8,8 @@ import {
   SearchOptions,
   VectorSearchAndFetchVectors,
   VectorIndexItem,
+  VectorGetItemBatch,
+  VectorGetItemMetadataBatch,
 } from '@gomomento/sdk-core';
 import {
   expectWithMessage,
@@ -1011,5 +1013,153 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         }
       );
     });
+  });
+
+  describe('getItemBatch and getItemMetadataBatch', () => {
+    /*
+     * In the following tests we test both search and searchAndFetchVectors with a common
+     * suite of tests. To do this we abstract away calling the search method, building the hits
+     * (which may or may not contain the vectors), and asserting the results.
+     *
+     * We have two helpers to do this: search and buildSearchHits. The search method calls the
+     * appropriate search method on the vector client. The buildSearchHits method takes the
+     * search hits and the search method name and returns the expected search hits.
+     */
+
+    async function get(
+      vectorClient: IVectorIndexClient,
+      getMethodName: string,
+      indexName: string,
+      ids: string[]
+    ): Promise<
+      VectorGetItemBatch.Response | VectorGetItemMetadataBatch.Response
+    > {
+      if (getMethodName === 'getItemBatch') {
+        return await vectorClient.getItemBatch(indexName, ids);
+      } else if (getMethodName === 'getItemMetadataBatch') {
+        return await vectorClient.getItemMetadataBatch(indexName, ids);
+      } else {
+        throw new Error(`unknown search method ${getMethodName}`);
+      }
+    }
+
+    it.each([
+      {
+        getMethodName: 'getItemBatch',
+        ids: [],
+        expectedResponse: VectorGetItemBatch.Success,
+        hits: {},
+      },
+      {
+        getMethodName: 'getItemMetdataBatch',
+        ids: [],
+        expectedResponse: VectorGetItemMetadataBatch.Success,
+        hits: {},
+      },
+      {
+        getMethodName: 'getItemBatch',
+        ids: ['test_item_1'],
+        expectedResponse: VectorGetItemBatch.Success,
+        hits: {
+          test_item_1: {
+            id: 'test_item_1',
+            vector: [1.0, 2.0],
+            metadata: {key1: 'value1'},
+          },
+        },
+      },
+      {
+        getMethodName: 'getItemMetadataBatch',
+        ids: ['test_item_1'],
+        expectedResponse: VectorGetItemMetadataBatch.Success,
+        hits: {
+          test_item_1: {
+            key1: 'value1',
+          },
+        },
+      },
+      {
+        getMethodName: 'getItemBatch',
+        ids: ['missing_id'],
+        expectedResponse: VectorGetItemBatch.Success,
+        hits: {},
+      },
+      {
+        getMethodName: 'getItemMetadataBatch',
+        ids: ['missing_id'],
+        expectedResponse: VectorGetItemMetadataBatch.Success,
+        hits: {},
+      },
+      {
+        getMethodName: 'getItemBatch',
+        ids: ['test_item_1', 'missing_id_2', 'test_item_2'],
+        expectedResponse: VectorGetItemBatch.Success,
+        hits: {
+          test_item_1: {
+            id: 'test_item_1',
+            vector: [1.0, 2.0],
+            metadata: {key1: 'value1'},
+          },
+          test_item_2: {
+            id: 'test_item_2',
+            vector: [3.0, 4.0],
+          },
+        },
+      },
+      {
+        getMethodName: 'getItemMetadataBatch',
+        ids: ['test_item_1', 'missing_id_2', 'test_item_2'],
+        expectedResponse: VectorGetItemMetadataBatch.Success,
+        hits: {
+          test_item_1: {
+            key1: 'value1',
+          },
+        },
+      },
+    ])(
+      'should get item metadata',
+      async ({getMethodName, ids, expectedResponse, hits}) => {
+        const indexName = testIndexName();
+        await WithIndex(
+          vectorClient,
+          indexName,
+          2,
+          VectorSimilarityMetric.INNER_PRODUCT,
+          async () => {
+            const upsertResponse = await vectorClient.upsertItemBatch(
+              indexName,
+              [
+                {
+                  id: 'test_item_1',
+                  vector: [1.0, 2.0],
+                  metadata: {key1: 'value1'},
+                },
+                {id: 'test_item_2', vector: [3.0, 4.0]},
+                {id: 'test_item_3', vector: [5.0, 6.0]},
+              ]
+            );
+            expectWithMessage(() => {
+              expect(upsertResponse).toBeInstanceOf(
+                VectorUpsertItemBatch.Success
+              );
+            }, `expected SUCCESS but got ${upsertResponse.toString()}}`);
+
+            await sleep(2_000);
+
+            const getResponse = await get(
+              vectorClient,
+              getMethodName,
+              indexName,
+              ids
+            );
+            expectWithMessage(() => {
+              expect(getResponse).toBeInstanceOf(expectedResponse);
+            }, `expected SUCCESS but got ${getResponse.toString()}}`);
+
+            expect(getResponse.hits()).toEqual(hits);
+          }
+        );
+      }
+    );
   });
 }

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -4,6 +4,8 @@ import {
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorGetItemBatch,
+  VectorGetItemMetadataBatch,
 } from '../messages/responses/vector';
 import {VectorIndexItem} from '../messages/vector-index';
 
@@ -57,4 +59,15 @@ export interface IVectorIndexClient extends IVectorIndexControlClient {
     indexName: string,
     ids: Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
+
+  getItemBatch(
+    indexName: string,
+    ids: Array<string>
+  ): Promise<VectorGetItemBatch.Response>;
+
+  getItemMetadataBatch(
+    indexName: string,
+    ids: Array<string>,
+    metadataFields?: Array<string>
+  ): Promise<VectorGetItemMetadataBatch.Response>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,7 +68,11 @@ import * as GenerateDisposableToken from './messages/responses/generate-disposab
 // VectorClient Response Types
 export * as vector from './messages/responses/vector';
 export * from './messages/responses/vector';
-export {VectorIndexItem, VectorIndexStoredItem} from './messages/vector-index';
+export {
+  VectorIndexMetadata,
+  VectorIndexItem,
+  VectorIndexStoredItem,
+} from './messages/vector-index';
 
 // Leaderboard Response Types
 export * as leaderboard from './messages/responses/leaderboard';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,7 +68,7 @@ import * as GenerateDisposableToken from './messages/responses/generate-disposab
 // VectorClient Response Types
 export * as vector from './messages/responses/vector';
 export * from './messages/responses/vector';
-export {VectorIndexItem} from './messages/vector-index';
+export {VectorIndexItem, VectorIndexStoredItem} from './messages/vector-index';
 
 // Leaderboard Response Types
 export * as leaderboard from './messages/responses/leaderboard';

--- a/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
+++ b/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
@@ -6,6 +6,8 @@ import {
   VectorSearch,
   VectorSearchAndFetchVectors,
   VectorDeleteItemBatch,
+  VectorGetItemBatch,
+  VectorGetItemMetadataBatch,
 } from '../../..';
 import {
   IVectorIndexClient,
@@ -170,11 +172,45 @@ export abstract class AbstractVectorIndexClient
    * @param {string} indexName - Name of the index to delete the items from.
    * @param {Array<string>} ids - The IDs of the items to be deleted from the index.
    * @returns {Promise<VectorDeleteItemBatch.Response>}
+   * {@link VectorDeleteItemBatch.Success} on success.
+   * {@link VectorDeleteItemBatch.Error} on error.
    */
   public async deleteItemBatch(
     indexName: string,
     ids: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     return await this.dataClient.deleteItemBatch(indexName, ids);
+  }
+
+  /**
+   * Gets a batch of items from a vector index by ID.
+   *
+   * @param indexName - Name of the index to get the items from.
+   * @param ids - The IDs of the items to be retrieved from the index.
+   * @returns {Promise<VectorGetItemBatch.Response>}
+   * {@link VectorGetItemBatch.Success} on success, with the found items.
+   * {@link VectorGetItemBatch.Error} on error.
+   */
+  public async getItemBatch(
+    indexName: string,
+    ids: string[]
+  ): Promise<VectorGetItemBatch.Response> {
+    return await this.dataClient.getItemBatch(indexName, ids);
+  }
+
+  /**
+   * Gets metadata for a batch of items from a vector index by ID.
+   *
+   * @param indexName - Name of the index to get the items from.
+   * @param ids - The IDs of the items to be retrieved from the index.
+   * @returns {Promise<VectorGetItemMetadataBatch.Response>}
+   * {@link VectorGetItemMetadataBatch.Success} on success, with the found item metadata.
+   * {@link VectorGetItemMetadataBatch.Error} on error.
+   */
+  public async getItemMetadataBatch(
+    indexName: string,
+    ids: string[]
+  ): Promise<VectorGetItemMetadataBatch.Response> {
+    return await this.dataClient.getItemMetadataBatch(indexName, ids);
   }
 }

--- a/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
+++ b/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
@@ -3,6 +3,8 @@ import {
   VectorDeleteItemBatch,
   VectorSearch,
   VectorSearchAndFetchVectors,
+  VectorGetItemBatch,
+  VectorGetItemMetadataBatch,
 } from '../../../messages/responses/vector';
 import {VectorIndexItem} from '../../../messages/vector-index';
 import {SearchOptions} from '../../../clients/IVectorIndexClient';
@@ -26,4 +28,12 @@ export interface IVectorIndexDataClient {
     indexName: string,
     ids: Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
+  getItemBatch(
+    indexName: string,
+    ids: Array<string>
+  ): Promise<VectorGetItemBatch.Response>;
+  getItemMetadataBatch(
+    indexName: string,
+    ids: Array<string>
+  ): Promise<VectorGetItemMetadataBatch.Response>;
 }

--- a/packages/core/src/messages/responses/vector/index.ts
+++ b/packages/core/src/messages/responses/vector/index.ts
@@ -5,3 +5,5 @@ export * as VectorUpsertItemBatch from './vector-upsert-item-batch';
 export * as VectorSearch from './vector-search';
 export * as VectorSearchAndFetchVectors from './vector-search-and-fetch-vectors';
 export * as VectorDeleteItemBatch from './vector-delete-item-batch';
+export * as VectorGetItemBatch from './vector-get-item-batch';
+export * as VectorGetItemMetadataBatch from './vector-get-item-metadata-batch';

--- a/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../../errors';
-import {VectorIndexItem} from '../../vector-index';
+import {VectorIndexStoredItem} from '../../vector-index';
 import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
 
 /**
@@ -22,7 +22,7 @@ import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
  * ```
  */
 export abstract class Response extends ResponseBase {
-  hits(): Record<string, VectorIndexItem> | undefined {
+  hits(): Record<string, VectorIndexStoredItem> | undefined {
     if (this instanceof Success) {
       return this.hits();
     }
@@ -36,8 +36,8 @@ class _Success extends Response {}
  * Indicates a Successful VectorGetItemBatch request.
  */
 export class Success extends ResponseSuccess(_Success) {
-  private readonly _hits: Record<string, VectorIndexItem>;
-  constructor(hits: Record<string, VectorIndexItem>) {
+  private readonly _hits: Record<string, VectorIndexStoredItem>;
+  constructor(hits: Record<string, VectorIndexStoredItem>) {
     super();
     this._hits = hits;
   }
@@ -46,9 +46,9 @@ export class Success extends ResponseSuccess(_Success) {
    *
    * Items that were not found will not be included in the
    * returned object.
-   * @returns {Record<string, VectorIndexItem>} The items that were found in the index.
+   * @returns {Record<string, VectorIndexStoredItem>} The items that were found in the index.
    */
-  hits(): Record<string, VectorIndexItem> {
+  hits(): Record<string, VectorIndexStoredItem> {
     return this._hits;
   }
 }

--- a/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
@@ -1,0 +1,72 @@
+import {SdkError} from '../../../errors';
+import {VectorIndexItem} from '../../vector-index';
+import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
+
+/**
+ * Parent response type for a VectorGetItemBatch request.  The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Success}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof VectorGetItemBatch.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `VectorGetItemBatch.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {
+  hits(): Record<string, VectorIndexItem> | undefined {
+    if (this instanceof Success) {
+      return this.hits();
+    }
+    return undefined;
+  }
+}
+
+class _Success extends Response {}
+
+/**
+ * Indicates a Successful VectorGetItemBatch request.
+ */
+export class Success extends ResponseSuccess(_Success) {
+  private readonly _hits: Record<string, VectorIndexItem>;
+  constructor(hits: Record<string, VectorIndexItem>) {
+    super();
+    this._hits = hits;
+  }
+  /**
+   * Returns the found items from the VectorGetItemBatch request.
+   *
+   * Items that were not found will not be included in the
+   * returned object.
+   * @returns {Record<string, VectorIndexItem>} The items that were found in the index.
+   */
+  hits(): Record<string, VectorIndexItem> {
+    return this._hits;
+  }
+}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the VectorGetItemBatch request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}

--- a/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
@@ -1,0 +1,84 @@
+import {SdkError} from '../../../errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
+
+/**
+ * Parent response type for a VectorGetItemMetadataBatch request. The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Success}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof VectorGetItemMetadataBatch.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `VectorGetItemMetadataBatch.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {
+  hits():
+    | Record<string, Record<string, string | number | boolean | Array<string>>>
+    | undefined {
+    if (this instanceof Success) {
+      return this.hits();
+    }
+    return undefined;
+  }
+}
+
+class _Success extends Response {}
+
+/**
+ * Indicates a Successful VectorGetItemMetadataBatch request.
+ */
+export class Success extends ResponseSuccess(_Success) {
+  private readonly _hits: Record<
+    string,
+    Record<string, string | number | boolean | Array<string>>
+  >;
+  constructor(
+    hits: Record<
+      string,
+      Record<string, string | number | boolean | Array<string>>
+    >
+  ) {
+    super();
+    this._hits = hits;
+  }
+  /**
+   * Returns the metadat for the found items from the VectorGetItemMetadataBatch request.
+   *
+   * Items that were not found will not be included in the
+   * returned object.
+   * @returns {Record<string, Record<string, string | number | boolean | Array<string>>>} The metadata for items found in the index.
+   */
+  hits(): Record<
+    string,
+    Record<string, string | number | boolean | Array<string>>
+  > {
+    return this._hits;
+  }
+}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the VectorGetItemMetadataBatch request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}

--- a/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
@@ -1,4 +1,5 @@
 import {SdkError} from '../../../errors';
+import {VectorIndexMetadata} from '../../..';
 import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
 
 /**
@@ -21,9 +22,7 @@ import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
  * ```
  */
 export abstract class Response extends ResponseBase {
-  hits():
-    | Record<string, Record<string, string | number | boolean | Array<string>>>
-    | undefined {
+  hits(): Record<string, VectorIndexMetadata> | undefined {
     if (this instanceof Success) {
       return this.hits();
     }
@@ -37,16 +36,8 @@ class _Success extends Response {}
  * Indicates a Successful VectorGetItemMetadataBatch request.
  */
 export class Success extends ResponseSuccess(_Success) {
-  private readonly _hits: Record<
-    string,
-    Record<string, string | number | boolean | Array<string>>
-  >;
-  constructor(
-    hits: Record<
-      string,
-      Record<string, string | number | boolean | Array<string>>
-    >
-  ) {
+  private readonly _hits: Record<string, VectorIndexMetadata>;
+  constructor(hits: Record<string, VectorIndexMetadata>) {
     super();
     this._hits = hits;
   }
@@ -55,12 +46,9 @@ export class Success extends ResponseSuccess(_Success) {
    *
    * Items that were not found will not be included in the
    * returned object.
-   * @returns {Record<string, Record<string, string | number | boolean | Array<string>>>} The metadata for items found in the index.
+   * @returns {Record<string, VectorIndexMetadata>} The metadata for items found in the index.
    */
-  hits(): Record<
-    string,
-    Record<string, string | number | boolean | Array<string>>
-  > {
+  hits(): Record<string, VectorIndexMetadata> {
     return this._hits;
   }
 }

--- a/packages/core/src/messages/vector-index.ts
+++ b/packages/core/src/messages/vector-index.ts
@@ -1,5 +1,39 @@
+/**
+ * An item to upsert into the vector index.
+ */
 export interface VectorIndexItem {
+  /**
+   * The ID of the item.
+   */
   id: string;
+  /**
+   * The vector of the item.
+   */
   vector: Array<number>;
+  /**
+   * The metadata of the item, if any.
+   */
   metadata?: Record<string, string | number | boolean | Array<string>>;
+}
+
+/**
+ * An item stored in the vector index.
+ *
+ * @remarks Specifying metadata is optional when upserting with
+ * `VectorIndexItem` but it is always returned when fetching items.
+ * Ie we know with certainty that `metadata` is not undefined.
+ */
+export interface VectorIndexStoredItem {
+  /**
+   * The ID of the item.
+   */
+  id: string;
+  /**
+   * The vector of the item.
+   */
+  vector: Array<number>;
+  /**
+   * The metadata of the item.
+   */
+  metadata: Record<string, string | number | boolean | Array<string>>;
 }

--- a/packages/core/src/messages/vector-index.ts
+++ b/packages/core/src/messages/vector-index.ts
@@ -1,4 +1,12 @@
 /**
+ * The metadata of an item stored in the vector index.
+ */
+export type VectorIndexMetadata = Record<
+  string,
+  string | number | boolean | Array<string>
+>;
+
+/**
  * An item to upsert into the vector index.
  */
 export interface VectorIndexItem {
@@ -13,7 +21,7 @@ export interface VectorIndexItem {
   /**
    * The metadata of the item, if any.
    */
-  metadata?: Record<string, string | number | boolean | Array<string>>;
+  metadata?: VectorIndexMetadata;
 }
 
 /**
@@ -35,5 +43,5 @@ export interface VectorIndexStoredItem {
   /**
    * The metadata of the item.
    */
-  metadata: Record<string, string | number | boolean | Array<string>>;
+  metadata: VectorIndexMetadata;
 }


### PR DESCRIPTION
Implements MVI `get item batch` and `get item metadata batch`, adds tests, and extracts `VectorIndexMetadata` to separate type.