### PR TITLE
feat: new configuration setting to opt-in to throwing on errors

### DIFF
--- a/packages/client-sdk-nodejs/jest.config.ts
+++ b/packages/client-sdk-nodejs/jest.config.ts
@@ -3,7 +3,7 @@ import type {Config} from 'jest';
 const config: Config = {
   setupFilesAfterEnv: ['jest-extended/all'],
   testEnvironment: 'node',
-  roots: ['<rootDir>/test'],
+ roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/packages/client-sdk-nodejs/src/auth-client-props.ts
+++ b/packages/client-sdk-nodejs/src/auth-client-props.ts
@@ -5,4 +5,11 @@ export interface AuthClientProps {
    * controls how the client will get authentication information for connecting to the Momento service
    */
   credentialProvider: CredentialProvider;
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  throwOnErrors?: boolean;
 }

--- a/packages/client-sdk-nodejs/src/config/configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/configuration.ts
@@ -20,6 +20,10 @@ export interface ConfigurationProps {
    * Configures middleware functions that will wrap each request
    */
   middlewares: Middleware[];
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 /**
@@ -83,6 +87,22 @@ export interface Configuration {
    * @returns {Configuration} a new Configuration object with its TransportStrategy updated to use the specified client timeout
    */
   withClientTimeoutMillis(clientTimeoutMillis: number): Configuration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): Configuration;
 }
 
 export class CacheConfiguration implements Configuration {
@@ -90,12 +110,14 @@ export class CacheConfiguration implements Configuration {
   private readonly retryStrategy: RetryStrategy;
   private readonly transportStrategy: TransportStrategy;
   private readonly middlewares: Middleware[];
+  private readonly throwOnErrors: boolean;
 
   constructor(props: ConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.retryStrategy = props.retryStrategy;
     this.transportStrategy = props.transportStrategy;
     this.middlewares = props.middlewares;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -112,6 +134,7 @@ export class CacheConfiguration implements Configuration {
       retryStrategy: retryStrategy,
       transportStrategy: this.transportStrategy,
       middlewares: this.middlewares,
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -125,6 +148,7 @@ export class CacheConfiguration implements Configuration {
       retryStrategy: this.retryStrategy,
       transportStrategy: transportStrategy,
       middlewares: this.middlewares,
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -138,6 +162,7 @@ export class CacheConfiguration implements Configuration {
       retryStrategy: this.retryStrategy,
       transportStrategy: this.transportStrategy,
       middlewares: middlewares,
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -147,6 +172,7 @@ export class CacheConfiguration implements Configuration {
       retryStrategy: this.retryStrategy,
       transportStrategy: this.transportStrategy,
       middlewares: [middleware, ...this.middlewares],
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -157,6 +183,21 @@ export class CacheConfiguration implements Configuration {
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeout),
       middlewares: this.middlewares,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): Configuration {
+    return new CacheConfiguration({
+      loggerFactory: this.loggerFactory,
+      retryStrategy: this.retryStrategy,
+      transportStrategy: this.transportStrategy,
+      middlewares: this.middlewares,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/configurations.ts
@@ -69,6 +69,7 @@ export class Laptop extends CacheConfiguration {
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
       middlewares: defaultMiddlewares,
+      throwOnErrors: false,
     });
   }
 }
@@ -98,6 +99,7 @@ export class Lambda extends CacheConfiguration {
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
       middlewares: defaultMiddlewares,
+      throwOnErrors: false,
     });
   }
 }
@@ -138,6 +140,7 @@ class InRegionDefault extends CacheConfiguration {
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
       middlewares: defaultMiddlewares,
+      throwOnErrors: false,
     });
   }
 }
