### PR TITLE
chore: use the `.value()` syntax in the ThrowOnErrors example

### DIFF
--- a/examples/nodejs/cache/doc-example-files/config-and-error-handling.ts
+++ b/examples/nodejs/cache/doc-example-files/config-and-error-handling.ts
@@ -54,10 +54,10 @@ async function example_configuration_ConstructWithThrowOnErrorsConfig() {
 
 async function example_configuration_ErrorHandlingExceptionErrorCode(cacheClient: CacheClient) {
   try {
-    const result = await cacheClient.get('test-cache', 'test-key');
-    if (result instanceof CacheGet.Hit) {
-      console.log(`Retrieved value for key 'test-key': ${result.valueString()}`);
-    } else if (result instanceof CacheGet.Miss) {
+    const result = (await cacheClient.get('test-cache', 'test-key')).value();
+    if (result !== undefined) {
+      console.log(`Retrieved value for key 'test-key': ${result}`);
+    } else {
       console.log("Key 'test-key' was not found in cache 'test-cache'");
     }
   } catch (e) {


### PR DESCRIPTION
The combination of the new `.value()` accessors and the `WithThrowOnErrors`
config allows users to write code that doesn't do any `instanceof` checks.
That is probably the more idiomatic combination for cases where users are
doing `ThrowOnError`. This commit updates the ThrowOnError example code
to use `.value()`, accordingly.
