### PR TITLE
fix: correctly export get/rotate webhook secret response types

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -153,6 +153,8 @@ import {
   DeleteWebhook,
   ListWebhooks,
   PutWebhook,
+  GetWebhookSecret,
+  RotateWebhookSecret,
   WebhookDestinationType,
 } from '@gomomento/sdk-core';
 
@@ -330,6 +332,8 @@ export {
   DeleteWebhook,
   ListWebhooks,
   PutWebhook,
+  GetWebhookSecret,
+  RotateWebhookSecret,
   WebhookDestinationType,
   // AuthClient response types
   AuthClient,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -138,6 +138,8 @@ import {
   DeleteWebhook,
   ListWebhooks,
   PutWebhook,
+  GetWebhookSecret,
+  RotateWebhookSecret,
   WebhookDestinationType,
 } from '@gomomento/sdk-core';
 
@@ -319,5 +321,7 @@ export {
   DeleteWebhook,
   ListWebhooks,
   PutWebhook,
+  GetWebhookSecret,
+  RotateWebhookSecret,
   WebhookDestinationType,
 };


### PR DESCRIPTION
When implementing these 2 new methods, I forgot to export their return types. This pr just adds these as some more exports in `index.ts`