### PR TITLE
chore: use default accessor in mvi list indexes response base

### DIFF
--- a/packages/core/src/messages/responses/vector/list-vector-indexes.ts
+++ b/packages/core/src/messages/responses/vector/list-vector-indexes.ts
@@ -21,7 +21,14 @@ import {ResponseBase, ResponseError, ResponseSuccess} from '../response-base';
  * }
  * ```
  */
-export abstract class Response extends ResponseBase {}
+export abstract class Response extends ResponseBase {
+  getIndexes(): VectorIndexInfo[] | undefined {
+    if (this instanceof Success) {
+      return this.getIndexes();
+    }
+    return undefined;
+  }
+}
 
 class _Success extends Response {
   private readonly indexes: VectorIndexInfo[];


### PR DESCRIPTION
We have adopted a pattern where users can call accessors on the
response base class to avoid an instanceof guard. That is, suppose a
user calls `client.listIndexes()`. This returns a
`ListVectorIndexes.Response` class, which will either be a `Success`
or `Error`. A user should then use `instanceof` to check the appropriate
subtype.

In order to simplify access we move the accessor to the base class and
do an instanceof check there. In the event the response is not a
success we return undefined.
