### PR TITLE
refactor: use `values` noun for get item* consistent w/cache usage

### DIFF
--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1048,19 +1048,19 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         getMethodName: 'getItemBatch',
         ids: [],
         expectedResponse: VectorGetItemBatch.Success,
-        hits: {},
+        values: {},
       },
       {
         getMethodName: 'getItemMetadataBatch',
         ids: [],
         expectedResponse: VectorGetItemMetadataBatch.Success,
-        hits: {},
+        values: {},
       },
       {
         getMethodName: 'getItemBatch',
         ids: ['test_item_1'],
         expectedResponse: VectorGetItemBatch.Success,
-        hits: {
+        values: {
           test_item_1: {
             id: 'test_item_1',
             vector: [1.0, 2.0],
@@ -1072,7 +1072,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         getMethodName: 'getItemMetadataBatch',
         ids: ['test_item_1'],
         expectedResponse: VectorGetItemMetadataBatch.Success,
-        hits: {
+        values: {
           test_item_1: {
             key1: 'value1',
           },
@@ -1082,19 +1082,19 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         getMethodName: 'getItemBatch',
         ids: ['missing_id'],
         expectedResponse: VectorGetItemBatch.Success,
-        hits: {},
+        values: {},
       },
       {
         getMethodName: 'getItemMetadataBatch',
         ids: ['missing_id'],
         expectedResponse: VectorGetItemMetadataBatch.Success,
-        hits: {},
+        values: {},
       },
       {
         getMethodName: 'getItemBatch',
         ids: ['test_item_1', 'missing_id_2', 'test_item_2'],
         expectedResponse: VectorGetItemBatch.Success,
-        hits: {
+        values: {
           test_item_1: {
             id: 'test_item_1',
             vector: [1.0, 2.0],
@@ -1111,7 +1111,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         getMethodName: 'getItemMetadataBatch',
         ids: ['test_item_1', 'missing_id_2', 'test_item_2'],
         expectedResponse: VectorGetItemMetadataBatch.Success,
-        hits: {
+        values: {
           test_item_1: {
             key1: 'value1',
           },
@@ -1120,7 +1120,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
       },
     ])(
       'should get items and get item metadata',
-      async ({getMethodName, ids, expectedResponse, hits}) => {
+      async ({getMethodName, ids, expectedResponse, values}) => {
         const indexName = testIndexName();
         await WithIndex(
           vectorClient,
@@ -1158,7 +1158,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
               expect(getResponse).toBeInstanceOf(expectedResponse);
             }, `expected SUCCESS but got ${getResponse.toString()}}`);
 
-            expect(getResponse.hits()).toEqual(hits);
+            expect(getResponse.values()).toEqual(values);
           }
         );
       }

--- a/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
@@ -22,9 +22,9 @@ import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
  * ```
  */
 export abstract class Response extends ResponseBase {
-  hits(): Record<string, VectorIndexStoredItem> | undefined {
+  values(): Record<string, VectorIndexStoredItem> | undefined {
     if (this instanceof Success) {
-      return this.hits();
+      return this.values();
     }
     return undefined;
   }
@@ -36,10 +36,10 @@ class _Success extends Response {}
  * Indicates a Successful VectorGetItemBatch request.
  */
 export class Success extends ResponseSuccess(_Success) {
-  private readonly _hits: Record<string, VectorIndexStoredItem>;
-  constructor(hits: Record<string, VectorIndexStoredItem>) {
+  private readonly _values: Record<string, VectorIndexStoredItem>;
+  constructor(values: Record<string, VectorIndexStoredItem>) {
     super();
-    this._hits = hits;
+    this._values = values;
   }
   /**
    * Returns the found items from the VectorGetItemBatch request.
@@ -49,7 +49,7 @@ export class Success extends ResponseSuccess(_Success) {
    * @returns {Record<string, VectorIndexStoredItem>} The items that were found in the index.
    */
   hits(): Record<string, VectorIndexStoredItem> {
-    return this._hits;
+    return this._values;
   }
 }
 

--- a/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-batch.ts
@@ -48,7 +48,7 @@ export class Success extends ResponseSuccess(_Success) {
    * returned object.
    * @returns {Record<string, VectorIndexStoredItem>} The items that were found in the index.
    */
-  hits(): Record<string, VectorIndexStoredItem> {
+  values(): Record<string, VectorIndexStoredItem> {
     return this._values;
   }
 }

--- a/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
@@ -48,7 +48,7 @@ export class Success extends ResponseSuccess(_Success) {
    * returned object.
    * @returns {Record<string, VectorIndexMetadata>} The metadata for items found in the index.
    */
-  hits(): Record<string, VectorIndexMetadata> {
+  values(): Record<string, VectorIndexMetadata> {
     return this._values;
   }
 }

--- a/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
+++ b/packages/core/src/messages/responses/vector/vector-get-item-metadata-batch.ts
@@ -22,9 +22,9 @@ import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
  * ```
  */
 export abstract class Response extends ResponseBase {
-  hits(): Record<string, VectorIndexMetadata> | undefined {
+  values(): Record<string, VectorIndexMetadata> | undefined {
     if (this instanceof Success) {
-      return this.hits();
+      return this.values();
     }
     return undefined;
   }
@@ -36,10 +36,10 @@ class _Success extends Response {}
  * Indicates a Successful VectorGetItemMetadataBatch request.
  */
 export class Success extends ResponseSuccess(_Success) {
-  private readonly _hits: Record<string, VectorIndexMetadata>;
-  constructor(hits: Record<string, VectorIndexMetadata>) {
+  private readonly _values: Record<string, VectorIndexMetadata>;
+  constructor(values: Record<string, VectorIndexMetadata>) {
     super();
-    this._hits = hits;
+    this._values = values;
   }
   /**
    * Returns the metadat for the found items from the VectorGetItemMetadataBatch request.
@@ -49,7 +49,7 @@ export class Success extends ResponseSuccess(_Success) {
    * @returns {Record<string, VectorIndexMetadata>} The metadata for items found in the index.
    */
   hits(): Record<string, VectorIndexMetadata> {
-    return this._hits;
+    return this._values;
   }
 }
 


### PR DESCRIPTION
Consistent with the cache terminology, we use the noun `values` to
access the `get item batch` and `get item metadata batch` items.