@@ -179,6 +182,7 @@ class InRegionLowLatency extends CacheConfiguration {
       retryStrategy: defaultRetryStrategy(loggerFactory),
       transportStrategy: transportStrategy,
       middlewares: defaultMiddlewares,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/leaderboard-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configuration.ts
@@ -26,6 +26,22 @@ export interface LeaderboardConfiguration {
   withTransportStrategy(
     transportStrategy: TransportStrategy
   ): LeaderboardConfiguration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): LeaderboardConfiguration;
 }
 
 export interface LeaderboardConfigurationProps {
@@ -37,6 +53,11 @@ export interface LeaderboardConfigurationProps {
    * Configures low-level options for network interactions with the Momento service
    */
   transportStrategy: TransportStrategy;
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 export class LeaderboardClientConfiguration
@@ -44,10 +65,12 @@ export class LeaderboardClientConfiguration
 {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TransportStrategy;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: LeaderboardConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -65,6 +88,7 @@ export class LeaderboardClientConfiguration
       loggerFactory: this.loggerFactory,
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeoutMillis),
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -74,6 +98,19 @@ export class LeaderboardClientConfiguration
     return new LeaderboardClientConfiguration({
       loggerFactory: this.loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): LeaderboardConfiguration {
+    return new LeaderboardClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      transportStrategy: this.transportStrategy,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
@@ -57,6 +57,7 @@ export class Laptop extends LeaderboardClientConfiguration {
     return new Laptop({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/topic-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configuration.ts
@@ -5,6 +5,11 @@ export interface TopicConfigurationProps {
    * Configures logging verbosity and format
    */
   loggerFactory: MomentoLoggerFactory;
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 /**
@@ -18,16 +23,45 @@ export interface TopicConfiguration {
    * @returns {MomentoLoggerFactory} the current configuration options for logging verbosity and format
    */
   getLoggerFactory(): MomentoLoggerFactory;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): TopicConfiguration;
 }
 
 export class TopicClientConfiguration implements TopicConfiguration {
   private readonly loggerFactory: MomentoLoggerFactory;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: TopicConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
     return this.loggerFactory;
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): TopicConfiguration {
+    return new TopicClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      throwOnErrors: throwOnErrors,
+    });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -25,6 +25,7 @@ export class Default extends TopicClientConfiguration {
   ): TopicConfiguration {
     return new TopicClientConfiguration({
       loggerFactory: loggerFactory,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/vector-index-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/vector-index-configuration.ts
@@ -26,6 +26,22 @@ export interface VectorIndexConfiguration {
   withTransportStrategy(
     transportStrategy: TransportStrategy
   ): VectorIndexConfiguration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): VectorIndexConfiguration;
 }
 
 export interface VectorIndexConfigurationProps {
@@ -37,6 +53,10 @@ export interface VectorIndexConfigurationProps {
    * Configures low-level options for network interactions with the Momento service
    */
   transportStrategy: TransportStrategy;
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 export class VectorIndexClientConfiguration
@@ -44,10 +64,12 @@ export class VectorIndexClientConfiguration
 {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TransportStrategy;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: VectorIndexConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -65,6 +87,7 @@ export class VectorIndexClientConfiguration
       loggerFactory: this.loggerFactory,
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeoutMillis),
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -74,6 +97,19 @@ export class VectorIndexClientConfiguration
     return new VectorIndexClientConfiguration({
       loggerFactory: this.loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): VectorIndexConfiguration {
+    return new VectorIndexClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      transportStrategy: this.transportStrategy,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/vector-index-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/vector-index-configurations.ts
@@ -57,6 +57,7 @@ export class Laptop extends VectorIndexClientConfiguration {
     return new Laptop({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }
@@ -100,6 +101,7 @@ export class Browser extends VectorIndexClientConfiguration {
     return new Browser({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -18,25 +18,27 @@ import {
   FailedPreconditionError,
 } from '../../src';
 
+export interface HandleCacheServiceErrorOptions {
+  err: ServiceError | null;
+  errorResponseFactoryFn: (err: SdkError) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resolveFn: (result: any) => void;
+  rejectFn: (err: SdkError) => void;
+}
+
 export class CacheServiceErrorMapper {
   private readonly throwOnError: boolean;
 
   constructor(throwOnError: boolean) {
     this.throwOnError = throwOnError;
   }
-  handleError(
-    err: ServiceError | null,
-    errorResponseFactoryFn: (err: SdkError) => unknown,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolveFn: (result: any) => void,
-    rejectFn: (err: SdkError) => void
-  ): void {
-    const error = this.convertError(err);
+  handleError(opts: HandleCacheServiceErrorOptions): void {
+    const error = this.convertError(opts.err);
 
     if (this.throwOnError) {
-      rejectFn(error);
+      opts.rejectFn(error);
     } else {
-      resolveFn(errorResponseFactoryFn(error));
+      opts.resolveFn(opts.errorResponseFactoryFn(error));
     }
   }
 

--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -18,7 +18,7 @@ import {
   FailedPreconditionError,
 } from '../../src';
 
-export interface HandleCacheServiceErrorOptions {
+export interface ResolveOrRejectErrorOptions {
   err: ServiceError | null;
   errorResponseFactoryFn: (err: SdkError) => unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,7 +32,7 @@ export class CacheServiceErrorMapper {
   constructor(throwOnError: boolean) {
     this.throwOnError = throwOnError;
   }
-  handleError(opts: HandleCacheServiceErrorOptions): void {
+  resolveOrRejectError(opts: ResolveOrRejectErrorOptions): void {
     const error = this.convertError(opts.err);
 
     if (this.throwOnError) {

--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -22,8 +22,6 @@ export class CacheServiceErrorMapper {
   private readonly throwOnError: boolean;
 
   constructor(throwOnError: boolean) {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    console.log(`CONSTRUCTING CACHE SERVICE ERROR MAPPER: ${throwOnError}`);
     this.throwOnError = throwOnError;
   }
   handleError(

--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -18,49 +18,74 @@ import {
   FailedPreconditionError,
 } from '../../src';
 
-export function cacheServiceErrorMapper(err: ServiceError | null): SdkError {
-  const errParams: [
-    string,
-    number | undefined,
-    object | undefined,
-    string | undefined
-  ] = [
-    err?.message || 'Unable to process request',
-    err?.code,
-    err?.metadata,
-    err?.stack,
-  ];
-  switch (err?.code) {
-    case Status.PERMISSION_DENIED:
-      return new PermissionError(...errParams);
-    case Status.DATA_LOSS:
-    case Status.INTERNAL:
-    case Status.ABORTED:
-      return new InternalServerError(...errParams);
-    case Status.UNKNOWN:
-      return new UnknownServiceError(...errParams);
-    case Status.UNAVAILABLE:
-      return new ServerUnavailableError(...errParams);
-    case Status.NOT_FOUND:
-      return new NotFoundError(...errParams);
-    case Status.OUT_OF_RANGE:
-    case Status.UNIMPLEMENTED:
-      return new BadRequestError(...errParams);
-    case Status.FAILED_PRECONDITION:
-      return new FailedPreconditionError(...errParams);
-    case Status.INVALID_ARGUMENT:
-      return new InvalidArgumentError(...errParams);
-    case Status.CANCELLED:
-      return new CancelledError(...errParams);
-    case Status.DEADLINE_EXCEEDED:
-      return new TimeoutError(...errParams);
-    case Status.UNAUTHENTICATED:
-      return new AuthenticationError(...errParams);
-    case Status.RESOURCE_EXHAUSTED:
-      return new LimitExceededError(...errParams);
-    case Status.ALREADY_EXISTS:
-      return new AlreadyExistsError(...errParams);
-    default:
-      return new UnknownError(...errParams);
+export class CacheServiceErrorMapper {
+  private readonly throwOnError: boolean;
+
+  constructor(throwOnError: boolean) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    console.log(`CONSTRUCTING CACHE SERVICE ERROR MAPPER: ${throwOnError}`);
+    this.throwOnError = throwOnError;
+  }
+  handleError(
+    err: ServiceError | null,
+    errorResponseFactoryFn: (err: SdkError) => unknown,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolveFn: (result: any) => void,
+    rejectFn: (err: SdkError) => void
+  ): void {
+    const error = this.convertError(err);
+
+    if (this.throwOnError) {
+      rejectFn(error);
+    } else {
+      resolveFn(errorResponseFactoryFn(error));
+    }
+  }
+
+  convertError(err: ServiceError | null): SdkError {
+    const errParams: [
+      string,
+      number | undefined,
+      object | undefined,
+      string | undefined
+    ] = [
+      err?.message || 'Unable to process request',
+      err?.code,
+      err?.metadata,
+      err?.stack,
+    ];
+    switch (err?.code) {
+      case Status.PERMISSION_DENIED:
+        return new PermissionError(...errParams);
+      case Status.DATA_LOSS:
+      case Status.INTERNAL:
+      case Status.ABORTED:
+        return new InternalServerError(...errParams);
+      case Status.UNKNOWN:
+        return new UnknownServiceError(...errParams);
+      case Status.UNAVAILABLE:
+        return new ServerUnavailableError(...errParams);
+      case Status.NOT_FOUND:
+        return new NotFoundError(...errParams);
+      case Status.OUT_OF_RANGE:
+      case Status.UNIMPLEMENTED:
+        return new BadRequestError(...errParams);
+      case Status.FAILED_PRECONDITION:
+        return new FailedPreconditionError(...errParams);
+      case Status.INVALID_ARGUMENT:
+        return new InvalidArgumentError(...errParams);
+      case Status.CANCELLED:
+        return new CancelledError(...errParams);
+      case Status.DEADLINE_EXCEEDED:
+        return new TimeoutError(...errParams);
+      case Status.UNAUTHENTICATED:
+        return new AuthenticationError(...errParams);
+      case Status.RESOURCE_EXHAUSTED:
+        return new LimitExceededError(...errParams);
+      case Status.ALREADY_EXISTS:
+        return new AlreadyExistsError(...errParams);
+      default:
+        return new UnknownError(...errParams);
+    }
   }
 }

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -97,7 +97,7 @@ export class CacheControlClient {
               if (err.code === Status.ALREADY_EXISTS) {
                 resolve(new CreateCache.AlreadyExists());
               } else {
-                this.cacheServiceErrorMapper.handleError({
+                this.cacheServiceErrorMapper.resolveOrRejectError({
                   err: err,
                   errorResponseFactoryFn: e => new CreateCache.Error(e),
                   resolveFn: resolve,
@@ -130,7 +130,7 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, _resp) => {
             if (err) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new DeleteCache.Error(e),
                 resolveFn: resolve,
@@ -170,7 +170,7 @@ export class CacheControlClient {
           if (resp) {
             resolve(new CacheFlush.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheFlush.Error(e),
               resolveFn: resolve,
@@ -191,7 +191,7 @@ export class CacheControlClient {
         .getClient()
         .ListCaches(request, {interceptors: this.interceptors}, (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new ListCaches.Error(e),
               resolveFn: resolve,
@@ -241,7 +241,7 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new CreateSigningKey.Error(e),
                 resolveFn: resolve,
@@ -267,7 +267,7 @@ export class CacheControlClient {
         .getClient()
         .RevokeSigningKey(request, {interceptors: this.interceptors}, err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new RevokeSigningKey.Error(e),
               resolveFn: resolve,
@@ -294,7 +294,7 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new ListSigningKeys.Error(e),
                 resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -25,7 +25,6 @@ import {
   validateCacheName,
   validateTtlMinutes,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {_SigningKey} from '@gomomento/sdk-core/dist/src/messages/responses/grpc-response-types';
 import {
   CacheLimits,
@@ -80,7 +79,10 @@ export class CacheControlClient {
     try {
       validateCacheName(name);
     } catch (err) {
-      return new CreateCache.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateCache.Error(err)
+      );
     }
     this.logger.debug(`Creating cache: ${name}`);
     const request = new grpcControl._CreateCacheRequest({
@@ -116,7 +118,10 @@ export class CacheControlClient {
     try {
       validateCacheName(name);
     } catch (err) {
-      return new DeleteCache.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new DeleteCache.Error(err)
+      );
     }
     const request = new grpcControl._DeleteCacheRequest({
       cache_name: name,
@@ -148,7 +153,10 @@ export class CacheControlClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheFlush.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheFlush.Error(err)
+      );
     }
     this.logger.debug(`Flushing cache: ${cacheName}`);
     return await this.sendFlushCache(cacheName);
@@ -228,7 +236,10 @@ export class CacheControlClient {
     try {
       validateTtlMinutes(ttlMinutes);
     } catch (err) {
-      return new CreateSigningKey.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateSigningKey.Error(err)
+      );
     }
     this.logger.debug("Issuing 'createSigningKey' request");
     const request = new grpcControl._CreateSigningKeyRequest();

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -97,12 +97,12 @@ export class CacheControlClient {
               if (err.code === Status.ALREADY_EXISTS) {
                 resolve(new CreateCache.AlreadyExists());
               } else {
-                this.cacheServiceErrorMapper.handleError(
-                  err,
-                  e => new CreateCache.Error(e),
-                  resolve,
-                  reject
-                );
+                this.cacheServiceErrorMapper.handleError({
+                  err: err,
+                  errorResponseFactoryFn: e => new CreateCache.Error(e),
+                  resolveFn: resolve,
+                  rejectFn: reject,
+                });
               }
             } else {
               resolve(new CreateCache.Success());
@@ -130,12 +130,12 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, _resp) => {
             if (err) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new DeleteCache.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new DeleteCache.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               resolve(new DeleteCache.Success());
             }
@@ -170,12 +170,12 @@ export class CacheControlClient {
           if (resp) {
             resolve(new CacheFlush.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheFlush.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheFlush.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -191,12 +191,12 @@ export class CacheControlClient {
         .getClient()
         .ListCaches(request, {interceptors: this.interceptors}, (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new ListCaches.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new ListCaches.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             const caches = resp.cache.map(cache => {
               const cacheName = cache.cache_name;
@@ -241,12 +241,12 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CreateSigningKey.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new CreateSigningKey.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               const signingKey = new _SigningKey(resp?.key, resp?.expires_at);
               resolve(new CreateSigningKey.Success(endpoint, signingKey));
@@ -267,12 +267,12 @@ export class CacheControlClient {
         .getClient()
         .RevokeSigningKey(request, {interceptors: this.interceptors}, err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new RevokeSigningKey.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new RevokeSigningKey.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new RevokeSigningKey.Success());
           }
@@ -294,12 +294,12 @@ export class CacheControlClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new ListSigningKeys.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new ListSigningKeys.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               const signingKeys = resp.signing_key.map(
                 sk => new _SigningKey(sk.key_id, sk.expires_at)

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -338,12 +338,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSet.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSet.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSet.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -384,12 +384,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheSetFetch.Hit(resp.found.elements));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -440,12 +440,12 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetAddElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetAddElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSetAddElements.Success());
           }
@@ -497,12 +497,12 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSetRemoveElements.Success());
           }
@@ -583,12 +583,12 @@ export class CacheDataClient implements IDataClient {
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetIfNotExists.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetIfNotExists.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -627,12 +627,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDelete.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDelete.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -694,12 +694,12 @@ export class CacheDataClient implements IDataClient {
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheGet.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheGet.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -771,12 +771,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListConcatenateBack.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListConcatenateBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheListConcatenateBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -848,12 +849,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListConcatenateFront.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListConcatenateFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheListConcatenateFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -923,12 +925,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListFetch.Hit(resp.found.values));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1004,12 +1006,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListRetain.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListRetain.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListRetain.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1054,12 +1056,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListLength.Hit(resp.found.length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1108,12 +1110,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListPopBack.Hit(resp.found.back));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPopBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPopBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1162,12 +1164,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListPopFront.Hit(resp.found.front));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPopFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPopFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1235,12 +1237,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListPushBack.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPushBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPushBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1308,12 +1310,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListPushFront.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPushFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPushFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1366,12 +1368,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListRemoveValue.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListRemoveValue.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListRemoveValue.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1420,12 +1422,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.missing) {
             resolve(new CacheDictionaryFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionaryFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1491,12 +1493,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionarySetField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionarySetField.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionarySetField.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1565,12 +1567,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionarySetFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionarySetFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionarySetFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1649,12 +1652,13 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryGetField.Error(e, field),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryGetField.Error(e, field),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1716,12 +1720,13 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.dictionary === 'missing') {
             resolve(new CacheDictionaryGetFields.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryGetFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryGetFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1778,12 +1783,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionaryRemoveField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryRemoveField.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryRemoveField.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1840,12 +1846,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionaryRemoveFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryRemoveFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryRemoveFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1897,12 +1904,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheDictionaryLength.Hit(resp.found.length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionaryLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1964,12 +1971,12 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheIncrement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheIncrement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2042,12 +2049,13 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheDictionaryIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryIncrement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryIncrement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2117,12 +2125,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSortedSetPutElement.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetPutElement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetPutElement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2193,12 +2202,13 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSortedSetPutElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetPutElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetPutElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2308,12 +2318,12 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2452,12 +2462,12 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2524,12 +2534,12 @@ export class CacheDataClient implements IDataClient {
                 resolve(new CacheSortedSetGetRank.Hit(resp.element_rank.rank));
               }
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CacheSortedSetGetRank.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new CacheSortedSetGetRank.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           }
         );
@@ -2618,12 +2628,13 @@ export class CacheDataClient implements IDataClient {
               });
               resolve(new CacheSortedSetGetScores.Hit(elements, values));
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CacheSortedSetGetScores.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e =>
+                  new CacheSortedSetGetScores.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           }
         );
@@ -2698,12 +2709,13 @@ export class CacheDataClient implements IDataClient {
                 resolve(new CacheSortedSetIncrementScore.Success(0));
               }
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CacheSortedSetIncrementScore.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e =>
+                  new CacheSortedSetIncrementScore.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           }
         );
@@ -2759,12 +2771,13 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetRemoveElement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetRemoveElement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSortedSetRemoveElement.Success());
           }
@@ -2822,12 +2835,13 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSortedSetRemoveElements.Success());
           }
@@ -2887,12 +2901,12 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheSortedSetLength.Hit(resp.found.length));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2973,12 +2987,13 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheSortedSetLengthByScore.Hit(resp.found.length));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetLengthByScore.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetLengthByScore.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3108,12 +3123,12 @@ export class CacheDataClient implements IDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheItemGetType.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheItemGetType.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3152,12 +3167,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheItemGetTtl.Hit(resp.found.remaining_ttl_millis));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheItemGetTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheItemGetTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3204,12 +3219,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheKeyExists.Success(resp.exists));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheKeyExists.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheKeyExists.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3269,12 +3284,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheUpdateTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheUpdateTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheUpdateTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3321,12 +3336,12 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheKeysExist.Success(resp.exists));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheKeysExist.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheKeysExist.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3386,12 +3401,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheIncreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheIncreaseTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheIncreaseTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3451,12 +3466,12 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheDecreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDecreaseTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDecreaseTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -301,8 +301,9 @@ export class CacheDataClient implements IDataClient {
       );
     }
     if (ttl && ttl < 0) {
-      return new CacheSet.Error(
-        new InvalidArgumentError('ttl must be a positive integer')
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        new InvalidArgumentError('ttl must be a positive integer'),
+        err => new CacheSet.Error(err)
       );
     }
     const ttlToUse = ttl || this.defaultTtlSeconds;
@@ -537,8 +538,9 @@ export class CacheDataClient implements IDataClient {
       );
     }
     if (ttl && ttl < 0) {
-      return new CacheSetIfNotExists.Error(
-        new InvalidArgumentError('ttl must be a positive integer')
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        new InvalidArgumentError('ttl must be a positive integer'),
+        err => new CacheSetIfNotExists.Error(err)
       );
     }
     this.logger.trace(
@@ -2633,15 +2635,15 @@ export class CacheDataClient implements IDataClient {
     } else if (responses instanceof CacheSortedSetGetScores.Miss) {
       return new CacheSortedSetGetScore.Miss(this.convert(value));
     } else if (responses instanceof CacheSortedSetGetScores.Error) {
-      return new CacheSortedSetGetScore.Error(
+      return this.cacheServiceErrorMapper.returnOrThrowError(
         responses.innerException(),
-        this.convert(value)
+        err => new CacheSortedSetGetScore.Error(err, this.convert(value))
       );
     }
 
-    return new CacheSortedSetGetScore.Error(
+    return this.cacheServiceErrorMapper.returnOrThrowError(
       new UnknownError('Unknown response type'),
-      this.convert(value)
+      err => new CacheSortedSetGetScore.Error(err, this.convert(value))
     );
   }
 

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -91,7 +91,6 @@ import {
   _ECacheResult,
   _SortedSetGetScoreResponsePart,
 } from '@gomomento/sdk-core/dist/src/messages/responses/grpc-response-types';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import grpcCache = cache.cache_client;
 import _Unbounded = cache_client._Unbounded;
 import ECacheResult = cache_client.ECacheResult;
@@ -296,7 +295,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheSet.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSet.Error(err)
+      );
     }
     if (ttl && ttl < 0) {
       return new CacheSet.Error(
@@ -358,7 +360,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetFetch.Error(err)
+      );
     }
     return await this.sendSetFetch(cacheName, this.convert(setName));
   }
@@ -406,7 +411,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetAddElements.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetAddElements.Error(err)
+      );
     }
     return await this.sendSetAddElements(
       cacheName,
@@ -463,7 +471,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetRemoveElements.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetRemoveElements.Error(err)
+      );
     }
     return await this.sendSetRemoveElements(
       cacheName,
@@ -520,7 +531,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheSetIfNotExists.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetIfNotExists.Error(err)
+      );
     }
     if (ttl && ttl < 0) {
       return new CacheSetIfNotExists.Error(
@@ -602,7 +616,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheDelete.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDelete.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'delete' request; key: ${key.toString()}`);
     return await this.sendDelete(cacheName, this.convert(key));
@@ -646,7 +663,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheGet.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheGet.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
     const result = await this.sendGet(cacheName, this.convert(key));
@@ -717,8 +737,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListConcatenateBack.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListConcatenateBack.Error(err)
       );
     }
 
@@ -795,8 +816,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListConcatenateFront.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListConcatenateFront.Error(err)
       );
     }
 
@@ -873,7 +895,10 @@ export class CacheDataClient implements IDataClient {
       validateListName(listName);
       validateListSliceStartEnd(startIndex, endIndex);
     } catch (err) {
-      return new CacheListFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListFetch.Error(err)
+      );
     }
     this.logger.trace(
       "Issuing 'listFetch' request; listName: %s, startIndex: %s, endIndex: %s",
@@ -949,7 +974,10 @@ export class CacheDataClient implements IDataClient {
       validateListName(listName);
       validateListSliceStartEnd(startIndex, endIndex);
     } catch (err) {
-      return new CacheListRetain.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListRetain.Error(err)
+      );
     }
     this.logger.trace(
       "Issuing 'listRetain' request; listName: %s, startIndex: %s, endIndex: %s, ttl: %s",
@@ -1026,7 +1054,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListLength.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListLength.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'listLength' request; listName: ${listName}`);
     const result = await this.sendListLength(cacheName, this.convert(listName));
@@ -1076,7 +1107,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPopBack.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPopBack.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'listPopBack' request");
@@ -1130,7 +1164,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPopFront.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPopFront.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'listPopFront' request");
@@ -1187,7 +1224,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPushBack.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPushBack.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1260,7 +1300,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPushFront.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPushFront.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1331,7 +1374,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListRemoveValue.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListRemoveValue.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1388,7 +1434,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionaryFetch' request; dictionaryName: ${dictionaryName}`
@@ -1445,7 +1494,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionarySetField.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionarySetField.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
@@ -1517,8 +1569,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionarySetFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionarySetFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1589,9 +1642,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryGetField.Error(
-        normalizeSdkError(err as Error),
-        this.convert(field)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryGetField.Error(err, this.convert(field))
       );
     }
     this.logger.trace(
@@ -1674,8 +1727,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryGetFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryGetFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1742,8 +1796,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryRemoveField.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryRemoveField.Error(err)
       );
     }
     this.logger.trace(
@@ -1805,8 +1860,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryRemoveFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryRemoveFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1867,7 +1923,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryLength.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryLength.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionaryLength' request; dictionaryName: ${dictionaryName}`
@@ -1925,7 +1984,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheIncrement.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheIncrement.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'increment' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
@@ -1994,8 +2056,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryIncrement.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryIncrement.Error(err)
       );
     }
     this.logger.trace(
@@ -2073,8 +2136,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetPutElement.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetPutElement.Error(err)
       );
     }
     this.logger.trace(
@@ -2151,8 +2215,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetPutElements.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetPutElements.Error(err)
       );
     }
     this.logger.trace(
@@ -2227,7 +2292,10 @@ export class CacheDataClient implements IDataClient {
       validateSortedSetName(sortedSetName);
       validateSortedSetRanks(startRank, endRank);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2350,7 +2418,10 @@ export class CacheDataClient implements IDataClient {
         validateSortedSetCount(count);
       }
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2483,7 +2554,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetGetRank.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetGetRank.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2580,7 +2654,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetGetScores.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetGetScores.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2652,8 +2729,9 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetIncrementScore.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetIncrementScore.Error(err)
       );
     }
 
@@ -2731,7 +2809,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetRemoveElement' request");
@@ -2795,7 +2876,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetRemoveElements' request");
@@ -2858,7 +2942,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetLength' request");
@@ -2924,7 +3011,10 @@ export class CacheDataClient implements IDataClient {
       validateSortedSetName(sortedSetName);
       validateSortedSetScores(minScore, maxScore);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -3093,7 +3183,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheItemGetType.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheItemGetType.Error(err)
+      );
     }
     return await this.sendItemGetType(cacheName, this.convert(key));
   }
@@ -3141,7 +3234,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheItemGetTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheItemGetTtl.Error(err)
+      );
     }
     return await this.sendItemGetTtl(cacheName, this.convert(key));
   }
@@ -3186,7 +3282,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheKeyExists.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheKeyExists.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'keyExists' request");
@@ -3240,7 +3339,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheUpdateTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheUpdateTtl.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -3303,7 +3405,10 @@ export class CacheDataClient implements IDataClient {
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheKeysExist.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheKeysExist.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'keysExist' request");
@@ -3357,7 +3462,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheIncreaseTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheIncreaseTtl.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -3422,7 +3530,10 @@ export class CacheDataClient implements IDataClient {
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheDecreaseTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDecreaseTtl.Error(err)
+      );
     }
 
     this.logger.trace(

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -338,7 +338,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSet.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSet.Error(e),
               resolveFn: resolve,
@@ -384,7 +384,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheSetFetch.Hit(resp.found.elements));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetFetch.Error(e),
               resolveFn: resolve,
@@ -440,7 +440,7 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetAddElements.Error(e),
               resolveFn: resolve,
@@ -497,7 +497,7 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetRemoveElements.Error(e),
               resolveFn: resolve,
@@ -583,7 +583,7 @@ export class CacheDataClient implements IDataClient {
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetIfNotExists.Error(e),
               resolveFn: resolve,
@@ -627,7 +627,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDelete.Error(e),
               resolveFn: resolve,
@@ -694,7 +694,7 @@ export class CacheDataClient implements IDataClient {
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheGet.Error(e),
               resolveFn: resolve,
@@ -771,7 +771,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListConcatenateBack.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheListConcatenateBack.Error(e),
@@ -849,7 +849,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListConcatenateFront.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheListConcatenateFront.Error(e),
@@ -925,7 +925,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListFetch.Hit(resp.found.values));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListFetch.Error(e),
               resolveFn: resolve,
@@ -1006,7 +1006,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListRetain.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListRetain.Error(e),
               resolveFn: resolve,
@@ -1056,7 +1056,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListLength.Hit(resp.found.length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListLength.Error(e),
               resolveFn: resolve,
@@ -1110,7 +1110,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListPopBack.Hit(resp.found.back));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPopBack.Error(e),
               resolveFn: resolve,
@@ -1164,7 +1164,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheListPopFront.Hit(resp.found.front));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPopFront.Error(e),
               resolveFn: resolve,
@@ -1237,7 +1237,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListPushBack.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPushBack.Error(e),
               resolveFn: resolve,
@@ -1310,7 +1310,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListPushFront.Success(resp.list_length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPushFront.Error(e),
               resolveFn: resolve,
@@ -1368,7 +1368,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheListRemoveValue.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListRemoveValue.Error(e),
               resolveFn: resolve,
@@ -1422,7 +1422,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.missing) {
             resolve(new CacheDictionaryFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionaryFetch.Error(e),
               resolveFn: resolve,
@@ -1493,7 +1493,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionarySetField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionarySetField.Error(e),
               resolveFn: resolve,
@@ -1567,7 +1567,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionarySetFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionarySetFields.Error(e),
@@ -1652,7 +1652,7 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryGetField.Error(e, field),
@@ -1720,7 +1720,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.dictionary === 'missing') {
             resolve(new CacheDictionaryGetFields.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryGetFields.Error(e),
@@ -1783,7 +1783,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionaryRemoveField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryRemoveField.Error(e),
@@ -1846,7 +1846,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheDictionaryRemoveFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryRemoveFields.Error(e),
@@ -1904,7 +1904,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheDictionaryLength.Hit(resp.found.length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionaryLength.Error(e),
               resolveFn: resolve,
@@ -1971,7 +1971,7 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheIncrement.Error(e),
               resolveFn: resolve,
@@ -2049,7 +2049,7 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheDictionaryIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryIncrement.Error(e),
@@ -2125,7 +2125,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSortedSetPutElement.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetPutElement.Error(e),
@@ -2202,7 +2202,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheSortedSetPutElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetPutElements.Error(e),
@@ -2318,7 +2318,7 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
               resolveFn: resolve,
@@ -2462,7 +2462,7 @@ export class CacheDataClient implements IDataClient {
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
               resolveFn: resolve,
@@ -2534,7 +2534,7 @@ export class CacheDataClient implements IDataClient {
                 resolve(new CacheSortedSetGetRank.Hit(resp.element_rank.rank));
               }
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new CacheSortedSetGetRank.Error(e),
                 resolveFn: resolve,
@@ -2628,7 +2628,7 @@ export class CacheDataClient implements IDataClient {
               });
               resolve(new CacheSortedSetGetScores.Hit(elements, values));
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e =>
                   new CacheSortedSetGetScores.Error(e),
@@ -2709,7 +2709,7 @@ export class CacheDataClient implements IDataClient {
                 resolve(new CacheSortedSetIncrementScore.Success(0));
               }
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e =>
                   new CacheSortedSetIncrementScore.Error(e),
@@ -2771,7 +2771,7 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetRemoveElement.Error(e),
@@ -2835,7 +2835,7 @@ export class CacheDataClient implements IDataClient {
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetRemoveElements.Error(e),
@@ -2901,7 +2901,7 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheSortedSetLength.Hit(resp.found.length));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetLength.Error(e),
               resolveFn: resolve,
@@ -2987,7 +2987,7 @@ export class CacheDataClient implements IDataClient {
               resolve(new CacheSortedSetLengthByScore.Hit(resp.found.length));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetLengthByScore.Error(e),
@@ -3123,7 +3123,7 @@ export class CacheDataClient implements IDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheItemGetType.Error(e),
               resolveFn: resolve,
@@ -3167,7 +3167,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.found) {
             resolve(new CacheItemGetTtl.Hit(resp.found.remaining_ttl_millis));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheItemGetTtl.Error(e),
               resolveFn: resolve,
@@ -3219,7 +3219,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheKeyExists.Success(resp.exists));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheKeyExists.Error(e),
               resolveFn: resolve,
@@ -3284,7 +3284,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheUpdateTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheUpdateTtl.Error(e),
               resolveFn: resolve,
@@ -3336,7 +3336,7 @@ export class CacheDataClient implements IDataClient {
           if (resp) {
             resolve(new CacheKeysExist.Success(resp.exists));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheKeysExist.Error(e),
               resolveFn: resolve,
@@ -3401,7 +3401,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheIncreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheIncreaseTtl.Error(e),
               resolveFn: resolve,
@@ -3466,7 +3466,7 @@ export class CacheDataClient implements IDataClient {
           } else if (resp?.set) {
             resolve(new CacheDecreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDecreaseTtl.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -124,7 +124,7 @@ export class InternalAuthClient implements IAuthClient {
         {interceptors: this.interceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new GenerateApiKey.Error(e),
               resolveFn: resolve,
@@ -169,7 +169,7 @@ export class InternalAuthClient implements IAuthClient {
         {interceptors: this.interceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new RefreshApiKey.Error(e),
               resolveFn: resolve,
@@ -245,7 +245,7 @@ export class InternalAuthClient implements IAuthClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e =>
                   new GenerateDisposableToken.Error(e),

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -39,7 +39,6 @@ import {
 } from '@gomomento/sdk-core';
 import {IAuthClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {AuthClientProps} from '../auth-client-props';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   asCachePermission,
   asPermissionsObject,
@@ -97,7 +96,10 @@ export class InternalAuthClient implements IAuthClient {
     try {
       permissions = permissionsFromTokenScope(scope);
     } catch (err) {
-      return new GenerateApiKey.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateApiKey.Error(err)
+      );
     }
     const request = new grpcAuth._GenerateApiTokenRequest({
       auth_token: this.creds.getAuthToken(),
@@ -108,7 +110,10 @@ export class InternalAuthClient implements IAuthClient {
       try {
         validateValidForSeconds(expiresIn.seconds());
       } catch (err) {
-        return new GenerateApiKey.Error(normalizeSdkError(err as Error));
+        return this.cacheServiceErrorMapper.returnOrThrowError(
+          err as Error,
+          err => new GenerateApiKey.Error(err)
+        );
       }
 
       request.expires = new Expires({
@@ -207,7 +212,10 @@ export class InternalAuthClient implements IAuthClient {
     try {
       validateDisposableTokenExpiry(expiresIn);
     } catch (err) {
-      return new GenerateDisposableToken.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateDisposableToken.Error(err)
+      );
     }
     const expires = new token.token._GenerateDisposableTokenRequest.Expires({
       valid_for_seconds: expiresIn.seconds(),
@@ -217,7 +225,10 @@ export class InternalAuthClient implements IAuthClient {
     try {
       permissions = permissionsFromDisposableTokenScope(scope);
     } catch (err) {
-      return new GenerateDisposableToken.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateDisposableToken.Error(err)
+      );
     }
 
     const tokenId = disposableTokenProps?.tokenId;
@@ -225,8 +236,9 @@ export class InternalAuthClient implements IAuthClient {
       try {
         validateDisposableTokenTokenID(tokenId);
       } catch (err) {
-        return new GenerateDisposableToken.Error(
-          normalizeSdkError(err as Error)
+        return this.cacheServiceErrorMapper.returnOrThrowError(
+          err as Error,
+          err => new GenerateDisposableToken.Error(err)
         );
       }
     }

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -124,12 +124,12 @@ export class InternalAuthClient implements IAuthClient {
         {interceptors: this.interceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new GenerateApiKey.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new GenerateApiKey.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new GenerateApiKey.Success(
@@ -169,12 +169,12 @@ export class InternalAuthClient implements IAuthClient {
         {interceptors: this.interceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new RefreshApiKey.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new RefreshApiKey.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new RefreshApiKey.Success(
@@ -245,12 +245,13 @@ export class InternalAuthClient implements IAuthClient {
           {interceptors: this.interceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new GenerateDisposableToken.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e =>
+                  new GenerateDisposableToken.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               resolve(
                 new GenerateDisposableToken.Success(

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -11,7 +11,6 @@ import {
   LeaderboardOrder,
 } from '@gomomento/sdk-core';
 import {LeaderboardClientProps} from '../leaderboard-client-props';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   validateLeaderboardNumberOfElements,
   validateSortedSetScores,
@@ -164,7 +163,10 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     try {
       validateLeaderboardNumberOfElements(size);
     } catch (err) {
-      return new LeaderboardUpsert.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardUpsert.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'upsert' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, number of elements: ${size}`
@@ -223,7 +225,10 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
       validateLeaderboardOffset(offsetValue);
       validateLeaderboardCount(countValue);
     } catch (err) {
-      return new LeaderboardFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'fetchByScore' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, order: ${orderValue.toString()}, minScore: ${
@@ -314,7 +319,10 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     try {
       validateLeaderboardRanks(startRank, endRank);
     } catch (err) {
-      return new LeaderboardFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'fetchByRank' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, order: ${rankOrder.toString()}, startRank: ${startRank}, endRank: ${endRank}`
@@ -487,8 +495,9 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     try {
       validateLeaderboardNumberOfElements(ids.length);
     } catch (err) {
-      return new LeaderboardRemoveElements.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardRemoveElements.Error(err)
       );
     }
     this.logger.trace(

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -194,7 +194,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardUpsert.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardUpsert.Error(e),
               resolveFn: resolve,
@@ -291,7 +291,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -365,7 +365,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -423,7 +423,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -467,7 +467,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .count;
             resolve(new LeaderboardLength.Success(length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardLength.Error(e),
               resolveFn: resolve,
@@ -519,7 +519,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardRemoveElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new LeaderboardRemoveElements.Error(e),
@@ -562,7 +562,7 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardDelete.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -194,12 +194,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardUpsert.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardUpsert.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardUpsert.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -291,12 +291,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -365,12 +365,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -423,12 +423,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .elements;
             resolve(new LeaderboardFetch.Success(foundElements));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -467,12 +467,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
               .count;
             resolve(new LeaderboardLength.Success(length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -519,12 +519,13 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardRemoveElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new LeaderboardRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -561,12 +562,12 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           if (resp) {
             resolve(new LeaderboardDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardDelete.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardDelete.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -3,7 +3,7 @@ import grpcPubsub = pubsub.cache_client.pubsub;
 // older versions of node don't have the global util variables https://github.com/nodejs/node/issues/20365
 import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
 import {ClientTimeoutInterceptor} from './grpc/client-timeout-interceptor';
-import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {ChannelCredentials, Interceptor, ServiceError} from '@grpc/grpc-js';
 import {Status} from '@grpc/grpc-js/build/src/constants';
 import {version} from '../../package.json';
@@ -33,6 +33,7 @@ export class PubsubClient extends AbstractPubsubClient {
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
   private static readonly DEFAULT_MAX_SESSION_MEMORY_MB: number = 256;
   protected readonly logger: MomentoLogger;
+  private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly unaryInterceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
 
@@ -47,6 +48,9 @@ export class PubsubClient extends AbstractPubsubClient {
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
     this.logger = this.configuration.getLoggerFactory().getLogger(this);
+    this.cacheServiceErrorMapper = new CacheServiceErrorMapper(
+      this.configuration.getThrowOnErrors()
+    );
     this.unaryRequestTimeoutMs = PubsubClient.DEFAULT_REQUEST_TIMEOUT_MS;
     this.logger.debug(
       `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
@@ -105,7 +109,7 @@ export class PubsubClient extends AbstractPubsubClient {
       value: topicValue,
     });
 
-    return await new Promise(resolve => {
+    return await new Promise((resolve, reject) => {
       this.client.Publish(
         request,
         {
@@ -115,7 +119,12 @@ export class PubsubClient extends AbstractPubsubClient {
           if (resp) {
             resolve(new TopicPublish.Success());
           } else {
-            resolve(new TopicPublish.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new TopicPublish.Error(e),
+              resolve,
+              reject
+            );
           }
         }
       );
@@ -158,7 +167,7 @@ export class PubsubClient extends AbstractPubsubClient {
       call.cancel();
     };
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const prepareCallbackOptions: PrepareSubscribeCallbackOptions = {
         ...options,
         restartedDueToError: false,
@@ -244,7 +253,7 @@ export class PubsubClient extends AbstractPubsubClient {
         serviceError.code === Status.INTERNAL &&
         serviceError.details === PubsubClient.RST_STREAM_NO_ERROR_MESSAGE;
       const momentoError = new TopicSubscribe.Error(
-        cacheServiceErrorMapper(serviceError)
+        this.cacheServiceErrorMapper.convertError(serviceError)
       );
       this.handleSubscribeError(options, momentoError, isRstStreamNoError);
     };

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -119,12 +119,12 @@ export class PubsubClient extends AbstractPubsubClient {
           if (resp) {
             resolve(new TopicPublish.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new TopicPublish.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new TopicPublish.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -25,7 +25,7 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/clients/pubsub/AbstractPubsubClient';
 import {TopicConfiguration} from '../config/topic-configuration';
 
-export class PubsubClient extends AbstractPubsubClient {
+export class PubsubClient extends AbstractPubsubClient<ServiceError> {
   private readonly client: grpcPubsub.PubsubClient;
   private readonly configuration: TopicConfiguration;
   protected readonly credentialProvider: CredentialProvider;
@@ -33,7 +33,7 @@ export class PubsubClient extends AbstractPubsubClient {
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
   private static readonly DEFAULT_MAX_SESSION_MEMORY_MB: number = 256;
   protected readonly logger: MomentoLogger;
-  private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
+  protected readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly unaryInterceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
 

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -119,7 +119,7 @@ export class PubsubClient extends AbstractPubsubClient {
           if (resp) {
             resolve(new TopicPublish.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new TopicPublish.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -110,12 +110,13 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
           new grpcControl._SimilarityMetric._CosineSimilarity();
         break;
       default:
-        return new CreateVectorIndex.Error(
+        this.cacheServiceErrorMapper.returnOrThrowError(
           new InvalidArgumentError(
             `Invalid similarity metric: ${
               similarityMetric as unknown as string
             }`
-          )
+          ),
+          err => new CreateVectorIndex.Error(err)
         );
     }
     request.similarity_metric = similarityMetricPb;

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -130,7 +130,7 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
             if (err.code === Status.ALREADY_EXISTS) {
               resolve(new CreateVectorIndex.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new CreateVectorIndex.Error(e),
                 resolveFn: resolve,
@@ -158,7 +158,7 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
             if (err || !resp) {
               // TODO: `Argument of type 'unknown' is not assignable to parameter of type 'Error'.`
               //  I don't see how this is different from the other methods here. So, yeah, what?
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new ListVectorIndexes.Error(e),
                 resolveFn: resolve,
@@ -219,7 +219,7 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new DeleteVectorIndex.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -130,12 +130,12 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
             if (err.code === Status.ALREADY_EXISTS) {
               resolve(new CreateVectorIndex.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CreateVectorIndex.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new CreateVectorIndex.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           } else {
             resolve(new CreateVectorIndex.Success());
@@ -158,12 +158,12 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
             if (err || !resp) {
               // TODO: `Argument of type 'unknown' is not assignable to parameter of type 'Error'.`
               //  I don't see how this is different from the other methods here. So, yeah, what?
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new ListVectorIndexes.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new ListVectorIndexes.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               const indexes = resp.indexes.map(index => {
                 let similarityMetric: VectorSimilarityMetric =
@@ -219,12 +219,12 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new DeleteVectorIndex.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new DeleteVectorIndex.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new DeleteVectorIndex.Success());
           }

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -18,10 +18,7 @@ import {
   validateIndexName,
   validateNumDimensions,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {
-  normalizeSdkError,
-  UnknownError,
-} from '@gomomento/sdk-core/dist/src/errors';
+import {UnknownError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   CreateVectorIndex,
   DeleteVectorIndex,
@@ -86,7 +83,10 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
       validateIndexName(indexName);
       validateNumDimensions(numDimensions);
     } catch (err) {
-      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateVectorIndex.Error(err)
+      );
     }
     this.logger.debug("Issuing 'createIndex' request");
     const request = new grpcControl._CreateIndexRequest();
@@ -206,7 +206,10 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
     try {
       validateIndexName(name);
     } catch (err) {
-      return new DeleteVectorIndex.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new DeleteVectorIndex.Error(err)
+      );
     }
     const request = new grpcControl._DeleteIndexRequest({
       index_name: name,

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -27,10 +27,7 @@ import {
   validateIndexName,
   validateTopK,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {
-  UnknownError,
-  normalizeSdkError,
-} from '@gomomento/sdk-core/dist/src/errors';
+import {UnknownError} from '@gomomento/sdk-core/dist/src/errors';
 import {ALL_VECTOR_METADATA} from '@gomomento/sdk-core/dist/src/clients/IVectorIndexClient';
 
 export class VectorIndexDataClient implements IVectorIndexDataClient {
@@ -99,7 +96,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         items
       );
     } catch (err) {
-      return new VectorUpsertItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorUpsertItemBatch.Error(err)
+      );
     }
     return await this.sendUpsertItemBatch(indexName, request);
   }
@@ -199,7 +199,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorDeleteItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorDeleteItemBatch.Error(err)
+      );
     }
     return await this.sendDeleteItemBatch(indexName, ids);
   }
@@ -243,7 +246,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         validateTopK(options.topK);
       }
     } catch (err) {
-      return new VectorSearch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorSearch.Error(err)
+      );
     }
     return await this.sendSearch(indexName, queryVector, options);
   }
@@ -368,8 +374,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         validateTopK(options.topK);
       }
     } catch (err) {
-      return new VectorSearchAndFetchVectors.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorSearchAndFetchVectors.Error(err)
       );
     }
     return await this.sendSearchAndFetchVectors(
@@ -439,7 +446,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorGetItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorGetItemBatch.Error(err)
+      );
     }
     return await this.sendGetItemBatch(indexName, ids);
   }
@@ -518,8 +528,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorGetItemMetadataBatch.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorGetItemMetadataBatch.Error(err)
       );
     }
     return await this.sendGetItemMetadataBatch(indexName, ids);

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -180,7 +180,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorUpsertItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorUpsertItemBatch.Error(e),
               resolveFn: resolve,
@@ -220,7 +220,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorDeleteItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorDeleteItemBatch.Error(e),
               resolveFn: resolve,
@@ -345,7 +345,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorSearch.Error(e),
               resolveFn: resolve,
@@ -419,7 +419,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new VectorSearchAndFetchVectors.Error(e),
@@ -499,7 +499,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorGetItemBatch.Error(e),
               resolveFn: resolve,
@@ -577,7 +577,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new VectorGetItemMetadataBatch.Error(e),

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -180,12 +180,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorUpsertItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorUpsertItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorUpsertItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -220,12 +220,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorDeleteItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorDeleteItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorDeleteItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -345,12 +345,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorSearch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorSearch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -419,12 +419,13 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorSearchAndFetchVectors.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new VectorSearchAndFetchVectors.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -498,12 +499,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorGetItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorGetItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -576,12 +577,13 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorGetItemMetadataBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new VectorGetItemMetadataBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -77,7 +77,7 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new DeleteWebhook.Error(e),
               resolveFn: resolve,
@@ -106,7 +106,7 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new ListWebhooks.Error(e),
               resolveFn: resolve,
@@ -162,7 +162,7 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new PutWebhook.Error(e),
               resolveFn: resolve,
@@ -196,7 +196,7 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new GetWebhookSecret.Error(e),
               resolveFn: resolve,
@@ -242,7 +242,7 @@ export class WebhookClient implements IWebhookClient {
           {interceptors: this.unaryInterceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new RotateWebhookSecret.Error(e),
                 resolveFn: resolve,

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -24,7 +24,6 @@ import {
   validateTopicName,
   validateWebhookName,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 
 export class WebhookClient implements IWebhookClient {
   private readonly webhookClient: grpcWebhook.WebhookClient;
@@ -61,7 +60,10 @@ export class WebhookClient implements IWebhookClient {
     try {
       validateCacheName(id.cacheName);
     } catch (err) {
-      return new DeleteWebhook.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new DeleteWebhook.Error(err)
+      );
     }
     const request = new grpcWebhook._DeleteWebhookRequest({
       webhook_id: new grpcWebhook._WebhookId({
@@ -95,7 +97,10 @@ export class WebhookClient implements IWebhookClient {
     try {
       validateCacheName(cache);
     } catch (err) {
-      return new ListWebhooks.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new ListWebhooks.Error(err)
+      );
     }
     const request = new grpcWebhook._ListWebhookRequest({cache_name: cache});
     this.logger.debug('issuing "ListWebhooks" request');
@@ -139,7 +144,10 @@ export class WebhookClient implements IWebhookClient {
       validateTopicName(webhook.topicName);
       validateWebhookName(webhook.id.webhookName);
     } catch (err) {
-      return new PutWebhook.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new PutWebhook.Error(err)
+      );
     }
 
     const request = new grpcWebhook._PutWebhookRequest({
@@ -181,7 +189,10 @@ export class WebhookClient implements IWebhookClient {
       validateCacheName(id.cacheName);
       validateWebhookName(id.webhookName);
     } catch (err) {
-      return new GetWebhookSecret.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GetWebhookSecret.Error(err)
+      );
     }
 
     const request = new grpcWebhook._GetWebhookSecretRequest({
@@ -223,7 +234,10 @@ export class WebhookClient implements IWebhookClient {
       validateCacheName(id.cacheName);
       validateWebhookName(id.webhookName);
     } catch (err) {
-      return new RotateWebhookSecret.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new RotateWebhookSecret.Error(err)
+      );
     }
 
     const webhookId = grpcWebhook._WebhookId.fromObject({

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -77,12 +77,12 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new DeleteWebhook.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new DeleteWebhook.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new DeleteWebhook.Success());
           }
@@ -106,12 +106,12 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new ListWebhooks.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new ListWebhooks.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             const webhooks = resp.webhook.map(wh => {
               const webhook: Webhook = {
@@ -162,12 +162,12 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new PutWebhook.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new PutWebhook.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new PutWebhook.Success(resp.secret_string));
           }
@@ -196,12 +196,12 @@ export class WebhookClient implements IWebhookClient {
         {interceptors: this.unaryInterceptors},
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new GetWebhookSecret.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new GetWebhookSecret.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new GetWebhookSecret.Success({
@@ -242,12 +242,12 @@ export class WebhookClient implements IWebhookClient {
           {interceptors: this.unaryInterceptors},
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new RotateWebhookSecret.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new RotateWebhookSecret.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               resolve(
                 new RotateWebhookSecret.Success({

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -86,6 +86,12 @@ function momentoClientForTesting(): CacheClient {
   return new CacheClient(integrationTestCacheClientProps());
 }
 
+function momentoClientForTestingWithThrowOnErrors(): CacheClient {
+  const props = integrationTestCacheClientProps();
+  props.configuration = props.configuration.withThrowOnErrors(true);
+  return new CacheClient(props);
+}
+
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
     configuration:
@@ -125,6 +131,7 @@ function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
 
 export function SetupIntegrationTest(): {
   cacheClient: CacheClient;
+  cacheClientWithThrowOnErrors: CacheClient;
   integrationTestCacheName: string;
 } {
   const cacheName = testCacheName();
@@ -149,7 +156,12 @@ export function SetupIntegrationTest(): {
   });
 
   const client = momentoClientForTesting();
-  return {cacheClient: client, integrationTestCacheName: cacheName};
+  const clientWithThrowOnErrors = momentoClientForTestingWithThrowOnErrors();
+  return {
+    cacheClient: client,
+    cacheClientWithThrowOnErrors: clientWithThrowOnErrors,
+    integrationTestCacheName: cacheName,
+  };
 }
 
 export function SetupTopicIntegrationTest(): {

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -108,6 +108,14 @@ function momentoTopicClientForTesting(): TopicClient {
   });
 }
 
+function momentoTopicClientWithThrowOnErrorsForTesting(): TopicClient {
+  return new TopicClient({
+    configuration:
+      integrationTestCacheClientProps().configuration.withThrowOnErrors(true),
+    credentialProvider: integrationTestCacheClientProps().credentialProvider,
+  });
+}
+
 function momentoTopicClientForTestingWithSessionToken(): TopicClient {
   return new TopicClient({
     configuration: integrationTestCacheClientProps().configuration,
@@ -174,13 +182,17 @@ export function SetupIntegrationTest(): {
 
 export function SetupTopicIntegrationTest(): {
   topicClient: TopicClient;
+  topicClientWithThrowOnErrors: TopicClient;
   cacheClient: CacheClient;
   integrationTestCacheName: string;
 } {
   const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
   const topicClient = momentoTopicClientForTesting();
+  const topicClientWithThrowOnErrors =
+    momentoTopicClientWithThrowOnErrorsForTesting();
   return {
     topicClient,
+    topicClientWithThrowOnErrors,
     cacheClient: cacheClient,
     integrationTestCacheName: integrationTestCacheName,
   };

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -145,6 +145,14 @@ function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
   });
 }
 
+function momentoLeaderboardClientWithThrowOnErrorsForTesting(): PreviewLeaderboardClient {
+  return new PreviewLeaderboardClient({
+    credentialProvider: credsProvider(),
+    configuration:
+      LeaderboardConfigurations.Laptop.latest().withThrowOnErrors(true),
+  });
+}
+
 export function SetupIntegrationTest(): {
   cacheClient: CacheClient;
   cacheClientWithThrowOnErrors: CacheClient;
@@ -210,12 +218,16 @@ export function SetupVectorIntegrationTest(): {
 
 export function SetupLeaderboardIntegrationTest(): {
   leaderboardClient: PreviewLeaderboardClient;
+  leaderboardClientWithThrowOnErrors: PreviewLeaderboardClient;
   integrationTestCacheName: string;
 } {
   const {integrationTestCacheName} = SetupIntegrationTest();
   const leaderboardClient = momentoLeaderboardClientForTesting();
+  const leaderboardClientWithThrowOnErrors =
+    momentoLeaderboardClientWithThrowOnErrorsForTesting();
   return {
     leaderboardClient,
+    leaderboardClientWithThrowOnErrors,
     integrationTestCacheName: integrationTestCacheName,
   };
 }

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -122,6 +122,14 @@ function momentoVectorClientForTesting(): PreviewVectorIndexClient {
   });
 }
 
+function momentoVectorClientWithThrowsOnErrorsForTesting(): PreviewVectorIndexClient {
+  return new PreviewVectorIndexClient({
+    credentialProvider: credsProvider(),
+    configuration:
+      VectorIndexConfigurations.Laptop.latest().withThrowOnErrors(true),
+  });
+}
+
 function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
   return new PreviewLeaderboardClient({
     credentialProvider: credsProvider(),
@@ -180,9 +188,12 @@ export function SetupTopicIntegrationTest(): {
 
 export function SetupVectorIntegrationTest(): {
   vectorClient: PreviewVectorIndexClient;
+  vectorClientWithThrowOnErrors: PreviewVectorIndexClient;
 } {
   const vectorClient = momentoVectorClientForTesting();
-  return {vectorClient};
+  const vectorClientWithThrowOnErrors =
+    momentoVectorClientWithThrowsOnErrorsForTesting();
+  return {vectorClient, vectorClientWithThrowOnErrors};
 }
 
 export function SetupLeaderboardIntegrationTest(): {

--- a/packages/client-sdk-nodejs/test/integration/shared/get-set-delete.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/get-set-delete.test.ts
@@ -1,6 +1,11 @@
 import {runGetSetDeleteTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, cacheClientWithThrowOnErrors, integrationTestCacheName} =
+  SetupIntegrationTest();
 
-runGetSetDeleteTests(cacheClient, integrationTestCacheName);
+runGetSetDeleteTests(
+  cacheClient,
+  cacheClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-nodejs/test/integration/shared/leaderboard.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/leaderboard.test.ts
@@ -1,7 +1,14 @@
 import {runLeaderboardClientTests} from '@gomomento/common-integration-tests';
 import {SetupLeaderboardIntegrationTest} from '../integration-setup';
 
-const {leaderboardClient, integrationTestCacheName} =
-  SetupLeaderboardIntegrationTest();
+const {
+  leaderboardClient,
+  leaderboardClientWithThrowOnErrors,
+  integrationTestCacheName,
+} = SetupLeaderboardIntegrationTest();
 
-runLeaderboardClientTests(leaderboardClient, integrationTestCacheName);
+runLeaderboardClientTests(
+  leaderboardClient,
+  leaderboardClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-nodejs/test/integration/shared/topic-client.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/topic-client.test.ts
@@ -1,6 +1,15 @@
 import {runTopicClientTests} from '@gomomento/common-integration-tests';
 import {SetupTopicIntegrationTest} from '../integration-setup';
 
-const {topicClient, cacheClient, integrationTestCacheName} =
-  SetupTopicIntegrationTest();
-runTopicClientTests(topicClient, cacheClient, integrationTestCacheName);
+const {
+  topicClient,
+  topicClientWithThrowOnErrors,
+  cacheClient,
+  integrationTestCacheName,
+} = SetupTopicIntegrationTest();
+runTopicClientTests(
+  topicClient,
+  topicClientWithThrowOnErrors,
+  cacheClient,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-nodejs/test/integration/shared/vector-data-plane.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/vector-data-plane.test.ts
@@ -1,6 +1,7 @@
 import {runVectorDataPlaneTest} from '@gomomento/common-integration-tests';
 import {SetupVectorIntegrationTest} from '../integration-setup';
 
-const {vectorClient} = SetupVectorIntegrationTest();
+const {vectorClient, vectorClientWithThrowOnErrors} =
+  SetupVectorIntegrationTest();
 
-runVectorDataPlaneTest(vectorClient);
+runVectorDataPlaneTest(vectorClient, vectorClientWithThrowOnErrors);

--- a/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
@@ -49,7 +49,7 @@ describe('CacheServiceErrorMapper', () => {
 
   it('should return permission denied error when Status.PERMISSION_DENIED', () => {
     const serviceError = generateServiceError(Status.PERMISSION_DENIED);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -59,7 +59,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return invalid argument error when grpc status is INVALID_ARGUMENT', () => {
     const serviceError = generateServiceError(Status.INVALID_ARGUMENT);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -69,7 +69,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return failed precondition error when grpc status is FAILED_PRECONDITION', () => {
     const serviceError = generateServiceError(Status.FAILED_PRECONDITION);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -83,7 +83,7 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.UNIMPLEMENTED),
     ];
     serviceErrors.forEach(e => {
-      cacheServiceErrorMapper.handleError({
+      cacheServiceErrorMapper.resolveOrRejectError({
         err: e,
         errorResponseFactoryFn: errorResponseFactoryFn,
         resolveFn: resolveFn,
@@ -94,7 +94,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return cache not found error when grpc status is NOT_FOUND', () => {
     const serviceError = generateServiceError(Status.NOT_FOUND);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -104,7 +104,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return unavailable error when grpc status is UNAVAILABLE', () => {
     const serviceError = generateServiceError(Status.UNAVAILABLE);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -114,7 +114,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return unknown service error when grpc status is UNKNOWN', () => {
     const serviceError = generateServiceError(Status.UNKNOWN);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -129,7 +129,7 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.ABORTED),
     ];
     serviceErrors.forEach(e => {
-      cacheServiceErrorMapper.handleError({
+      cacheServiceErrorMapper.resolveOrRejectError({
         err: e,
         errorResponseFactoryFn: errorResponseFactoryFn,
         resolveFn: resolveFn,
@@ -140,7 +140,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return cancelled error when grpc status is CANCELLED', () => {
     const serviceError = generateServiceError(Status.CANCELLED);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -150,7 +150,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return timeout error when grpc status is DEADLINE_EXCEEDED', () => {
     const serviceError = generateServiceError(Status.DEADLINE_EXCEEDED);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -160,7 +160,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return authentication error when grpc status is UNAUTHENTICATED', () => {
     const serviceError = generateServiceError(Status.UNAUTHENTICATED);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -170,7 +170,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return limit exceeded error when grpc status is RESOURCE_EXHAUSTED', () => {
     const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -180,7 +180,7 @@ describe('CacheServiceErrorMapper', () => {
   });
   it('should return already exists error when grpc status is ALREADY_EXISTS', () => {
     const serviceError = generateServiceError(Status.ALREADY_EXISTS);
-    cacheServiceErrorMapper.handleError({
+    cacheServiceErrorMapper.resolveOrRejectError({
       err: serviceError,
       errorResponseFactoryFn: errorResponseFactoryFn,
       resolveFn: resolveFn,
@@ -194,7 +194,7 @@ describe('CacheServiceErrorMapper', () => {
 
     it('should reject with LimitExceeded when grpc status is RESOURCE_EXHAUSTED', () => {
       const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
-      mapperWithThrowOnErrors.handleError({
+      mapperWithThrowOnErrors.resolveOrRejectError({
         err: serviceError,
         errorResponseFactoryFn: errorResponseFactoryFn,
         resolveFn: resolveFn,

--- a/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
@@ -49,32 +49,32 @@ describe('CacheServiceErrorMapper', () => {
 
   it('should return permission denied error when Status.PERMISSION_DENIED', () => {
     const serviceError = generateServiceError(Status.PERMISSION_DENIED);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(PermissionError);
   });
   it('should return invalid argument error when grpc status is INVALID_ARGUMENT', () => {
     const serviceError = generateServiceError(Status.INVALID_ARGUMENT);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(InvalidArgumentError);
   });
   it('should return failed precondition error when grpc status is FAILED_PRECONDITION', () => {
     const serviceError = generateServiceError(Status.FAILED_PRECONDITION);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(FailedPreconditionError);
   });
   it('should return bad request error when grpc status is OUT_OF_RANGE or UNIMPLEMENTED', () => {
@@ -83,43 +83,43 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.UNIMPLEMENTED),
     ];
     serviceErrors.forEach(e => {
-      cacheServiceErrorMapper.handleError(
-        e,
-        errorResponseFactoryFn,
-        resolveFn,
-        rejectFn
-      );
+      cacheServiceErrorMapper.handleError({
+        err: e,
+        errorResponseFactoryFn: errorResponseFactoryFn,
+        resolveFn: resolveFn,
+        rejectFn: rejectFn,
+      });
       expect(resolved).toBeInstanceOf(BadRequestError);
     });
   });
   it('should return cache not found error when grpc status is NOT_FOUND', () => {
     const serviceError = generateServiceError(Status.NOT_FOUND);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(NotFoundError);
   });
   it('should return unavailable error when grpc status is UNAVAILABLE', () => {
     const serviceError = generateServiceError(Status.UNAVAILABLE);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(ServerUnavailableError);
   });
   it('should return unknown service error when grpc status is UNKNOWN', () => {
     const serviceError = generateServiceError(Status.UNKNOWN);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(UnknownServiceError);
   });
   it('should return internal server error when grpc status is DATA_LOSS, INTERNAL, ABORTED', () => {
@@ -129,63 +129,63 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.ABORTED),
     ];
     serviceErrors.forEach(e => {
-      cacheServiceErrorMapper.handleError(
-        e,
-        errorResponseFactoryFn,
-        resolveFn,
-        rejectFn
-      );
+      cacheServiceErrorMapper.handleError({
+        err: e,
+        errorResponseFactoryFn: errorResponseFactoryFn,
+        resolveFn: resolveFn,
+        rejectFn: rejectFn,
+      });
       expect(resolved).toBeInstanceOf(InternalServerError);
     });
   });
   it('should return cancelled error when grpc status is CANCELLED', () => {
     const serviceError = generateServiceError(Status.CANCELLED);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(CancelledError);
   });
   it('should return timeout error when grpc status is DEADLINE_EXCEEDED', () => {
     const serviceError = generateServiceError(Status.DEADLINE_EXCEEDED);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(TimeoutError);
   });
   it('should return authentication error when grpc status is UNAUTHENTICATED', () => {
     const serviceError = generateServiceError(Status.UNAUTHENTICATED);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(AuthenticationError);
   });
   it('should return limit exceeded error when grpc status is RESOURCE_EXHAUSTED', () => {
     const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(LimitExceededError);
   });
   it('should return already exists error when grpc status is ALREADY_EXISTS', () => {
     const serviceError = generateServiceError(Status.ALREADY_EXISTS);
-    cacheServiceErrorMapper.handleError(
-      serviceError,
-      errorResponseFactoryFn,
-      resolveFn,
-      rejectFn
-    );
+    cacheServiceErrorMapper.handleError({
+      err: serviceError,
+      errorResponseFactoryFn: errorResponseFactoryFn,
+      resolveFn: resolveFn,
+      rejectFn: rejectFn,
+    });
     expect(resolved).toBeInstanceOf(AlreadyExistsError);
   });
 
@@ -194,12 +194,12 @@ describe('CacheServiceErrorMapper', () => {
 
     it('should reject with LimitExceeded when grpc status is RESOURCE_EXHAUSTED', () => {
       const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
-      mapperWithThrowOnErrors.handleError(
-        serviceError,
-        errorResponseFactoryFn,
-        resolveFn,
-        rejectFn
-      );
+      mapperWithThrowOnErrors.handleError({
+        err: serviceError,
+        errorResponseFactoryFn: errorResponseFactoryFn,
+        resolveFn: resolveFn,
+        rejectFn: rejectFn,
+      });
       expect(rejected).toBeInstanceOf(LimitExceededError);
     });
   });

--- a/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-service-error-mapper.test.ts
@@ -1,5 +1,5 @@
 import {Status} from '@grpc/grpc-js/build/src/constants';
-import {cacheServiceErrorMapper} from '../../src/errors/cache-service-error-mapper';
+import {CacheServiceErrorMapper} from '../../src/errors/cache-service-error-mapper';
 import {Metadata, ServiceError} from '@grpc/grpc-js';
 import {
   AlreadyExistsError,
@@ -12,6 +12,7 @@ import {
   LimitExceededError,
   NotFoundError,
   PermissionError,
+  SdkError,
   ServerUnavailableError,
   TimeoutError,
   UnknownServiceError,
@@ -28,20 +29,53 @@ const generateServiceError = (status: Status): ServiceError => {
 };
 
 describe('CacheServiceErrorMapper', () => {
+  const cacheServiceErrorMapper = new CacheServiceErrorMapper(false);
+  let resolved: SdkError | unknown;
+  let rejected: SdkError | unknown;
+  beforeEach(() => {
+    resolved = undefined;
+    rejected = undefined;
+  });
+
+  const errorResponseFactoryFn = (err: SdkError): never => {
+    return err as never;
+  };
+  const resolveFn = (result: unknown) => {
+    resolved = result;
+  };
+  const rejectFn = (err: SdkError) => {
+    rejected = err;
+  };
+
   it('should return permission denied error when Status.PERMISSION_DENIED', () => {
     const serviceError = generateServiceError(Status.PERMISSION_DENIED);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(PermissionError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(PermissionError);
   });
   it('should return invalid argument error when grpc status is INVALID_ARGUMENT', () => {
     const serviceError = generateServiceError(Status.INVALID_ARGUMENT);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(InvalidArgumentError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(InvalidArgumentError);
   });
   it('should return failed precondition error when grpc status is FAILED_PRECONDITION', () => {
     const serviceError = generateServiceError(Status.FAILED_PRECONDITION);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(FailedPreconditionError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(FailedPreconditionError);
   });
   it('should return bad request error when grpc status is OUT_OF_RANGE or UNIMPLEMENTED', () => {
     const serviceErrors = [
@@ -49,24 +83,44 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.UNIMPLEMENTED),
     ];
     serviceErrors.forEach(e => {
-      const res = cacheServiceErrorMapper(e);
-      expect(res).toBeInstanceOf(BadRequestError);
+      cacheServiceErrorMapper.handleError(
+        e,
+        errorResponseFactoryFn,
+        resolveFn,
+        rejectFn
+      );
+      expect(resolved).toBeInstanceOf(BadRequestError);
     });
   });
   it('should return cache not found error when grpc status is NOT_FOUND', () => {
     const serviceError = generateServiceError(Status.NOT_FOUND);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(NotFoundError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(NotFoundError);
   });
   it('should return unavailable error when grpc status is UNAVAILABLE', () => {
     const serviceError = generateServiceError(Status.UNAVAILABLE);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(ServerUnavailableError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(ServerUnavailableError);
   });
   it('should return unknown service error when grpc status is UNKNOWN', () => {
     const serviceError = generateServiceError(Status.UNKNOWN);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(UnknownServiceError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(UnknownServiceError);
   });
   it('should return internal server error when grpc status is DATA_LOSS, INTERNAL, ABORTED', () => {
     const serviceErrors = [
@@ -75,33 +129,78 @@ describe('CacheServiceErrorMapper', () => {
       generateServiceError(Status.ABORTED),
     ];
     serviceErrors.forEach(e => {
-      const res = cacheServiceErrorMapper(e);
-      expect(res).toBeInstanceOf(InternalServerError);
+      cacheServiceErrorMapper.handleError(
+        e,
+        errorResponseFactoryFn,
+        resolveFn,
+        rejectFn
+      );
+      expect(resolved).toBeInstanceOf(InternalServerError);
     });
   });
   it('should return cancelled error when grpc status is CANCELLED', () => {
     const serviceError = generateServiceError(Status.CANCELLED);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(CancelledError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(CancelledError);
   });
   it('should return timeout error when grpc status is DEADLINE_EXCEEDED', () => {
     const serviceError = generateServiceError(Status.DEADLINE_EXCEEDED);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(TimeoutError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(TimeoutError);
   });
   it('should return authentication error when grpc status is UNAUTHENTICATED', () => {
     const serviceError = generateServiceError(Status.UNAUTHENTICATED);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(AuthenticationError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(AuthenticationError);
   });
   it('should return limit exceeded error when grpc status is RESOURCE_EXHAUSTED', () => {
     const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(LimitExceededError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(LimitExceededError);
   });
   it('should return already exists error when grpc status is ALREADY_EXISTS', () => {
     const serviceError = generateServiceError(Status.ALREADY_EXISTS);
-    const res = cacheServiceErrorMapper(serviceError);
-    expect(res).toBeInstanceOf(AlreadyExistsError);
+    cacheServiceErrorMapper.handleError(
+      serviceError,
+      errorResponseFactoryFn,
+      resolveFn,
+      rejectFn
+    );
+    expect(resolved).toBeInstanceOf(AlreadyExistsError);
+  });
+
+  describe('when throwOnErrors is true', () => {
+    const mapperWithThrowOnErrors = new CacheServiceErrorMapper(true);
+
+    it('should reject with LimitExceeded when grpc status is RESOURCE_EXHAUSTED', () => {
+      const serviceError = generateServiceError(Status.RESOURCE_EXHAUSTED);
+      mapperWithThrowOnErrors.handleError(
+        serviceError,
+        errorResponseFactoryFn,
+        resolveFn,
+        rejectFn
+      );
+      expect(rejected).toBeInstanceOf(LimitExceededError);
+    });
   });
 });

--- a/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/config/configuration.test.ts
@@ -29,6 +29,7 @@ describe('configuration.ts', () => {
     retryStrategy: testRetryStrategy,
     transportStrategy: testTransportStrategy,
     middlewares: testMiddlewares,
+    throwOnErrors: false,
   });
 
   it('should support overriding retry strategy', () => {
@@ -93,6 +94,21 @@ describe('configuration.ts', () => {
     );
     expect(configWithNewClientTimeout.getTransportStrategy()).toEqual(
       expectedTransportStrategy
+    );
+  });
+
+  it('should support overriding throwOnErrors strategy', () => {
+    const throwOnErrors = true;
+    const configWithThrowOnErrors =
+      testConfiguration.withThrowOnErrors(throwOnErrors);
+    expect(configWithThrowOnErrors.getLoggerFactory()).toEqual(
+      testLoggerFactory
+    );
+    expect(configWithThrowOnErrors.getRetryStrategy()).toEqual(
+      testRetryStrategy
+    );
+    expect(configWithThrowOnErrors.getTransportStrategy()).toEqual(
+      testTransportStrategy
     );
   });
 

--- a/packages/client-sdk-web/src/auth-client-props.ts
+++ b/packages/client-sdk-web/src/auth-client-props.ts
@@ -5,4 +5,11 @@ export interface AuthClientProps {
    * controls how the client will get authentication information for connecting to the Momento service
    */
   credentialProvider: CredentialProvider;
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  throwOnErrors?: boolean;
 }

--- a/packages/client-sdk-web/src/config/configuration.ts
+++ b/packages/client-sdk-web/src/config/configuration.ts
@@ -17,6 +17,11 @@ export interface ConfigurationProps {
    * Configures middleware functions that will wrap each request
    */
   middlewares: Middleware[];
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 /**
@@ -61,17 +66,35 @@ export interface Configuration {
    * @returns {Configuration} a new Configuration object with its TransportStrategy updated to use the specified client timeout
    */
   withClientTimeoutMillis(clientTimeoutMillis: number): Configuration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): Configuration;
 }
 
 export class CacheConfiguration implements Configuration {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TransportStrategy;
   private readonly middlewares: Middleware[] = [];
+  private readonly throwOnErrors: boolean;
 
   constructor(props: ConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
     this.middlewares = props.middlewares;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -87,6 +110,7 @@ export class CacheConfiguration implements Configuration {
       loggerFactory: this.loggerFactory,
       transportStrategy: transportStrategy,
       middlewares: this.middlewares,
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -99,6 +123,7 @@ export class CacheConfiguration implements Configuration {
       loggerFactory: this.loggerFactory,
       transportStrategy: this.transportStrategy,
       middlewares: middlewares,
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -108,6 +133,20 @@ export class CacheConfiguration implements Configuration {
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeout),
       middlewares: this.middlewares,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): Configuration {
+    return new CacheConfiguration({
+      loggerFactory: this.loggerFactory,
+      transportStrategy: this.transportStrategy,
+      middlewares: this.middlewares,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/configurations.ts
+++ b/packages/client-sdk-web/src/config/configurations.ts
@@ -49,6 +49,7 @@ export class Laptop extends CacheConfiguration {
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
       middlewares: [],
+      throwOnErrors: false,
     });
   }
 }
@@ -91,6 +92,7 @@ export class Browser extends CacheConfiguration {
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
       middlewares: [],
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/leaderboard-configuration.ts
+++ b/packages/client-sdk-web/src/config/leaderboard-configuration.ts
@@ -26,6 +26,22 @@ export interface LeaderboardConfiguration {
   withTransportStrategy(
     transportStrategy: TransportStrategy
   ): LeaderboardConfiguration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): LeaderboardConfiguration;
 }
 
 export interface LeaderboardConfigurationProps {
@@ -37,6 +53,10 @@ export interface LeaderboardConfigurationProps {
    * Configures low-level options for network interactions with the Momento service
    */
   transportStrategy: TransportStrategy;
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 export class LeaderboardClientConfiguration
@@ -44,10 +64,12 @@ export class LeaderboardClientConfiguration
 {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TransportStrategy;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: LeaderboardConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -65,6 +87,7 @@ export class LeaderboardClientConfiguration
       loggerFactory: this.loggerFactory,
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeoutMillis),
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -74,6 +97,19 @@ export class LeaderboardClientConfiguration
     return new LeaderboardClientConfiguration({
       loggerFactory: this.loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): LeaderboardConfiguration {
+    return new LeaderboardClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      transportStrategy: this.transportStrategy,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/leaderboard-configurations.ts
+++ b/packages/client-sdk-web/src/config/leaderboard-configurations.ts
@@ -52,6 +52,7 @@ export class Laptop extends LeaderboardClientConfiguration {
     return new Laptop({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/topic-configuration.ts
+++ b/packages/client-sdk-web/src/config/topic-configuration.ts
@@ -5,6 +5,11 @@ export interface TopicConfigurationProps {
    * Configures logging verbosity and format
    */
   loggerFactory: MomentoLoggerFactory;
+
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 /**
@@ -18,16 +23,45 @@ export interface TopicConfiguration {
    * @returns {MomentoLoggerFactory} the current configuration options for logging verbosity and format
    */
   getLoggerFactory(): MomentoLoggerFactory;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): TopicConfiguration;
 }
 
 export class TopicClientConfiguration implements TopicConfiguration {
   private readonly loggerFactory: MomentoLoggerFactory;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: TopicConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
     return this.loggerFactory;
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): TopicConfiguration {
+    return new TopicClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      throwOnErrors: throwOnErrors,
+    });
   }
 }

--- a/packages/client-sdk-web/src/config/topic-configurations.ts
+++ b/packages/client-sdk-web/src/config/topic-configurations.ts
@@ -25,6 +25,7 @@ export class Default extends TopicClientConfiguration {
   ): TopicConfiguration {
     return new TopicClientConfiguration({
       loggerFactory: loggerFactory,
+      throwOnErrors: false,
     });
   }
 }
@@ -58,6 +59,7 @@ export class Laptop extends TopicClientConfiguration {
   ): TopicConfiguration {
     return new Laptop({
       loggerFactory: loggerFactory,
+      throwOnErrors: false,
     });
   }
 }
@@ -91,6 +93,7 @@ export class Browser extends TopicClientConfiguration {
   ): TopicConfiguration {
     return new Browser({
       loggerFactory: loggerFactory,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/vector-index-configuration.ts
+++ b/packages/client-sdk-web/src/config/vector-index-configuration.ts
@@ -26,6 +26,22 @@ export interface VectorIndexConfiguration {
   withTransportStrategy(
     transportStrategy: TransportStrategy
   ): VectorIndexConfiguration;
+
+  /**
+   * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   */
+  getThrowOnErrors(): boolean;
+
+  /**
+   * Copy constructor for configuring whether the client should return a Momento Error object or throw an exception when an
+   * error occurs. By default, this is set to false, and the client will return a Momento Error object on errors. Set it
+   * to true if you prefer for exceptions to be thrown.
+   * @param {boolean} throwOnErrors
+   * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
+   */
+  withThrowOnErrors(throwOnErrors: boolean): VectorIndexConfiguration;
 }
 
 export interface VectorIndexConfigurationProps {
@@ -37,6 +53,10 @@ export interface VectorIndexConfigurationProps {
    * Configures low-level options for network interactions with the Momento service
    */
   transportStrategy: TransportStrategy;
+  /**
+   * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
+   */
+  throwOnErrors: boolean;
 }
 
 export class VectorIndexClientConfiguration
@@ -44,10 +64,12 @@ export class VectorIndexClientConfiguration
 {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TransportStrategy;
+  private readonly throwOnErrors: boolean;
 
   constructor(props: VectorIndexConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
+    this.throwOnErrors = props.throwOnErrors;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -65,6 +87,7 @@ export class VectorIndexClientConfiguration
       loggerFactory: this.loggerFactory,
       transportStrategy:
         this.transportStrategy.withClientTimeoutMillis(clientTimeoutMillis),
+      throwOnErrors: this.throwOnErrors,
     });
   }
 
@@ -74,6 +97,19 @@ export class VectorIndexClientConfiguration
     return new VectorIndexClientConfiguration({
       loggerFactory: this.loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: this.throwOnErrors,
+    });
+  }
+
+  getThrowOnErrors(): boolean {
+    return this.throwOnErrors;
+  }
+
+  withThrowOnErrors(throwOnErrors: boolean): VectorIndexConfiguration {
+    return new VectorIndexClientConfiguration({
+      loggerFactory: this.loggerFactory,
+      transportStrategy: this.transportStrategy,
+      throwOnErrors: throwOnErrors,
     });
   }
 }

--- a/packages/client-sdk-web/src/config/vector-index-configurations.ts
+++ b/packages/client-sdk-web/src/config/vector-index-configurations.ts
@@ -52,6 +52,7 @@ export class Laptop extends VectorIndexClientConfiguration {
     return new Laptop({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }
@@ -93,6 +94,7 @@ export class Browser extends VectorIndexClientConfiguration {
     return new Browser({
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
+      throwOnErrors: false,
     });
   }
 }

--- a/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
@@ -17,6 +17,14 @@ import {
 } from '../../src';
 import {RpcError, StatusCode} from 'grpc-web';
 
+export interface HandleCacheServiceErrorOptions {
+  err: RpcError | null;
+  errorResponseFactoryFn: (err: SdkError) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resolveFn: (result: any) => void;
+  rejectFn: (err: SdkError) => void;
+}
+
 export class CacheServiceErrorMapper {
   private readonly throwOnErrors: boolean;
 
@@ -24,18 +32,12 @@ export class CacheServiceErrorMapper {
     this.throwOnErrors = throwOnErrors;
   }
 
-  handleError(
-    err: RpcError | null,
-    errorResponseFactoryFn: (err: SdkError) => unknown,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    resolveFn: (result: any) => void,
-    rejectFn: (err: SdkError) => void
-  ): void {
-    const error = this.convertError(err);
+  handleError(opts: HandleCacheServiceErrorOptions): void {
+    const error = this.convertError(opts.err);
     if (this.throwOnErrors) {
-      rejectFn(error);
+      opts.rejectFn(error);
     } else {
-      resolveFn(errorResponseFactoryFn(error));
+      opts.resolveFn(opts.errorResponseFactoryFn(error));
     }
   }
 

--- a/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
@@ -17,7 +17,7 @@ import {
 } from '../../src';
 import {RpcError, StatusCode} from 'grpc-web';
 
-export interface HandleCacheServiceErrorOptions {
+export interface ResolveOrRejectErrorOptions {
   err: RpcError | null;
   errorResponseFactoryFn: (err: SdkError) => unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,7 +32,7 @@ export class CacheServiceErrorMapper {
     this.throwOnErrors = throwOnErrors;
   }
 
-  handleError(opts: HandleCacheServiceErrorOptions): void {
+  resolveOrRejectError(opts: ResolveOrRejectErrorOptions): void {
     const error = this.convertError(opts.err);
     if (this.throwOnErrors) {
       opts.rejectFn(error);

--- a/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
@@ -17,49 +17,72 @@ import {
 } from '../../src';
 import {RpcError, StatusCode} from 'grpc-web';
 
-export function cacheServiceErrorMapper(err: RpcError | null): SdkError {
-  const errParams: [
-    string,
-    number | undefined,
-    object | undefined,
-    string | undefined
-  ] = [
-    err?.message || 'Unable to process request',
-    err?.code,
-    err?.metadata,
-    err?.stack,
-  ];
-  switch (err?.code) {
-    case StatusCode.PERMISSION_DENIED:
-      return new PermissionError(...errParams);
-    case StatusCode.DATA_LOSS:
-    case StatusCode.INTERNAL:
-    case StatusCode.ABORTED:
-      return new InternalServerError(...errParams);
-    case StatusCode.UNKNOWN:
-      return new UnknownServiceError(...errParams);
-    case StatusCode.UNAVAILABLE:
-      return new ServerUnavailableError(...errParams);
-    case StatusCode.NOT_FOUND:
-      return new NotFoundError(...errParams);
-    case StatusCode.OUT_OF_RANGE:
-    case StatusCode.UNIMPLEMENTED:
-      return new BadRequestError(...errParams);
-    case StatusCode.FAILED_PRECONDITION:
-      return new FailedPreconditionError(...errParams);
-    case StatusCode.INVALID_ARGUMENT:
-      return new InvalidArgumentError(...errParams);
-    case StatusCode.CANCELLED:
-      return new CancelledError(...errParams);
-    case StatusCode.DEADLINE_EXCEEDED:
-      return new TimeoutError(...errParams);
-    case StatusCode.UNAUTHENTICATED:
-      return new AuthenticationError(...errParams);
-    case StatusCode.RESOURCE_EXHAUSTED:
-      return new LimitExceededError(...errParams);
-    case StatusCode.ALREADY_EXISTS:
-      return new AlreadyExistsError(...errParams);
-    default:
-      return new UnknownError(...errParams);
+export class CacheServiceErrorMapper {
+  private readonly throwOnErrors: boolean;
+
+  constructor(throwOnErrors: boolean) {
+    this.throwOnErrors = throwOnErrors;
+  }
+
+  handleError(
+    err: RpcError | null,
+    errorResponseFactoryFn: (err: SdkError) => unknown,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolveFn: (result: any) => void,
+    rejectFn: (err: SdkError) => void
+  ): void {
+    const error = this.convertError(err);
+    if (this.throwOnErrors) {
+      rejectFn(error);
+    } else {
+      resolveFn(errorResponseFactoryFn(error));
+    }
+  }
+
+  convertError(err: RpcError | null): SdkError {
+    const errParams: [
+      string,
+      number | undefined,
+      object | undefined,
+      string | undefined
+    ] = [
+      err?.message || 'Unable to process request',
+      err?.code,
+      err?.metadata,
+      err?.stack,
+    ];
+    switch (err?.code) {
+      case StatusCode.PERMISSION_DENIED:
+        return new PermissionError(...errParams);
+      case StatusCode.DATA_LOSS:
+      case StatusCode.INTERNAL:
+      case StatusCode.ABORTED:
+        return new InternalServerError(...errParams);
+      case StatusCode.UNKNOWN:
+        return new UnknownServiceError(...errParams);
+      case StatusCode.UNAVAILABLE:
+        return new ServerUnavailableError(...errParams);
+      case StatusCode.NOT_FOUND:
+        return new NotFoundError(...errParams);
+      case StatusCode.OUT_OF_RANGE:
+      case StatusCode.UNIMPLEMENTED:
+        return new BadRequestError(...errParams);
+      case StatusCode.FAILED_PRECONDITION:
+        return new FailedPreconditionError(...errParams);
+      case StatusCode.INVALID_ARGUMENT:
+        return new InvalidArgumentError(...errParams);
+      case StatusCode.CANCELLED:
+        return new CancelledError(...errParams);
+      case StatusCode.DEADLINE_EXCEEDED:
+        return new TimeoutError(...errParams);
+      case StatusCode.UNAUTHENTICATED:
+        return new AuthenticationError(...errParams);
+      case StatusCode.RESOURCE_EXHAUSTED:
+        return new LimitExceededError(...errParams);
+      case StatusCode.ALREADY_EXISTS:
+        return new AlreadyExistsError(...errParams);
+      default:
+        return new UnknownError(...errParams);
+    }
   }
 }

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -139,7 +139,7 @@ export class InternalWebGrpcAuthClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new GenerateApiKey.Error(e),
               resolveFn: resolve,
@@ -183,7 +183,7 @@ export class InternalWebGrpcAuthClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new RefreshApiKey.Error(e),
               resolveFn: resolve,
@@ -259,7 +259,7 @@ export class InternalWebGrpcAuthClient<
           this.clientMetadataProvider.createClientMetadata(),
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e =>
                   new GenerateDisposableToken.Error(e),

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -139,12 +139,12 @@ export class InternalWebGrpcAuthClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new GenerateApiKey.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new GenerateApiKey.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new GenerateApiKey.Success(
@@ -183,12 +183,12 @@ export class InternalWebGrpcAuthClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new RefreshApiKey.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new RefreshApiKey.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new RefreshApiKey.Success(
@@ -259,12 +259,13 @@ export class InternalWebGrpcAuthClient<
           this.clientMetadataProvider.createClientMetadata(),
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new GenerateDisposableToken.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e =>
+                  new GenerateDisposableToken.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               resolve(
                 new GenerateDisposableToken.Success(

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -37,7 +37,6 @@ import {
   validateCacheKeyOrPrefix,
   validateDisposableTokenTokenID,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   convertToB64String,
   getWebControlEndpoint,
@@ -114,7 +113,10 @@ export class InternalWebGrpcAuthClient<
     try {
       permissions = permissionsFromScope(scope);
     } catch (err) {
-      return new GenerateApiKey.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateApiKey.Error(err)
+      );
     }
 
     request.setPermissions(permissions);
@@ -123,7 +125,10 @@ export class InternalWebGrpcAuthClient<
       try {
         validateValidForSeconds(expiresIn.seconds());
       } catch (err) {
-        return new GenerateApiKey.Error(normalizeSdkError(err as Error));
+        return this.cacheServiceErrorMapper.returnOrThrowError(
+          err as Error,
+          err => new GenerateApiKey.Error(err)
+        );
       }
 
       const grpcExpires = new Expires();
@@ -225,7 +230,10 @@ export class InternalWebGrpcAuthClient<
     try {
       permissions = permissionsFromScope(scope);
     } catch (err) {
-      return new GenerateDisposableToken.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateDisposableToken.Error(err)
+      );
     }
 
     request.setPermissions(permissions);
@@ -235,8 +243,9 @@ export class InternalWebGrpcAuthClient<
       try {
         validateDisposableTokenTokenID(tokenId);
       } catch (err) {
-        return new GenerateDisposableToken.Error(
-          normalizeSdkError(err as Error)
+        return this.cacheServiceErrorMapper.returnOrThrowError(
+          err as Error,
+          err => new GenerateDisposableToken.Error(err)
         );
       }
       request.setTokenId(tokenId);
@@ -245,7 +254,10 @@ export class InternalWebGrpcAuthClient<
     try {
       validateDisposableTokenExpiry(expiresIn);
     } catch (err) {
-      return new GenerateDisposableToken.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GenerateDisposableToken.Error(err)
+      );
     }
 
     const grpcExpires = new _GenerateDisposableTokenRequest.Expires();

--- a/packages/client-sdk-web/src/internal/auth-client.ts
+++ b/packages/client-sdk-web/src/internal/auth-client.ts
@@ -4,7 +4,7 @@ import {
   _GenerateApiTokenRequest,
   _RefreshApiTokenRequest,
 } from '@gomomento/generated-types-webtext/dist/auth_pb';
-import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import Never = _GenerateApiTokenRequest.Never;
 import Expires = _GenerateApiTokenRequest.Expires;
 import {
@@ -78,12 +78,16 @@ export class InternalWebGrpcAuthClient<
 > implements IAuthClient
 {
   private readonly creds: CredentialProvider;
+  private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly clientMetadataProvider: ClientMetadataProvider;
   private readonly authClient: auth.AuthClient;
   private readonly tokenClient: token.TokenClient;
 
   constructor(props: AuthClientProps) {
     this.creds = props.credentialProvider;
+    this.cacheServiceErrorMapper = new CacheServiceErrorMapper(
+      props.throwOnErrors ?? false
+    );
     this.clientMetadataProvider = new ClientMetadataProvider({});
     this.authClient = new auth.AuthClient(
       // Note: all web SDK requests are routed to a `web.` subdomain to allow us flexibility on the server
@@ -129,13 +133,18 @@ export class InternalWebGrpcAuthClient<
       request.setNever(new Never());
     }
 
-    return await new Promise<GenerateApiKey.Response>(resolve => {
+    return await new Promise<GenerateApiKey.Response>((resolve, reject) => {
       this.authClient.generateApiToken(
         request,
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            resolve(new GenerateApiKey.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new GenerateApiKey.Error(e),
+              resolve,
+              reject
+            );
           } else {
             resolve(
               new GenerateApiKey.Success(
@@ -168,13 +177,18 @@ export class InternalWebGrpcAuthClient<
     request.setApiKey(this.creds.getAuthToken());
     request.setRefreshToken(refreshToken);
 
-    return await new Promise<RefreshApiKey.Response>(resolve => {
+    return await new Promise<RefreshApiKey.Response>((resolve, reject) => {
       this.authClient.refreshApiToken(
         request,
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            resolve(new RefreshApiKey.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new RefreshApiKey.Error(e),
+              resolve,
+              reject
+            );
           } else {
             resolve(
               new RefreshApiKey.Success(
@@ -238,27 +252,32 @@ export class InternalWebGrpcAuthClient<
     grpcExpires.setValidForSeconds(expiresIn.seconds());
     request.setExpires(grpcExpires);
 
-    return await new Promise<GenerateDisposableToken.Response>(resolve => {
-      this.tokenClient.generateDisposableToken(
-        request,
-        this.clientMetadataProvider.createClientMetadata(),
-        (err, resp) => {
-          if (err || !resp) {
-            resolve(
-              new GenerateDisposableToken.Error(cacheServiceErrorMapper(err))
-            );
-          } else {
-            resolve(
-              new GenerateDisposableToken.Success(
-                resp.getApiKey(),
-                resp.getEndpoint(),
-                ExpiresAt.fromEpoch(resp.getValidUntil())
-              )
-            );
+    return await new Promise<GenerateDisposableToken.Response>(
+      (resolve, reject) => {
+        this.tokenClient.generateDisposableToken(
+          request,
+          this.clientMetadataProvider.createClientMetadata(),
+          (err, resp) => {
+            if (err || !resp) {
+              this.cacheServiceErrorMapper.handleError(
+                err,
+                e => new GenerateDisposableToken.Error(e),
+                resolve,
+                reject
+              );
+            } else {
+              resolve(
+                new GenerateDisposableToken.Success(
+                  resp.getApiKey(),
+                  resp.getEndpoint(),
+                  ExpiresAt.fromEpoch(resp.getValidUntil())
+                )
+              );
+            }
           }
-        }
-      );
-    });
+        );
+      }
+    );
   }
 }
 

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -16,7 +16,7 @@ import {
   _ListCachesRequest,
   _FlushCacheRequest,
 } from '@gomomento/generated-types-webtext/dist/controlclient_pb';
-import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {IControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {validateCacheName} from '@gomomento/sdk-core/dist/src/internal/utils';
@@ -39,6 +39,7 @@ export class CacheControlClient<
 {
   private readonly clientWrapper: control.ScsControlClient;
   private readonly logger: MomentoLogger;
+  private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
 
   private readonly clientMetadataProvider: ClientMetadataProvider;
 
@@ -47,6 +48,9 @@ export class CacheControlClient<
    */
   constructor(props: ControlClientProps) {
     this.logger = props.configuration.getLoggerFactory().getLogger(this);
+    this.cacheServiceErrorMapper = new CacheServiceErrorMapper(
+      props.configuration.getThrowOnErrors()
+    );
     this.logger.debug(
       `Creating control client using endpoint: '${getWebControlEndpoint(
         props.credentialProvider
@@ -74,7 +78,7 @@ export class CacheControlClient<
     const request = new _CreateCacheRequest();
     request.setCacheName(name);
 
-    return await new Promise<CreateCache.Response>(resolve => {
+    return await new Promise<CreateCache.Response>((resolve, reject) => {
       this.clientWrapper.createCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
@@ -83,7 +87,12 @@ export class CacheControlClient<
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateCache.AlreadyExists());
             } else {
-              resolve(new CreateCache.Error(cacheServiceErrorMapper(err)));
+              this.cacheServiceErrorMapper.handleError(
+                err,
+                e => new CreateCache.Error(e),
+                resolve,
+                reject
+              );
             }
           } else {
             resolve(new CreateCache.Success());
@@ -102,13 +111,18 @@ export class CacheControlClient<
     const request = new _DeleteCacheRequest();
     request.setCacheName(name);
     this.logger.debug(`Deleting cache: ${name}`);
-    return await new Promise<DeleteCache.Response>(resolve => {
+    return await new Promise<DeleteCache.Response>((resolve, reject) => {
       this.clientWrapper.deleteCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            resolve(new DeleteCache.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new DeleteCache.Error(e),
+              resolve,
+              reject
+            );
           } else {
             resolve(new DeleteCache.Success());
           }
@@ -132,7 +146,7 @@ export class CacheControlClient<
   ): Promise<CacheFlush.Response> {
     const request = new _FlushCacheRequest();
     request.setCacheName(cacheName);
-    return await new Promise<CacheFlush.Response>(resolve => {
+    return await new Promise<CacheFlush.Response>((resolve, reject) => {
       this.clientWrapper.flushCache(
         request,
         this.clientMetadataProvider.createClientMetadata(),
@@ -140,7 +154,12 @@ export class CacheControlClient<
           if (resp) {
             resolve(new CacheFlush.Success());
           } else {
-            resolve(new CacheFlush.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new CacheFlush.Error(e),
+              resolve,
+              reject
+            );
           }
         }
       );
@@ -151,13 +170,18 @@ export class CacheControlClient<
     const request = new _ListCachesRequest();
     request.setNextToken('');
     this.logger.debug("Issuing 'listCaches' request");
-    return await new Promise<ListCaches.Response>(resolve => {
+    return await new Promise<ListCaches.Response>((resolve, reject) => {
       this.clientWrapper.listCaches(
         request,
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err) {
-            resolve(new ListCaches.Error(cacheServiceErrorMapper(err)));
+            this.cacheServiceErrorMapper.handleError(
+              err,
+              e => new ListCaches.Error(e),
+              resolve,
+              reject
+            );
           } else {
             const caches = resp.getCacheList().map(cache => {
               const cacheName = cache.getCacheName();

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -87,7 +87,7 @@ export class CacheControlClient<
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateCache.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new CreateCache.Error(e),
                 resolveFn: resolve,
@@ -117,7 +117,7 @@ export class CacheControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new DeleteCache.Error(e),
               resolveFn: resolve,
@@ -154,7 +154,7 @@ export class CacheControlClient<
           if (resp) {
             resolve(new CacheFlush.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheFlush.Error(e),
               resolveFn: resolve,
@@ -176,7 +176,7 @@ export class CacheControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new ListCaches.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -87,12 +87,12 @@ export class CacheControlClient<
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateCache.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CreateCache.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new CreateCache.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           } else {
             resolve(new CreateCache.Success());
@@ -117,12 +117,12 @@ export class CacheControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new DeleteCache.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new DeleteCache.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new DeleteCache.Success());
           }
@@ -154,12 +154,12 @@ export class CacheControlClient<
           if (resp) {
             resolve(new CacheFlush.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheFlush.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheFlush.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -176,12 +176,12 @@ export class CacheControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new ListCaches.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new ListCaches.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             const caches = resp.getCacheList().map(cache => {
               const cacheName = cache.getCacheName();

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -18,7 +18,6 @@ import {
 } from '@gomomento/generated-types-webtext/dist/controlclient_pb';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {IControlClient} from '@gomomento/sdk-core/dist/src/internal/clients';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {validateCacheName} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {getWebControlEndpoint} from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
@@ -72,7 +71,10 @@ export class CacheControlClient<
     try {
       validateCacheName(name);
     } catch (err) {
-      return new CreateCache.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateCache.Error(err)
+      );
     }
     this.logger.debug(`Creating cache: ${name}`);
     const request = new _CreateCacheRequest();
@@ -106,7 +108,10 @@ export class CacheControlClient<
     try {
       validateCacheName(name);
     } catch (err) {
-      return new DeleteCache.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new DeleteCache.Error(err)
+      );
     }
     const request = new _DeleteCacheRequest();
     request.setCacheName(name);
@@ -135,7 +140,10 @@ export class CacheControlClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheFlush.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheFlush.Error(err)
+      );
     }
     this.logger.trace(`Flushing cache: ${cacheName}`);
     return await this.sendFlushCache(cacheName);

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -249,7 +249,7 @@ export class CacheDataClient<
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheGet.Error(e),
               resolveFn: resolve,
@@ -314,7 +314,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSet.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSet.Error(e),
               resolveFn: resolve,
@@ -396,7 +396,7 @@ export class CacheDataClient<
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetIfNotExists.Error(e),
               resolveFn: resolve,
@@ -439,7 +439,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDelete.Error(e),
               resolveFn: resolve,
@@ -504,7 +504,7 @@ export class CacheDataClient<
               resolve(new CacheIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheIncrement.Error(e),
               resolveFn: resolve,
@@ -551,7 +551,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheSetFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetFetch.Error(e),
               resolveFn: resolve,
@@ -606,7 +606,7 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetAddElements.Error(e),
               resolveFn: resolve,
@@ -660,7 +660,7 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSetRemoveElements.Error(e),
               resolveFn: resolve,
@@ -738,7 +738,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListConcatenateBack.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheListConcatenateBack.Error(e),
@@ -817,7 +817,7 @@ export class CacheDataClient<
               new CacheListConcatenateFront.Success(resp.getListLength())
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheListConcatenateFront.Error(e),
@@ -899,7 +899,7 @@ export class CacheDataClient<
               resolve(new CacheListFetch.Miss());
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListFetch.Error(e),
               resolveFn: resolve,
@@ -980,7 +980,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListRetain.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListRetain.Error(e),
               resolveFn: resolve,
@@ -1038,7 +1038,7 @@ export class CacheDataClient<
               resolve(new CacheListLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListLength.Error(e),
               resolveFn: resolve,
@@ -1095,7 +1095,7 @@ export class CacheDataClient<
               resolve(new CacheListPopBack.Hit(this.convertToUint8Array(val)));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPopBack.Error(e),
               resolveFn: resolve,
@@ -1152,7 +1152,7 @@ export class CacheDataClient<
               resolve(new CacheListPopFront.Hit(this.convertToUint8Array(val)));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPopFront.Error(e),
               resolveFn: resolve,
@@ -1224,7 +1224,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListPushBack.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPushBack.Error(e),
               resolveFn: resolve,
@@ -1296,7 +1296,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListPushFront.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListPushFront.Error(e),
               resolveFn: resolve,
@@ -1353,7 +1353,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListRemoveValue.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheListRemoveValue.Error(e),
               resolveFn: resolve,
@@ -1425,7 +1425,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionarySetField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionarySetField.Error(e),
               resolveFn: resolve,
@@ -1498,7 +1498,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionarySetFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionarySetFields.Error(e),
@@ -1589,7 +1589,7 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryGetField.Error(
@@ -1667,7 +1667,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheDictionaryGetFields.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryGetFields.Error(e),
@@ -1731,7 +1731,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheDictionaryFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionaryFetch.Error(e),
               resolveFn: resolve,
@@ -1808,7 +1808,7 @@ export class CacheDataClient<
               resolve(new CacheDictionaryIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryIncrement.Error(e),
@@ -1868,7 +1868,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionaryRemoveField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryRemoveField.Error(e),
@@ -1928,7 +1928,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionaryRemoveFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheDictionaryRemoveFields.Error(e),
@@ -1989,7 +1989,7 @@ export class CacheDataClient<
               resolve(new CacheDictionaryLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDictionaryLength.Error(e),
               resolveFn: resolve,
@@ -2098,7 +2098,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheSortedSetFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
               resolveFn: resolve,
@@ -2244,7 +2244,7 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
               resolveFn: resolve,
@@ -2321,7 +2321,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSortedSetPutElement.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetPutElement.Error(e),
@@ -2397,7 +2397,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSortedSetPutElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetPutElements.Error(e),
@@ -2510,7 +2510,7 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetGetScores.Error(e),
               resolveFn: resolve,
@@ -2582,7 +2582,7 @@ export class CacheDataClient<
               resolve(new CacheSortedSetGetRank.Miss());
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetGetRank.Error(e),
               resolveFn: resolve,
@@ -2663,7 +2663,7 @@ export class CacheDataClient<
               resolve(new CacheSortedSetIncrementScore.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetIncrementScore.Error(e),
@@ -2721,7 +2721,7 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetRemoveElement.Error(e),
@@ -2781,7 +2781,7 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetRemoveElements.Error(e),
@@ -2846,7 +2846,7 @@ export class CacheDataClient<
               resolve(new CacheSortedSetLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheSortedSetLength.Error(e),
               resolveFn: resolve,
@@ -2931,7 +2931,7 @@ export class CacheDataClient<
               resolve(new CacheSortedSetLengthByScore.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new CacheSortedSetLengthByScore.Error(e),
@@ -2980,7 +2980,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheItemGetType.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheItemGetType.Error(e),
               resolveFn: resolve,
@@ -3025,7 +3025,7 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheItemGetTtl.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheItemGetTtl.Error(e),
               resolveFn: resolve,
@@ -3076,7 +3076,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheKeyExists.Success(resp.getExistsList()));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheKeyExists.Error(e),
               resolveFn: resolve,
@@ -3130,7 +3130,7 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheKeysExist.Success(resp.getExistsList()));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheKeysExist.Error(e),
               resolveFn: resolve,
@@ -3194,7 +3194,7 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheUpdateTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheUpdateTtl.Error(e),
               resolveFn: resolve,
@@ -3258,7 +3258,7 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheIncreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheIncreaseTtl.Error(e),
               resolveFn: resolve,
@@ -3322,7 +3322,7 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheDecreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new CacheDecreaseTtl.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -278,8 +278,9 @@ export class CacheDataClient<
       );
     }
     if (ttl && ttl < 0) {
-      return new CacheSet.Error(
-        new InvalidArgumentError('ttl must be a positive integer')
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        new InvalidArgumentError('ttl must be a positive integer'),
+        err => new CacheSet.Error(err)
       );
     }
     const ttlToUse = ttl || this.defaultTtlSeconds;
@@ -346,8 +347,9 @@ export class CacheDataClient<
       );
     }
     if (ttl && ttl < 0) {
-      return new CacheSetIfNotExists.Error(
-        new InvalidArgumentError('ttl must be a positive integer')
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        new InvalidArgumentError('ttl must be a positive integer'),
+        err => new CacheSetIfNotExists.Error(err)
       );
     }
     this.logger.trace(
@@ -2498,15 +2500,17 @@ export class CacheDataClient<
     } else if (responses instanceof CacheSortedSetGetScores.Miss) {
       return new CacheSortedSetGetScore.Miss(this.convertToUint8Array(value));
     } else if (responses instanceof CacheSortedSetGetScores.Error) {
-      return new CacheSortedSetGetScore.Error(
+      return this.cacheServiceErrorMapper.returnOrThrowError(
         responses.innerException(),
-        this.convertToUint8Array(value)
+        err =>
+          new CacheSortedSetGetScore.Error(err, this.convertToUint8Array(value))
       );
     }
 
-    return new CacheSortedSetGetScore.Error(
+    return this.cacheServiceErrorMapper.returnOrThrowError(
       new UnknownError('Unknown response type'),
-      this.convertToUint8Array(value)
+      err =>
+        new CacheSortedSetGetScore.Error(err, this.convertToUint8Array(value))
     );
   }
 

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -249,12 +249,12 @@ export class CacheDataClient<
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheGet.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheGet.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -314,12 +314,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSet.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSet.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSet.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -396,12 +396,12 @@ export class CacheDataClient<
                 break;
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetIfNotExists.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetIfNotExists.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -439,12 +439,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDelete.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDelete.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -504,12 +504,12 @@ export class CacheDataClient<
               resolve(new CacheIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheIncrement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheIncrement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -551,12 +551,12 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheSetFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -606,12 +606,12 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetAddElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetAddElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSetAddElements.Success());
           }
@@ -660,12 +660,12 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSetRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSetRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSetRemoveElements.Success());
           }
@@ -738,12 +738,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListConcatenateBack.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListConcatenateBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheListConcatenateBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -816,12 +817,13 @@ export class CacheDataClient<
               new CacheListConcatenateFront.Success(resp.getListLength())
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListConcatenateFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheListConcatenateFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -897,12 +899,12 @@ export class CacheDataClient<
               resolve(new CacheListFetch.Miss());
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -978,12 +980,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListRetain.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListRetain.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListRetain.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1036,12 +1038,12 @@ export class CacheDataClient<
               resolve(new CacheListLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1093,12 +1095,12 @@ export class CacheDataClient<
               resolve(new CacheListPopBack.Hit(this.convertToUint8Array(val)));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPopBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPopBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1150,12 +1152,12 @@ export class CacheDataClient<
               resolve(new CacheListPopFront.Hit(this.convertToUint8Array(val)));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPopFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPopFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1222,12 +1224,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListPushBack.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPushBack.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPushBack.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1294,12 +1296,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListPushFront.Success(resp.getListLength()));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListPushFront.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListPushFront.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1351,12 +1353,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheListRemoveValue.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheListRemoveValue.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheListRemoveValue.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1423,12 +1425,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionarySetField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionarySetField.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionarySetField.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1496,12 +1498,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionarySetFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionarySetFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionarySetFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1586,16 +1589,16 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e =>
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
                 new CacheDictionaryGetField.Error(
                   e,
                   this.convertToUint8Array(field)
                 ),
-              resolve,
-              reject
-            );
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1664,12 +1667,13 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheDictionaryGetFields.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryGetFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryGetFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1727,12 +1731,12 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheDictionaryFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionaryFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1804,12 +1808,13 @@ export class CacheDataClient<
               resolve(new CacheDictionaryIncrement.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryIncrement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryIncrement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1863,12 +1868,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionaryRemoveField.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryRemoveField.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryRemoveField.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1922,12 +1928,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheDictionaryRemoveFields.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryRemoveFields.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheDictionaryRemoveFields.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -1982,12 +1989,12 @@ export class CacheDataClient<
               resolve(new CacheDictionaryLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDictionaryLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDictionaryLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2091,12 +2098,12 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheSortedSetFetch.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2237,12 +2244,12 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2314,12 +2321,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSortedSetPutElement.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetPutElement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetPutElement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2389,12 +2397,13 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheSortedSetPutElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetPutElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetPutElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2501,12 +2510,12 @@ export class CacheDataClient<
               );
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetGetScores.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetGetScores.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2573,12 +2582,12 @@ export class CacheDataClient<
               resolve(new CacheSortedSetGetRank.Miss());
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetGetRank.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetGetRank.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2654,12 +2663,13 @@ export class CacheDataClient<
               resolve(new CacheSortedSetIncrementScore.Success(0));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetIncrementScore.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetIncrementScore.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2711,12 +2721,13 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetRemoveElement.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetRemoveElement.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSortedSetRemoveElement.Success());
           }
@@ -2770,12 +2781,13 @@ export class CacheDataClient<
         },
         err => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new CacheSortedSetRemoveElements.Success());
           }
@@ -2834,12 +2846,12 @@ export class CacheDataClient<
               resolve(new CacheSortedSetLength.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheSortedSetLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2919,12 +2931,13 @@ export class CacheDataClient<
               resolve(new CacheSortedSetLengthByScore.Hit(len));
             }
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheSortedSetLengthByScore.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new CacheSortedSetLengthByScore.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -2967,12 +2980,12 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheItemGetType.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheItemGetType.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheItemGetType.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3012,12 +3025,12 @@ export class CacheDataClient<
           } else if (resp?.getMissing()) {
             resolve(new CacheItemGetTtl.Miss());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheItemGetTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheItemGetTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3063,12 +3076,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheKeyExists.Success(resp.getExistsList()));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheKeyExists.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheKeyExists.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3117,12 +3130,12 @@ export class CacheDataClient<
           if (resp) {
             resolve(new CacheKeysExist.Success(resp.getExistsList()));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheKeysExist.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheKeysExist.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3181,12 +3194,12 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheUpdateTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheUpdateTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheUpdateTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3245,12 +3258,12 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheIncreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheIncreaseTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheIncreaseTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -3309,12 +3322,12 @@ export class CacheDataClient<
           } else if (resp?.getSet()) {
             resolve(new CacheDecreaseTtl.Set());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new CacheDecreaseTtl.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new CacheDecreaseTtl.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -122,7 +122,6 @@ import {
   validateSortedSetScores,
   validateValidForSeconds,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   convertToB64String,
   createCallMetadata,
@@ -201,7 +200,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheGet.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheGet.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
     const result = await this.sendGet(cacheName, convertToB64String(key));
@@ -270,7 +272,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheSet.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSet.Error(err)
+      );
     }
     if (ttl && ttl < 0) {
       return new CacheSet.Error(
@@ -335,7 +340,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheSetIfNotExists.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetIfNotExists.Error(err)
+      );
     }
     if (ttl && ttl < 0) {
       return new CacheSetIfNotExists.Error(
@@ -415,7 +423,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheDelete.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDelete.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'delete' request; key: ${key.toString()}`);
     return await this.sendDelete(cacheName, convertToB64String(key));
@@ -460,7 +471,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheIncrement.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheIncrement.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'increment' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
@@ -524,7 +538,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetFetch.Error(err)
+      );
     }
     return await this.sendSetFetch(cacheName, convertToB64String(setName));
   }
@@ -573,7 +590,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetAddElements.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetAddElements.Error(err)
+      );
     }
     return await this.sendSetAddElements(
       cacheName,
@@ -629,7 +649,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSetName(setName);
     } catch (err) {
-      return new CacheSetRemoveElements.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSetRemoveElements.Error(err)
+      );
     }
     return await this.sendSetRemoveElements(
       cacheName,
@@ -685,8 +708,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListConcatenateBack.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListConcatenateBack.Error(err)
       );
     }
 
@@ -762,8 +786,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListConcatenateFront.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListConcatenateFront.Error(err)
       );
     }
 
@@ -841,7 +866,10 @@ export class CacheDataClient<
       validateListName(listName);
       validateListSliceStartEnd(startIndex, endIndex);
     } catch (err) {
-      return new CacheListFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListFetch.Error(err)
+      );
     }
     this.logger.trace(
       "Issuing 'listFetch' request; listName: %s, startIndex: %s, endIndex: %s",
@@ -923,7 +951,10 @@ export class CacheDataClient<
       validateListName(listName);
       validateListSliceStartEnd(startIndex, endIndex);
     } catch (err) {
-      return new CacheListRetain.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListRetain.Error(err)
+      );
     }
     this.logger.trace(
       "Issuing 'listRetain' request; listName: %s, startIndex: %s, endIndex: %s, ttl: %s",
@@ -1000,7 +1031,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListLength.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListLength.Error(err)
+      );
     }
     this.logger.trace(`Issuing 'listLength' request; listName: ${listName}`);
     const result = await this.sendListLength(
@@ -1058,7 +1092,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPopBack.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPopBack.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'listPopBack' request");
@@ -1115,7 +1152,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPopFront.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPopFront.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'listPopFront' request");
@@ -1175,7 +1215,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPushBack.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPushBack.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1247,7 +1290,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListPushFront.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListPushFront.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1317,7 +1363,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateListName(listName);
     } catch (err) {
-      return new CacheListRemoveValue.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheListRemoveValue.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -1376,7 +1425,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionarySetField.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionarySetField.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
@@ -1449,8 +1501,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionarySetFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionarySetFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1520,9 +1573,13 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryGetField.Error(
-        normalizeSdkError(err as Error),
-        this.convertToUint8Array(field)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err =>
+          new CacheDictionaryGetField.Error(
+            err,
+            this.convertToUint8Array(field)
+          )
       );
     }
     this.logger.trace(
@@ -1614,8 +1671,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryGetFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryGetFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1688,7 +1746,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionaryFetch' request; dictionaryName: ${dictionaryName}`
@@ -1754,8 +1815,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryIncrement.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryIncrement.Error(err)
       );
     }
     this.logger.trace(
@@ -1830,8 +1892,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryRemoveField.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryRemoveField.Error(err)
       );
     }
     this.logger.trace(
@@ -1890,8 +1953,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryRemoveFields.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryRemoveFields.Error(err)
       );
     }
     this.logger.trace(
@@ -1949,7 +2013,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateDictionaryName(dictionaryName);
     } catch (err) {
-      return new CacheDictionaryLength.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDictionaryLength.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'dictionaryLength' request; dictionaryName: ${dictionaryName}`
@@ -2013,7 +2080,10 @@ export class CacheDataClient<
       validateSortedSetName(sortedSetName);
       validateSortedSetRanks(startRank, endRank);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2130,7 +2200,10 @@ export class CacheDataClient<
         validateSortedSetCount(count);
       }
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2267,8 +2340,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetPutElement.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetPutElement.Error(err)
       );
     }
     this.logger.trace(
@@ -2347,8 +2421,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetPutElements.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetPutElements.Error(err)
       );
     }
     this.logger.trace(
@@ -2444,7 +2519,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetGetScores.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetGetScores.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2531,7 +2609,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetGetRank.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetGetRank.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2605,8 +2686,9 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetIncrementScore.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetIncrementScore.Error(err)
       );
     }
 
@@ -2685,7 +2767,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetRemoveElement' request");
@@ -2745,7 +2830,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetRemoveElements' request");
@@ -2804,7 +2892,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateSortedSetName(sortedSetName);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'sortedSetLength' request");
@@ -2869,7 +2960,10 @@ export class CacheDataClient<
       validateSortedSetName(sortedSetName);
       validateSortedSetScores(minScore, maxScore);
     } catch (err) {
-      return new CacheSortedSetFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheSortedSetFetch.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -2951,7 +3045,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheItemGetType.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheItemGetType.Error(err)
+      );
     }
     return await this.sendItemGetType(cacheName, convertToB64String(key));
   }
@@ -2999,7 +3096,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheItemGetTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheItemGetTtl.Error(err)
+      );
     }
     return await this.sendItemGetTtl(cacheName, convertToB64String(key));
   }
@@ -3044,7 +3144,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheKeyExists.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheKeyExists.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'keyExists' request");
@@ -3095,7 +3198,10 @@ export class CacheDataClient<
     try {
       validateCacheName(cacheName);
     } catch (err) {
-      return new CacheKeysExist.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheKeysExist.Error(err)
+      );
     }
 
     this.logger.trace("Issuing 'keysExist' request");
@@ -3151,7 +3257,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheUpdateTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheUpdateTtl.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -3215,7 +3324,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheIncreaseTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheIncreaseTtl.Error(err)
+      );
     }
 
     this.logger.trace(
@@ -3279,7 +3391,10 @@ export class CacheDataClient<
       validateCacheName(cacheName);
       validateValidForSeconds(ttlMilliseconds);
     } catch (err) {
-      return new CacheDecreaseTtl.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CacheDecreaseTtl.Error(err)
+      );
     }
 
     this.logger.trace(

--- a/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
@@ -8,7 +8,6 @@ import {
   LeaderboardOrder,
 } from '@gomomento/sdk-core';
 import {LeaderboardClientProps} from '../leaderboard-client-props';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   validateSortedSetScores,
   validateLeaderboardOffset,
@@ -122,7 +121,10 @@ export class LeaderboardDataClient<
     try {
       validateLeaderboardNumberOfElements(size);
     } catch (err) {
-      return new LeaderboardUpsert.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardUpsert.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'upsert' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, number of elements: ${size}`
@@ -180,7 +182,10 @@ export class LeaderboardDataClient<
       validateLeaderboardOffset(offsetValue);
       validateLeaderboardCount(countValue);
     } catch (err) {
-      return new LeaderboardFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'fetchByScore' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, order: ${orderValue.toString()}, minScore: ${
@@ -273,7 +278,10 @@ export class LeaderboardDataClient<
     try {
       validateLeaderboardRanks(startRank, endRank);
     } catch (err) {
-      return new LeaderboardFetch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardFetch.Error(err)
+      );
     }
     this.logger.trace(
       `Issuing 'fetchByRank' request; cache: ${cacheName}, leaderboard: ${leaderboardName}, order: ${rankOrder.toString()}, startRank: ${startRank}, endRank: ${endRank}`
@@ -447,8 +455,9 @@ export class LeaderboardDataClient<
     try {
       validateLeaderboardNumberOfElements(ids.length);
     } catch (err) {
-      return new LeaderboardRemoveElements.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new LeaderboardRemoveElements.Error(err)
       );
     }
     this.logger.trace(

--- a/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
@@ -151,7 +151,7 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardUpsert.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardUpsert.Error(e),
               resolveFn: resolve,
@@ -250,7 +250,7 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -325,7 +325,7 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -385,7 +385,7 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
               resolveFn: resolve,
@@ -427,7 +427,7 @@ export class LeaderboardDataClient<
             const length = resp.getCount();
             resolve(new LeaderboardLength.Success(length));
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardLength.Error(e),
               resolveFn: resolve,
@@ -478,7 +478,7 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardRemoveElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new LeaderboardRemoveElements.Error(e),
@@ -520,7 +520,7 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new LeaderboardDelete.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
@@ -151,12 +151,12 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardUpsert.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardUpsert.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardUpsert.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -250,12 +250,12 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -325,12 +325,12 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -385,12 +385,12 @@ export class LeaderboardDataClient<
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardFetch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardFetch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -427,12 +427,12 @@ export class LeaderboardDataClient<
             const length = resp.getCount();
             resolve(new LeaderboardLength.Success(length));
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardLength.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardLength.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -478,12 +478,13 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardRemoveElements.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardRemoveElements.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new LeaderboardRemoveElements.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -519,12 +520,12 @@ export class LeaderboardDataClient<
           if (resp) {
             resolve(new LeaderboardDelete.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new LeaderboardDelete.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new LeaderboardDelete.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -103,12 +103,12 @@ export class PubsubClient<
           if (resp) {
             resolve(new TopicPublish.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new TopicPublish.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new TopicPublish.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -103,7 +103,7 @@ export class PubsubClient<
           if (resp) {
             resolve(new TopicPublish.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new TopicPublish.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -27,14 +27,14 @@ import {TopicConfiguration} from '../config/topic-configuration';
 export class PubsubClient<
   REQ extends Request<REQ, RESP>,
   RESP extends UnaryResponse<REQ, RESP>
-> extends AbstractPubsubClient {
+> extends AbstractPubsubClient<RpcError> {
   private readonly client: pubsub.PubsubClient;
   private readonly configuration: TopicConfiguration;
   protected readonly credentialProvider: CredentialProvider;
   private readonly requestTimeoutMs: number;
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
   protected readonly logger: MomentoLogger;
-  private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
+  protected readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly clientMetadataProvider: ClientMetadataProvider;
 
   private static readonly RST_STREAM_NO_ERROR_MESSAGE =

--- a/packages/client-sdk-web/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-control-client.ts
@@ -129,7 +129,7 @@ export class VectorIndexControlClient<
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateVectorIndex.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new CreateVectorIndex.Error(e),
                 resolveFn: resolve,
@@ -153,7 +153,7 @@ export class VectorIndexControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new ListVectorIndexes.Error(e),
               resolveFn: resolve,
@@ -221,7 +221,7 @@ export class VectorIndexControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new DeleteVectorIndex.Error(e),
               resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-control-client.ts
@@ -110,11 +110,12 @@ export class VectorIndexControlClient<
         );
         break;
       default:
-        return new CreateVectorIndex.Error(
+        return this.cacheServiceErrorMapper.returnOrThrowError(
           new InvalidArgumentError(
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             `Invalid similarity metric: ${similarityMetric}`
-          )
+          ),
+          err => new CreateVectorIndex.Error(err)
         );
     }
     request.setSimilarityMetric(similarityMetricPb);

--- a/packages/client-sdk-web/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-control-client.ts
@@ -129,12 +129,12 @@ export class VectorIndexControlClient<
             if (err.code === StatusCode.ALREADY_EXISTS) {
               resolve(new CreateVectorIndex.AlreadyExists());
             } else {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new CreateVectorIndex.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new CreateVectorIndex.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             }
           } else {
             resolve(new CreateVectorIndex.Success());
@@ -153,12 +153,12 @@ export class VectorIndexControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new ListVectorIndexes.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new ListVectorIndexes.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             const indexes: VectorIndexInfo[] = resp
               .getIndexesList()
@@ -221,12 +221,12 @@ export class VectorIndexControlClient<
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new DeleteVectorIndex.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new DeleteVectorIndex.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new DeleteVectorIndex.Success());
           }

--- a/packages/client-sdk-web/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-control-client.ts
@@ -18,10 +18,7 @@ import {
   IVectorIndexControlClient,
   VectorSimilarityMetric,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
-import {
-  normalizeSdkError,
-  UnknownError,
-} from '@gomomento/sdk-core/dist/src/errors';
+import {UnknownError} from '@gomomento/sdk-core/dist/src/errors';
 import {
   validateIndexName,
   validateNumDimensions,
@@ -84,7 +81,10 @@ export class VectorIndexControlClient<
       validateIndexName(indexName);
       validateNumDimensions(numDimensions);
     } catch (err) {
-      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateVectorIndex.Error(err)
+      );
     }
     const request = new _CreateIndexRequest();
     request.setIndexName(indexName);
@@ -211,7 +211,10 @@ export class VectorIndexControlClient<
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new CreateVectorIndex.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new CreateVectorIndex.Error(err)
+      );
     }
     request.setIndexName(indexName);
     this.logger.debug("Issuing 'deleteIndex' request");

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -148,12 +148,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorUpsertItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorUpsertItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorUpsertItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -191,12 +191,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorDeleteItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorDeleteItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorDeleteItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -326,12 +326,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorSearch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorSearch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -408,12 +408,13 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorSearchAndFetchVectors.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new VectorSearchAndFetchVectors.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -494,12 +495,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorGetItemBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new VectorGetItemBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );
@@ -581,12 +582,13 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new VectorGetItemMetadataBatch.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e =>
+                new VectorGetItemMetadataBatch.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           }
         }
       );

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -22,7 +22,6 @@ import {
   validateIndexName,
   validateTopK,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {getWebVectorEndpoint} from '../utils/web-client-utils';
 import {ALL_VECTOR_METADATA} from '@gomomento/sdk-core/dist/src/clients/IVectorIndexClient';
@@ -69,7 +68,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         items
       );
     } catch (err) {
-      return new VectorUpsertItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorUpsertItemBatch.Error(err)
+      );
     }
     return await this.sendUpsertItemBatch(request);
   }
@@ -167,7 +169,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorDeleteItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorDeleteItemBatch.Error(err)
+      );
     }
     return await this.sendDeleteItemBatch(indexName, ids);
   }
@@ -214,7 +219,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         validateTopK(options.topK);
       }
     } catch (err) {
-      return new VectorSearch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorSearch.Error(err)
+      );
     }
     return await this.sendSearch(indexName, queryVector, options);
   }
@@ -349,8 +357,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         validateTopK(options.topK);
       }
     } catch (err) {
-      return new VectorSearchAndFetchVectors.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorSearchAndFetchVectors.Error(err)
       );
     }
     return await this.sendSearchAndFetchVectors(
@@ -428,7 +437,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorGetItemBatch.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorGetItemBatch.Error(err)
+      );
     }
     return await this.sendGetItemBatch(indexName, ids);
   }
@@ -514,8 +526,9 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     try {
       validateIndexName(indexName);
     } catch (err) {
-      return new VectorGetItemMetadataBatch.Error(
-        normalizeSdkError(err as Error)
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new VectorGetItemMetadataBatch.Error(err)
       );
     }
     return await this.sendGetItemMetadataBatch(indexName, ids);

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -148,7 +148,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorUpsertItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorUpsertItemBatch.Error(e),
               resolveFn: resolve,
@@ -191,7 +191,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           if (resp) {
             resolve(new VectorDeleteItemBatch.Success());
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorDeleteItemBatch.Error(e),
               resolveFn: resolve,
@@ -326,7 +326,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorSearch.Error(e),
               resolveFn: resolve,
@@ -408,7 +408,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new VectorSearchAndFetchVectors.Error(e),
@@ -495,7 +495,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new VectorGetItemBatch.Error(e),
               resolveFn: resolve,
@@ -582,7 +582,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
               )
             );
           } else {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e =>
                 new VectorGetItemMetadataBatch.Error(e),

--- a/packages/client-sdk-web/src/internal/webhook-client.ts
+++ b/packages/client-sdk-web/src/internal/webhook-client.ts
@@ -92,12 +92,12 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new DeleteWebhook.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new DeleteWebhook.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new DeleteWebhook.Success());
           }
@@ -122,12 +122,12 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new ListWebhooks.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new ListWebhooks.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             const webhooks = resp.getWebhookList().map(wh => {
               const webhook: Webhook = {
@@ -181,12 +181,12 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new PutWebhook.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new PutWebhook.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(new PutWebhook.Success(resp.getSecretString()));
           }
@@ -214,12 +214,12 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError(
-              err,
-              e => new GetWebhookSecret.Error(e),
-              resolve,
-              reject
-            );
+            this.cacheServiceErrorMapper.handleError({
+              err: err,
+              errorResponseFactoryFn: e => new GetWebhookSecret.Error(e),
+              resolveFn: resolve,
+              rejectFn: reject,
+            });
           } else {
             resolve(
               new GetWebhookSecret.Success({
@@ -258,12 +258,12 @@ export class WebhookClient implements IWebhookClient {
           this.clientMetadataProvider.createClientMetadata(),
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError(
-                err,
-                e => new RotateWebhookSecret.Error(e),
-                resolve,
-                reject
-              );
+              this.cacheServiceErrorMapper.handleError({
+                err: err,
+                errorResponseFactoryFn: e => new RotateWebhookSecret.Error(e),
+                resolveFn: resolve,
+                rejectFn: reject,
+              });
             } else {
               resolve(
                 new RotateWebhookSecret.Success({

--- a/packages/client-sdk-web/src/internal/webhook-client.ts
+++ b/packages/client-sdk-web/src/internal/webhook-client.ts
@@ -92,7 +92,7 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, _resp) => {
           if (err) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new DeleteWebhook.Error(e),
               resolveFn: resolve,
@@ -122,7 +122,7 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new ListWebhooks.Error(e),
               resolveFn: resolve,
@@ -181,7 +181,7 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new PutWebhook.Error(e),
               resolveFn: resolve,
@@ -214,7 +214,7 @@ export class WebhookClient implements IWebhookClient {
         this.clientMetadataProvider.createClientMetadata(),
         (err, resp) => {
           if (err || !resp) {
-            this.cacheServiceErrorMapper.handleError({
+            this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
               errorResponseFactoryFn: e => new GetWebhookSecret.Error(e),
               resolveFn: resolve,
@@ -258,7 +258,7 @@ export class WebhookClient implements IWebhookClient {
           this.clientMetadataProvider.createClientMetadata(),
           (err, resp) => {
             if (err || !resp) {
-              this.cacheServiceErrorMapper.handleError({
+              this.cacheServiceErrorMapper.resolveOrRejectError({
                 err: err,
                 errorResponseFactoryFn: e => new RotateWebhookSecret.Error(e),
                 resolveFn: resolve,

--- a/packages/client-sdk-web/src/internal/webhook-client.ts
+++ b/packages/client-sdk-web/src/internal/webhook-client.ts
@@ -20,7 +20,6 @@ import {
   validateTopicName,
   validateWebhookName,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
-import {normalizeSdkError} from '@gomomento/sdk-core/dist/src/errors';
 import {getWebControlEndpoint} from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {TopicConfiguration} from '../config/topic-configuration';
@@ -75,7 +74,10 @@ export class WebhookClient implements IWebhookClient {
     try {
       validateCacheName(id.cacheName);
     } catch (err) {
-      return new DeleteWebhook.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new DeleteWebhook.Error(err)
+      );
     }
 
     const request = new _DeleteWebhookRequest();
@@ -110,7 +112,10 @@ export class WebhookClient implements IWebhookClient {
     try {
       validateCacheName(cache);
     } catch (err) {
-      return new ListWebhooks.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new ListWebhooks.Error(err)
+      );
     }
     const request = new _ListWebhookRequest();
     request.setCacheName(cache);
@@ -155,7 +160,10 @@ export class WebhookClient implements IWebhookClient {
       validateTopicName(webhook.topicName);
       validateWebhookName(webhook.id.webhookName);
     } catch (err) {
-      return new PutWebhook.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new PutWebhook.Error(err)
+      );
     }
 
     const request = new _PutWebhookRequest();
@@ -200,7 +208,10 @@ export class WebhookClient implements IWebhookClient {
       validateCacheName(id.cacheName);
       validateWebhookName(id.webhookName);
     } catch (err) {
-      return new GetWebhookSecret.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GetWebhookSecret.Error(err)
+      );
     }
 
     const request = new _GetWebhookSecretRequest();
@@ -241,7 +252,10 @@ export class WebhookClient implements IWebhookClient {
       validateCacheName(id.cacheName);
       validateWebhookName(id.webhookName);
     } catch (err) {
-      return new RotateWebhookSecret.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new RotateWebhookSecret.Error(err)
+      );
     }
 
     const request = new _RotateWebhookSecretRequest();

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -75,6 +75,12 @@ function momentoClientForTesting(): CacheClient {
   return new CacheClient(IntegrationTestCacheClientProps);
 }
 
+function momentoClientWithThrowOnErrorsForTesting(): CacheClient {
+  const props = IntegrationTestCacheClientProps;
+  props.configuration = props.configuration.withThrowOnErrors(true);
+  return new CacheClient(props);
+}
+
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
     configuration:
@@ -114,6 +120,7 @@ function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
 
 export function SetupIntegrationTest(): {
   cacheClient: CacheClient;
+  cacheClientWithThrowOnErrors: CacheClient;
   integrationTestCacheName: string;
 } {
   const cacheName = testCacheName();
@@ -135,7 +142,12 @@ export function SetupIntegrationTest(): {
   });
 
   const client = momentoClientForTesting();
-  return {cacheClient: client, integrationTestCacheName: cacheName};
+  const clientWithThrowOnErrors = momentoClientWithThrowOnErrorsForTesting();
+  return {
+    cacheClient: client,
+    cacheClientWithThrowOnErrors: clientWithThrowOnErrors,
+    integrationTestCacheName: cacheName,
+  };
 }
 
 export function SetupTopicIntegrationTest(): {

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -136,6 +136,14 @@ function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
   });
 }
 
+function momentoLeaderboardClientWithThrowOnErrorsForTesting(): PreviewLeaderboardClient {
+  return new PreviewLeaderboardClient({
+    credentialProvider: credsProvider(),
+    configuration:
+      LeaderboardConfigurations.Laptop.latest().withThrowOnErrors(true),
+  });
+}
+
 export function SetupIntegrationTest(): {
   cacheClient: CacheClient;
   cacheClientWithThrowOnErrors: CacheClient;
@@ -198,12 +206,16 @@ export function SetupVectorIntegrationTest(): {
 
 export function SetupLeaderboardIntegrationTest(): {
   leaderboardClient: PreviewLeaderboardClient;
+  leaderboardClientWithThrowOnErrors: PreviewLeaderboardClient;
   integrationTestCacheName: string;
 } {
   const {integrationTestCacheName} = SetupIntegrationTest();
   const leaderboardClient = momentoLeaderboardClientForTesting();
+  const leaderboardClientWithThrowOnErrors =
+    momentoLeaderboardClientWithThrowOnErrorsForTesting();
   return {
     leaderboardClient,
+    leaderboardClientWithThrowOnErrors,
     integrationTestCacheName: integrationTestCacheName,
   };
 }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -114,6 +114,14 @@ function momentoVectorClientForTesting(): PreviewVectorIndexClient {
   });
 }
 
+function momentoVectorClientWithThrowsOnErrorsForTesting(): PreviewVectorIndexClient {
+  return new PreviewVectorIndexClient({
+    credentialProvider: credsProvider(),
+    configuration:
+      VectorIndexConfigurations.Laptop.latest().withThrowOnErrors(true),
+  });
+}
+
 function momentoLeaderboardClientForTesting(): PreviewLeaderboardClient {
   return new PreviewLeaderboardClient({
     credentialProvider: credsProvider(),
@@ -169,9 +177,12 @@ export function SetupTopicIntegrationTest(): {
 
 export function SetupVectorIntegrationTest(): {
   vectorClient: PreviewVectorIndexClient;
+  vectorClientWithThrowOnErrors: PreviewVectorIndexClient;
 } {
   const vectorClient = momentoVectorClientForTesting();
-  return {vectorClient};
+  const vectorClientWithThrowOnErrors =
+    momentoVectorClientWithThrowsOnErrorsForTesting();
+  return {vectorClient, vectorClientWithThrowOnErrors};
 }
 
 export function SetupLeaderboardIntegrationTest(): {

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -65,18 +65,21 @@ function sessionCredsProvider(): CredentialProvider {
   return _sessionCredsProvider;
 }
 
-export const IntegrationTestCacheClientProps: CacheClientProps = {
-  configuration: Configurations.Laptop.latest().withClientTimeoutMillis(60000),
-  credentialProvider: credsProvider(),
-  defaultTtlSeconds: 1111,
-};
+function integrationTestCacheClientProps(): CacheClientProps {
+  return {
+    configuration:
+      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
+    credentialProvider: credsProvider(),
+    defaultTtlSeconds: 1111,
+  };
+}
 
 function momentoClientForTesting(): CacheClient {
-  return new CacheClient(IntegrationTestCacheClientProps);
+  return new CacheClient(integrationTestCacheClientProps());
 }
 
 function momentoClientWithThrowOnErrorsForTesting(): CacheClient {
-  const props = IntegrationTestCacheClientProps;
+  const props: CacheClientProps = integrationTestCacheClientProps();
   props.configuration = props.configuration.withThrowOnErrors(true);
   return new CacheClient(props);
 }
@@ -99,7 +102,7 @@ function momentoTopicClientForTesting(): TopicClient {
 
 function momentoTopicClientForTestingWithSessionToken(): TopicClient {
   return new TopicClient({
-    configuration: IntegrationTestCacheClientProps.configuration,
+    configuration: integrationTestCacheClientProps().configuration,
     credentialProvider: sessionCredsProvider(),
   });
 }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -100,6 +100,13 @@ function momentoTopicClientForTesting(): TopicClient {
   });
 }
 
+function momentoTopicClientWithThrowOnErrorsForTesting(): TopicClient {
+  return new TopicClient({
+    configuration: TopicConfigurations.Default.latest().withThrowOnErrors(true),
+    credentialProvider: credsProvider(),
+  });
+}
+
 function momentoTopicClientForTestingWithSessionToken(): TopicClient {
   return new TopicClient({
     configuration: integrationTestCacheClientProps().configuration,
@@ -163,13 +170,17 @@ export function SetupIntegrationTest(): {
 
 export function SetupTopicIntegrationTest(): {
   topicClient: ITopicClient;
+  topicClientWithThrowOnErrors: ITopicClient;
   cacheClient: CacheClient;
   integrationTestCacheName: string;
 } {
   const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
   const topicClient = momentoTopicClientForTesting();
+  const topicClientWithThrowOnErrors =
+    momentoTopicClientWithThrowOnErrorsForTesting();
   return {
     topicClient,
+    topicClientWithThrowOnErrors,
     cacheClient: cacheClient,
     integrationTestCacheName: integrationTestCacheName,
   };

--- a/packages/client-sdk-web/test/integration/shared/get-set-delete.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/get-set-delete.test.ts
@@ -1,6 +1,11 @@
 import {runGetSetDeleteTests} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 
-const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, cacheClientWithThrowOnErrors, integrationTestCacheName} =
+  SetupIntegrationTest();
 
-runGetSetDeleteTests(cacheClient, integrationTestCacheName);
+runGetSetDeleteTests(
+  cacheClient,
+  cacheClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-web/test/integration/shared/leaderboard.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/leaderboard.test.ts
@@ -1,7 +1,14 @@
 import {runLeaderboardClientTests} from '@gomomento/common-integration-tests';
 import {SetupLeaderboardIntegrationTest} from '../integration-setup';
 
-const {leaderboardClient, integrationTestCacheName} =
-  SetupLeaderboardIntegrationTest();
+const {
+  leaderboardClient,
+  leaderboardClientWithThrowOnErrors,
+  integrationTestCacheName,
+} = SetupLeaderboardIntegrationTest();
 
-runLeaderboardClientTests(leaderboardClient, integrationTestCacheName);
+runLeaderboardClientTests(
+  leaderboardClient,
+  leaderboardClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-web/test/integration/shared/topic-client.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/topic-client.test.ts
@@ -1,6 +1,15 @@
 import {runTopicClientTests} from '@gomomento/common-integration-tests';
 import {SetupTopicIntegrationTest} from '../integration-setup';
 
-const {topicClient, cacheClient, integrationTestCacheName} =
-  SetupTopicIntegrationTest();
-runTopicClientTests(topicClient, cacheClient, integrationTestCacheName);
+const {
+  topicClient,
+  topicClientWithThrowOnErrors,
+  cacheClient,
+  integrationTestCacheName,
+} = SetupTopicIntegrationTest();
+runTopicClientTests(
+  topicClient,
+  topicClientWithThrowOnErrors,
+  cacheClient,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-web/test/integration/shared/vector-data-plane.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/vector-data-plane.test.ts
@@ -1,6 +1,7 @@
 import {SetupVectorIntegrationTest} from '../integration-setup';
 import {runVectorDataPlaneTest} from '@gomomento/common-integration-tests';
 
-const {vectorClient} = SetupVectorIntegrationTest();
+const {vectorClient, vectorClientWithThrowOnErrors} =
+  SetupVectorIntegrationTest();
 
-runVectorDataPlaneTest(vectorClient);
+runVectorDataPlaneTest(vectorClient, vectorClientWithThrowOnErrors);

--- a/packages/common-integration-tests/src/leaderboard-client.ts
+++ b/packages/common-integration-tests/src/leaderboard-client.ts
@@ -35,6 +35,7 @@ async function withTemporaryLeaderboard(
 
 export function runLeaderboardClientTests(
   leaderboardClient: ILeaderboardClient,
+  leaderboardClientWithThrowOnErrors: ILeaderboardClient,
   integrationTestCacheName: string
 ) {
   describe('#Creates leaderboard client', () => {
@@ -996,6 +997,23 @@ export function runLeaderboardClientTests(
         leaderboardName,
         integrationTestCacheName,
         deletesLeaderboard
+      );
+    });
+  });
+
+  describe('When client is configured to throw on errors', () => {
+    it('should throw if we attempt to fetch more than the max number of items', async () => {
+      const leaderboardName = `test-leaderboard-throw-on-error-${v4()}`;
+
+      await withTemporaryLeaderboard(
+        leaderboardClientWithThrowOnErrors,
+        leaderboardName,
+        integrationTestCacheName,
+        async (leaderboard: ILeaderboard) => {
+          await expect(async () => {
+            await leaderboard.fetchByRank(0, 8193);
+          }).rejects.toThrow(InvalidArgumentError);
+        }
       );
     });
   });

--- a/packages/common-integration-tests/src/topic-client.ts
+++ b/packages/common-integration-tests/src/topic-client.ts
@@ -290,4 +290,8 @@ export function runTopicClientTests(
       }
     });
   });
+
+  describe('when client is configured to throw on errors', () => {
+
+  });
 }

--- a/packages/common-integration-tests/src/topic-client.ts
+++ b/packages/common-integration-tests/src/topic-client.ts
@@ -291,7 +291,7 @@ export function runTopicClientTests(
     });
   });
 
-  describe('when client is configured to throw on errors', () => {
-
-  });
+  // describe('when client is configured to throw on errors', () => {
+  //
+  // });
 }

--- a/packages/common-integration-tests/src/topic-client.ts
+++ b/packages/common-integration-tests/src/topic-client.ts
@@ -7,6 +7,7 @@ import {
   TopicPublish,
   TopicSubscribe,
   SubscribeCallOptions,
+  NotFoundError,
 } from '@gomomento/sdk-core';
 import {
   expectWithMessage,
@@ -34,6 +35,7 @@ const STREAM_WAIT_TIME_MS = 2000;
 
 export function runTopicClientTests(
   topicClient: ITopicClient,
+  topicClientWithThrowOnErrors: ITopicClient,
   cacheClient: ICacheClient,
   integrationTestCacheName: string
 ) {
@@ -291,7 +293,11 @@ export function runTopicClientTests(
     });
   });
 
-  // describe('when client is configured to throw on errors', () => {
-  //
-  // });
+  describe('when client is configured to throw on errors', () => {
+    it('should throw when publishing to a cache that does not exist', async () => {
+      await expect(async () => {
+        await topicClientWithThrowOnErrors.publish(v4(), 'topic', 'value');
+      }).rejects.toThrow(NotFoundError);
+    });
+  });
 }

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1,4 +1,5 @@
 import {
+  InvalidArgumentError,
   IVectorIndexClient,
   VectorDeleteItemBatch,
   VectorSearch,
@@ -20,7 +21,6 @@ import {
   WithIndex,
 } from './common-int-test-utils';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
-import {InvalidArgumentError} from "@gomomento/sdk-core/dist/src";
 
 export function runVectorDataPlaneTest(
   vectorClient: IVectorIndexClient,

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -21,7 +21,10 @@ import {
 } from './common-int-test-utils';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 
-export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
+export function runVectorDataPlaneTest(
+  vectorClient: IVectorIndexClient,
+  vectorClientWithThrowOnErrors: IVectorIndexClient
+) {
   describe('upsertItem validation', () => {
     ItBehavesLikeItValidatesIndexName((props: ValidateVectorProps) => {
       return vectorClient.upsertItemBatch(props.indexName, []);
@@ -1165,5 +1168,27 @@ export function runVectorDataPlaneTest(vectorClient: IVectorIndexClient) {
         );
       }
     );
+  });
+
+  describe('when ThrowOnErrors is set to true', () => {
+    it('should throw when upserting item with wrong number of dimensions', async () => {
+      const indexName = testIndexName(
+        'throw-on-errors-data-upsert-wrong-dimensions'
+      );
+      await WithIndex(
+        vectorClientWithThrowOnErrors,
+        indexName,
+        2,
+        VectorSimilarityMetric.INNER_PRODUCT,
+        async () => {
+          await expect(
+            async () =>
+              await vectorClientWithThrowOnErrors.upsertItemBatch(indexName, [
+                {id: 'test_item', vector: [1.0, 2.0, 3.0]},
+              ])
+          ).rejects.toThrow(VectorUpsertItemBatch.Error);
+        }
+      );
+    });
   });
 }

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -20,6 +20,7 @@ import {
   WithIndex,
 } from './common-int-test-utils';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {InvalidArgumentError} from "@gomomento/sdk-core/dist/src";
 
 export function runVectorDataPlaneTest(
   vectorClient: IVectorIndexClient,
@@ -1186,7 +1187,7 @@ export function runVectorDataPlaneTest(
               await vectorClientWithThrowOnErrors.upsertItemBatch(indexName, [
                 {id: 'test_item', vector: [1.0, 2.0, 3.0]},
               ])
-          ).rejects.toThrow(VectorUpsertItemBatch.Error);
+          ).rejects.toThrow(InvalidArgumentError);
         }
       );
     });

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1176,7 +1176,7 @@ export function runVectorDataPlaneTest(
         'throw-on-errors-data-upsert-wrong-dimensions'
       );
       await WithIndex(
-        vectorClientWithThrowOnErrors,
+        vectorClient,
         indexName,
         2,
         VectorSimilarityMetric.INNER_PRODUCT,

--- a/packages/core/src/errors/ICacheServiceErrorMapper.ts
+++ b/packages/core/src/errors/ICacheServiceErrorMapper.ts
@@ -1,0 +1,18 @@
+import {SdkError} from '../../src';
+
+export interface ResolveOrRejectErrorOptions<TGrpcError> {
+  err: TGrpcError | null;
+  errorResponseFactoryFn: (err: SdkError) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resolveFn: (result: any) => void;
+  rejectFn: (err: SdkError) => void;
+}
+
+export interface ICacheServiceErrorMapper<TGrpcError> {
+  resolveOrRejectError(opts: ResolveOrRejectErrorOptions<TGrpcError>): void;
+  returnOrThrowError<TErrorResponse>(
+    err: Error,
+    errorResponseFactoryFn: (err: SdkError) => TErrorResponse
+  ): TErrorResponse;
+  convertError(err: TGrpcError | null): SdkError;
+}

--- a/packages/core/src/errors/error-utils.ts
+++ b/packages/core/src/errors/error-utils.ts
@@ -1,8 +1,0 @@
-// import {SdkError, UnknownError} from './errors';
-//
-// export function normalizeSdkError(error: Error): SdkError {
-//   if (error instanceof SdkError) {
-//     return error;
-//   }
-//   return new UnknownError(error.message);
-// }

--- a/packages/core/src/errors/error-utils.ts
+++ b/packages/core/src/errors/error-utils.ts
@@ -1,8 +1,8 @@
-import {SdkError, UnknownError} from './errors';
-
-export function normalizeSdkError(error: Error): SdkError {
-  if (error instanceof SdkError) {
-    return error;
-  }
-  return new UnknownError(error.message);
-}
+// import {SdkError, UnknownError} from './errors';
+//
+// export function normalizeSdkError(error: Error): SdkError {
+//   if (error instanceof SdkError) {
+//     return error;
+//   }
+//   return new UnknownError(error.message);
+// }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,2 +1,1 @@
-export * from './error-utils';
 export * from './errors';

--- a/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
+++ b/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
@@ -3,7 +3,7 @@ import {
   validateCacheName,
   validateTopicName,
 } from '../../utils';
-import {MomentoErrorCode, normalizeSdkError} from '../../../errors';
+import {MomentoErrorCode} from '../../../errors';
 import {
   CredentialProvider,
   TopicPublish,
@@ -104,7 +104,10 @@ export abstract class AbstractPubsubClient<TGrpcError>
       validateCacheName(cacheName);
       validateTopicName(topicName);
     } catch (err) {
-      return new TopicSubscribe.Error(normalizeSdkError(err as Error));
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new TopicSubscribe.Error(err)
+      );
     }
     this.logger.trace(
       'Issuing subscribe request; topic: %s',


### PR DESCRIPTION
This commit adds a new configuration setting to the various Configuration objects: `ThrowOnErrors`.

The default behavior for all of the Momento clients is to return errors as part of the function's return value, to try to make error handling feel more like a first-class part of the API. However there are some cases where it is easier to allow errors to bubble up the call stack and handle them via a try/catch, and some users may prefer that style of error handling since it is more prevalent in JS.

If the new ThrowOnErrors config option can be set to `true`, then the clients will throw exceptions rather than returning them as errors.