### PR TITLE
fix: correct number of arguments for sortedSetPutElements logger statements

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -2036,7 +2036,7 @@ export class CacheDataClient implements IDataClient {
       );
     }
     this.logger.trace(
-      "Issuing 'sortedSetPutElements' request; value: %s, score : %s, ttl: %s",
+      "Issuing 'sortedSetPutElements' request; elements : %s, ttl: %s",
       elements.toString(),
       ttl.ttlSeconds.toString() ?? 'null'
     );

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -2213,7 +2213,7 @@ export class CacheDataClient<
       );
     }
     this.logger.trace(
-      "Issuing 'sortedSetPutElements' request; value: %s, score : %s, ttl: %s",
+      "Issuing 'sortedSetPutElements' request; elements: %s, ttl: %s",
       elements.toString(),
       ttl.ttlSeconds.toString() ?? 'null'
     );


### PR DESCRIPTION
Corrected the logger statements for sortedSetPutElements. Had been showing up as an error in a customer's logs