### PR TITLE
chore: add scheduled job to update momento deps in all examples

### DIFF
--- a/.github/workflows/update-example-deps.yml
+++ b/.github/workflows/update-example-deps.yml
@@ -1,0 +1,29 @@
+  on:
+    schedule:
+      - cron: '0 12 * * *'
+    # for testing, temporarily allow manual triggering
+    workflow_dispatch:
+
+  jobs:
+    update-example-deps:
+      name: Update Momento deps in examples
+      runs-on: ubuntu-latest
+      env:
+        # TODO: remove token stored as secret in favor of using a
+        # momento-local instance that can be spun up for testing
+        MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+
+      steps:
+        - name: Setup repo
+          uses: actions/checkout@v3
+
+        - name: Install Node
+          uses: actions/setup-node@v3
+          with:
+            node-version: 16
+
+        - name: Run update script
+          id: validation
+          run: |
+            ./scripts/update-all-examples-dependencies.sh
+


### PR DESCRIPTION
This is the first step of replacing the dependabot functionality;
for now all this does is run the script. Will add more commits
to make it file a PR once we ensure this is working.
