### PR TITLE
test: add suffix to identify integration test index names

### DIFF
--- a/packages/common-integration-tests/src/common-int-test-utils.ts
+++ b/packages/common-integration-tests/src/common-int-test-utils.ts
@@ -41,8 +41,12 @@ export function testCacheName(): string {
   return process.env.TEST_CACHE_NAME || `js-integration-test-default-${v4()}`;
 }
 
-export function testIndexName(): string {
-  return `js-integration-test-${v4()}`;
+export function testIndexName(suffix?: string): string {
+  let indexName = `js-integration-test-${v4()}`;
+  if (suffix !== undefined) {
+    indexName = `${indexName}-${suffix}`;
+  }
+  return indexName;
 }
 
 export function testWebhook(cache?: string): Webhook {

--- a/packages/common-integration-tests/src/common-int-test-utils.ts
+++ b/packages/common-integration-tests/src/common-int-test-utils.ts
@@ -41,12 +41,13 @@ export function testCacheName(): string {
   return process.env.TEST_CACHE_NAME || `js-integration-test-default-${v4()}`;
 }
 
-export function testIndexName(suffix?: string): string {
-  let indexName = `js-integration-test-${v4()}`;
-  if (suffix !== undefined) {
-    indexName = `${indexName}-${suffix}`;
-  }
-  return indexName;
+/**
+ * Returns a unique index name for use in integration tests.
+ * @param meaningfulIdentifier Required suffix to identify the test for debugging purposes.
+ * @returns {string} A unique index name.
+ */
+export function testIndexName(meaningfulIdentifier: string): string {
+  return `js-integration-test-${v4()}-${meaningfulIdentifier}`;
 }
 
 export function testWebhook(cache?: string): Webhook {

--- a/packages/common-integration-tests/src/common-int-test-utils.ts
+++ b/packages/common-integration-tests/src/common-int-test-utils.ts
@@ -44,6 +44,7 @@ export function testCacheName(): string {
 /**
  * Returns a unique index name for use in integration tests.
  * @param meaningfulIdentifier Required suffix to identify the test for debugging purposes.
+ * Should be a string that describes the test uniquely.
  * @returns {string} A unique index name.
  */
 export function testIndexName(meaningfulIdentifier: string): string {

--- a/packages/common-integration-tests/src/vector-control-plane.ts
+++ b/packages/common-integration-tests/src/vector-control-plane.ts
@@ -30,7 +30,7 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
     });
 
     it('should return an InvalidArgumentError if given a bad similarity metric', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('control-create-with-bad-metric');
       const createResponse = await vectorClient.createIndex(
         indexName,
         1,
@@ -47,7 +47,7 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
     });
 
     it('should return a NotFoundError if deleting a non-existent index', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('control-delete-non-existent');
       const deleteResponse = await vectorClient.deleteIndex(indexName);
       expectWithMessage(() => {
         expect(deleteResponse).toBeInstanceOf(DeleteVectorIndex.Error);
@@ -60,7 +60,7 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
     });
 
     it('should return AlreadyExists response if trying to create a index that already exists', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('control-create-already-exists');
       await WithIndex(
         vectorClient,
         indexName,
@@ -78,21 +78,21 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
     it.each([
       {
         indexInfo: new VectorIndexInfo(
-          testIndexName(),
+          testIndexName('control-list-indexes-1'),
           10,
           VectorSimilarityMetric.INNER_PRODUCT
         ),
       },
       {
         indexInfo: new VectorIndexInfo(
-          testIndexName(),
+          testIndexName('control-list-indexes-2'),
           20,
           VectorSimilarityMetric.EUCLIDEAN_SIMILARITY
         ),
       },
       {
         indexInfo: new VectorIndexInfo(
-          testIndexName(),
+          testIndexName('control-list-indexes-3'),
           30,
           VectorSimilarityMetric.COSINE_SIMILARITY
         ),

--- a/packages/common-integration-tests/src/vector-control-plane.ts
+++ b/packages/common-integration-tests/src/vector-control-plane.ts
@@ -120,7 +120,7 @@ export function runVectorControlPlaneTest(vectorClient: IVectorIndexClient) {
     });
 
     it('should delete an index', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('control-delete-index');
       const createResponse = await vectorClient.createIndex(indexName, 1);
       expect(createResponse).toBeInstanceOf(CreateVectorIndex.Success);
       const deleteResponse = await vectorClient.deleteIndex(indexName);

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -119,7 +119,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upsertItem and search using inner product',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-inner-product');
         await WithIndex(
           vectorClient,
           indexName,
@@ -180,7 +180,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upsertItem and search using cosine similarity',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-cosine-similarity');
         await WithIndex(
           vectorClient,
           indexName,
@@ -259,7 +259,9 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upsertItem and search using euclidean similarity',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName(
+          'data-upsert-search-euclidean-similarity'
+        );
         await WithIndex(
           vectorClient,
           indexName,
@@ -330,7 +332,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     );
 
     it('should support upserting multiple items and searching', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('data-upsert-search-multiple-items');
       await WithIndex(
         vectorClient,
         indexName,
@@ -376,7 +378,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upserting multiple items and searching with top k',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-top-k');
         await WithIndex(
           vectorClient,
           indexName,
@@ -432,7 +434,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upsert and search with metadata',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-metadata');
         await WithIndex(
           vectorClient,
           indexName,
@@ -584,7 +586,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should support upsert and search with diverse metadata',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-diverse-metadata');
         await WithIndex(
           vectorClient,
           indexName,
@@ -694,7 +696,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         searchMethodName,
         response,
       }) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-upsert-search-threshold');
         await WithIndex(
           vectorClient,
           indexName,
@@ -790,7 +792,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     );
 
     it('should replacing existing items with upsert', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('data-upsert-replace-existing');
       await WithIndex(
         vectorClient,
         indexName,
@@ -861,7 +863,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     });
 
     it('should fail when upserting item with wrong number of dimensions', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('data-upsert-wrong-dimensions');
       await WithIndex(
         vectorClient,
         indexName,
@@ -898,7 +900,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should fail when searching with wrong number of dimensions',
       async ({searchMethodName, response}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-search-wrong-dimensions');
         await WithIndex(
           vectorClient,
           indexName,
@@ -951,7 +953,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
 
   describe('deleteItem', () => {
     it('should delete ids', async () => {
-      const indexName = testIndexName();
+      const indexName = testIndexName('data-delete-ids');
       await WithIndex(
         vectorClient,
         indexName,
@@ -1121,7 +1123,7 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
     ])(
       'should get items and get item metadata',
       async ({getMethodName, ids, expectedResponse, values}) => {
-        const indexName = testIndexName();
+        const indexName = testIndexName('data-get-items');
         await WithIndex(
           vectorClient,
           indexName,


### PR DESCRIPTION
Because we are seeing indexes leak in integration tests, we
hypothesize a particular integration test or tests may be at fault. To
identify these, we add a suffix to the test name that identifies each
test case.

I feel this is a good practice to adopt going forward
across the board.
