### PR TITLE
chore: add examples to docs for webhooks apis

### DIFF
--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -81,6 +81,9 @@ import {
   LeaderboardOrder,
   LeaderboardRemoveElements,
   LeaderboardUpsert,
+  ListWebhooks,
+  DeleteWebhook,
+  PutWebhook,
 } from '@gomomento/sdk';
 
 function retrieveApiKeyFromYourSecretsManager(): string {
@@ -1042,6 +1045,43 @@ async function example_API_TopicSubscribe(topicClient: TopicClient) {
   }
 }
 
+async function example_API_ListWebhooks(topicClient: TopicClient) {
+  const result = await topicClient.listWebhooks('test-cache');
+  if (result instanceof ListWebhooks.Success) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    console.log(`listed webhooks: ${result.getWebhooks()}`);
+  } else if (result instanceof ListWebhooks.Error) {
+    throw new Error(
+      `An error occurred while attempting to list webhooks for cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_DeleteWebhook(topicClient: TopicClient) {
+  const result = await topicClient.deleteWebhook('test-cache', 'a webhook');
+  if (result instanceof DeleteWebhook.Success) {
+    console.log('successfully deleted webhook');
+  } else if (result instanceof ListWebhooks.Error) {
+    throw new Error(
+      `An error occurred while attempting to delete webhook 'a webhook' inside of cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_PutWebhook(topicClient: TopicClient) {
+  const result = await topicClient.putWebhook('test-cache', 'examples webhook', {
+    topicName: 'a topic',
+    destination: 'https://www.thisisawebhookurl.com/v1/webhook',
+  });
+  if (result instanceof PutWebhook.Success) {
+    console.log('successfully created webhook');
+  } else if (result instanceof PutWebhook.Error) {
+    throw new Error(
+      `An error occurred while attempting to create a webhook 'examples webhook' inside of cache 'test-cache': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
 function example_API_InstantiateLeaderboardClient() {
   new PreviewLeaderboardClient({
     configuration: LeaderboardConfigurations.Laptop.v1(),
@@ -1367,6 +1407,11 @@ async function main() {
   });
   await example_API_TopicPublish(topicClient);
   await example_API_TopicSubscribe(topicClient);
+
+  // Webhooks
+  await example_API_ListWebhooks(topicClient);
+  await example_API_DeleteWebhook(topicClient);
+  await example_API_PutWebhook(topicClient);
 
   example_API_InstantiateLeaderboardClient();
   const leaderboardClient = new PreviewLeaderboardClient({

--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.45.7"
+        "@gomomento/sdk": "1.53.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.87.0.tgz",
-      "integrity": "sha512-vW4vp74SbP2P/ygQcMWW358YQcfMIvYxijbLwG0EfSM/c8uZFtFLxCOaV4ogLbP105DCEaR8CS5wbvXVoSAXsA==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
+      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -69,14 +69,14 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.45.7",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.7.tgz",
-      "integrity": "sha512-wCNjulaN7Dg9CfY9xM8bUC9DHpLpcvaWP5FZfVnGlxWrTFkc5RR2UBBcCzeb8EoL2iGn29LnNs6voblQdtI1bg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.53.0.tgz",
+      "integrity": "sha512-CI/3AD+hIMymwxST2/SMsmqCC/JoWHZnenJ5Y0Gii0QLHxQEjoMgm39p1PPWZAOc60LvC4s3e6+gJQDvqx4QJw==",
       "dependencies": {
-        "@gomomento/generated-types": "0.87.0",
-        "@gomomento/sdk-core": "1.45.7",
+        "@gomomento/generated-types": "0.97.1",
+        "@gomomento/sdk-core": "1.53.0",
         "@grpc/grpc-js": "1.9.0",
-        "@types/google-protobuf": "3.15.6",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
@@ -85,11 +85,11 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.45.7",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.7.tgz",
-      "integrity": "sha512-rjq8Ko8URbRhlV/Vw1oY5fuhjmT/ujbf2zQ2c/s1IYrGpbci217hPOdraS5h9hc/uqZ1cR5rPhppSJb5MBeQCQ==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.53.0.tgz",
+      "integrity": "sha512-DQSMdQAfG86XPrsrEI6yjTZAKfAONv1ch3H/2LCvYkBXWOKmAtpizcEXrhhE3whX9/FUx3OzYqUKtz7Sqf0Jzg==",
       "dependencies": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       },
       "engines": {
@@ -249,9 +249,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@types/google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "version": "3.15.10",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
@@ -3375,9 +3375,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.87.0.tgz",
-      "integrity": "sha512-vW4vp74SbP2P/ygQcMWW358YQcfMIvYxijbLwG0EfSM/c8uZFtFLxCOaV4ogLbP105DCEaR8CS5wbvXVoSAXsA==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
+      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3386,24 +3386,24 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.45.7",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.45.7.tgz",
-      "integrity": "sha512-wCNjulaN7Dg9CfY9xM8bUC9DHpLpcvaWP5FZfVnGlxWrTFkc5RR2UBBcCzeb8EoL2iGn29LnNs6voblQdtI1bg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.53.0.tgz",
+      "integrity": "sha512-CI/3AD+hIMymwxST2/SMsmqCC/JoWHZnenJ5Y0Gii0QLHxQEjoMgm39p1PPWZAOc60LvC4s3e6+gJQDvqx4QJw==",
       "requires": {
-        "@gomomento/generated-types": "0.87.0",
-        "@gomomento/sdk-core": "1.45.7",
+        "@gomomento/generated-types": "0.97.1",
+        "@gomomento/sdk-core": "1.53.0",
         "@grpc/grpc-js": "1.9.0",
-        "@types/google-protobuf": "3.15.6",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.45.7",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.45.7.tgz",
-      "integrity": "sha512-rjq8Ko8URbRhlV/Vw1oY5fuhjmT/ujbf2zQ2c/s1IYrGpbci217hPOdraS5h9hc/uqZ1cR5rPhppSJb5MBeQCQ==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.53.0.tgz",
+      "integrity": "sha512-DQSMdQAfG86XPrsrEI6yjTZAKfAONv1ch3H/2LCvYkBXWOKmAtpizcEXrhhE3whX9/FUx3OzYqUKtz7Sqf0Jzg==",
       "requires": {
-        "buffer": "^6.0.3",
+        "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
@@ -3531,9 +3531,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@types/google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "version": "3.15.10",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "@types/json-schema": {
       "version": "7.0.13",

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -32,7 +32,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.45.7"
+    "@gomomento/sdk": "1.53.0"
   },
   "engines": {
     "node": ">=10.4.0"


### PR DESCRIPTION
Adds examples to be consumed by our docs for webhooks. There are 2 more webhooks api that I want to add, but I need to merge and release [this](https://github.com/momentohq/client-sdk-javascript/pull/1072) pr first to be able to import their return types