### PR TITLE
chore: update example snippets for mvi count items

### DIFF
--- a/examples/nodejs/cache/package-lock.json
+++ b/examples/nodejs/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.58.0"
+        "@gomomento/sdk": "^1.60.0"
       },
       "devDependencies": {
         "@types/node": "^16.11.4",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
-      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.102.1.tgz",
+      "integrity": "sha512-xXCMbfDI3c/CgPr+a8FPmtyzA/V0G36aKKZrU4RUbSzdeZEQndwNdf9MSaQrThpzsAY3aJQq2ip+0v9xQPYb9A==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -71,12 +71,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.58.0.tgz",
-      "integrity": "sha512-u5EJIkr2EXui+p/K2s2jLPNSH8lhl7ahM9VyAt6mEumjkzBXBch9fFZuTtL9eS+3V0GTk6SqmS4fsdX9R1AxHQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.60.0.tgz",
+      "integrity": "sha512-X7evUOlueijLqoHtt3C+CItoYeUysT8zY3IDjVu/JNYZWfQ5JooHzQjQfI+KVMDlFB/bpd0qRCGk6XCE99mmvA==",
       "dependencies": {
-        "@gomomento/generated-types": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -108,14 +108,6 @@
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -283,8 +275,7 @@
     "node_modules/@types/node": {
       "version": "16.18.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
-      "dev": true
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
@@ -2772,9 +2763,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2792,14 +2783,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/protoc-gen-ts": {
@@ -3425,11 +3408,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3607,9 +3585,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
-      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.102.1.tgz",
+      "integrity": "sha512-xXCMbfDI3c/CgPr+a8FPmtyzA/V0G36aKKZrU4RUbSzdeZEQndwNdf9MSaQrThpzsAY3aJQq2ip+0v9xQPYb9A==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3618,12 +3596,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.58.0.tgz",
-      "integrity": "sha512-u5EJIkr2EXui+p/K2s2jLPNSH8lhl7ahM9VyAt6mEumjkzBXBch9fFZuTtL9eS+3V0GTk6SqmS4fsdX9R1AxHQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.60.0.tgz",
+      "integrity": "sha512-X7evUOlueijLqoHtt3C+CItoYeUysT8zY3IDjVu/JNYZWfQ5JooHzQjQfI+KVMDlFB/bpd0qRCGk6XCE99mmvA==",
       "requires": {
-        "@gomomento/generated-types": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -3631,9 +3609,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -3646,16 +3624,6 @@
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.10.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-          "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        }
       }
     },
     "@grpc/proto-loader": {
@@ -3802,8 +3770,7 @@
     "@types/node": {
       "version": "16.18.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
-      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg==",
-      "dev": true
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.5",
@@ -5546,9 +5513,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5562,16 +5529,6 @@
         "@protobufjs/utf8": "^1.1.0",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.10.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-          "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
-        }
       }
     },
     "protoc-gen-ts": {
@@ -5989,11 +5946,6 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/examples/nodejs/cache/package.json
+++ b/examples/nodejs/cache/package.json
@@ -32,7 +32,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.58.0"
+    "@gomomento/sdk": "^1.60.0"
   },
   "engines": {
     "node": ">=10.4.0"

--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -4,6 +4,7 @@ import {
   DeleteVectorIndex,
   ListVectorIndexes,
   PreviewVectorIndexClient,
+  VectorCountItems,
   VectorIndexConfigurations,
   VectorSearch,
   VectorSearchAndFetchVectors,
@@ -58,6 +59,15 @@ async function example_API_DeleteIndex(vectorClient: PreviewVectorIndexClient) {
     throw new Error(
       `An error occurred while attempting to delete index 'test-index': ${result.errorCode()}: ${result.toString()}`
     );
+  }
+}
+
+async function example_API_CountItems(vectorClient: PreviewVectorIndexClient) {
+  const result = await vectorClient.countItems('test-index');
+  if (result instanceof VectorCountItems.Success) {
+    console.log(`Found ${result.itemCount()} items`);
+  } else if (result instanceof VectorCountItems.Error) {
+    throw new Error(`An error occurred while counting items: ${result.errorCode()}: ${result.toString()}`);
   }
 }
 
@@ -142,6 +152,7 @@ async function main() {
   example_API_InstantiateVectorClient();
   await example_API_CreateIndex(vectorClient);
   await example_API_ListIndexes(vectorClient);
+  await example_API_CountItems(vectorClient);
   await example_API_UpsertItemBatch(vectorClient);
   await example_API_Search(vectorClient);
   await example_API_SearchAndFetchVectors(vectorClient);

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.58.0",
+        "@gomomento/sdk": "^1.60.0",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
-      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.102.1.tgz",
+      "integrity": "sha512-xXCMbfDI3c/CgPr+a8FPmtyzA/V0G36aKKZrU4RUbSzdeZEQndwNdf9MSaQrThpzsAY3aJQq2ip+0v9xQPYb9A==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -93,12 +93,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.58.0.tgz",
-      "integrity": "sha512-u5EJIkr2EXui+p/K2s2jLPNSH8lhl7ahM9VyAt6mEumjkzBXBch9fFZuTtL9eS+3V0GTk6SqmS4fsdX9R1AxHQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.60.0.tgz",
+      "integrity": "sha512-X7evUOlueijLqoHtt3C+CItoYeUysT8zY3IDjVu/JNYZWfQ5JooHzQjQfI+KVMDlFB/bpd0qRCGk6XCE99mmvA==",
       "dependencies": {
-        "@gomomento/generated-types": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -2924,9 +2924,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3878,9 +3878,9 @@
       }
     },
     "@gomomento/generated-types": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.97.1.tgz",
-      "integrity": "sha512-a3JkF6Q/ehdn48n4IU+icND+2gWXb3Gbb9wLG9VbG2/TUFcR3JDk2YhDqKhEendTbB46IpxsDTsJdpq2eTHpgg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.102.1.tgz",
+      "integrity": "sha512-xXCMbfDI3c/CgPr+a8FPmtyzA/V0G36aKKZrU4RUbSzdeZEQndwNdf9MSaQrThpzsAY3aJQq2ip+0v9xQPYb9A==",
       "requires": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",
@@ -3889,12 +3889,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.58.0.tgz",
-      "integrity": "sha512-u5EJIkr2EXui+p/K2s2jLPNSH8lhl7ahM9VyAt6mEumjkzBXBch9fFZuTtL9eS+3V0GTk6SqmS4fsdX9R1AxHQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.60.0.tgz",
+      "integrity": "sha512-X7evUOlueijLqoHtt3C+CItoYeUysT8zY3IDjVu/JNYZWfQ5JooHzQjQfI+KVMDlFB/bpd0qRCGk6XCE99mmvA==",
       "requires": {
-        "@gomomento/generated-types": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -3902,9 +3902,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -5933,9 +5933,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.58.0",
+    "@gomomento/sdk": "^1.60.0",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/cache/package-lock.json
+++ b/examples/web/cache/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.58.0",
+        "@gomomento/sdk-web": "^1.60.0",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -73,18 +73,18 @@
       }
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.97.1.tgz",
-      "integrity": "sha512-7Rjz2gPwyRo3L/bnU5eo0a0g7LjijF3pDDkN4yParUOO+DMbuRe4LTBtuvMVU3p1rmp6Y2LXr/9o7av8MW9wWg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.102.1.tgz",
+      "integrity": "sha512-wvmhU6o1oYdx4YJQmYgHa2KPHmVE253Po2lnCGftwtKSuqUsVSl/yWm8s5TmhYJ9ptG/3T9JoRgCGNMq6DmlZg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -94,12 +94,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.58.0.tgz",
-      "integrity": "sha512-kSkjKpkGJkG5hVmdIpFa48lRAyCqWgrl2uKiv/dmU2Tq3n2OeL8OQ5MecfKxP4tdAa3TrMU0vLHpzRE1Api+RA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.60.0.tgz",
+      "integrity": "sha512-3XMMQBkXr5PTH9P/KsDzBI2MFX20YP6ZXLexSh/8C4XC/WJ8ag99xGX03Vc1fUJZty5TomZngHScgN8lg6hlWQ==",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types-webtext": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -3213,30 +3213,30 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.97.1.tgz",
-      "integrity": "sha512-7Rjz2gPwyRo3L/bnU5eo0a0g7LjijF3pDDkN4yParUOO+DMbuRe4LTBtuvMVU3p1rmp6Y2LXr/9o7av8MW9wWg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.102.1.tgz",
+      "integrity": "sha512-wvmhU6o1oYdx4YJQmYgHa2KPHmVE253Po2lnCGftwtKSuqUsVSl/yWm8s5TmhYJ9ptG/3T9JoRgCGNMq6DmlZg==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.58.0.tgz",
-      "integrity": "sha512-kSkjKpkGJkG5hVmdIpFa48lRAyCqWgrl2uKiv/dmU2Tq3n2OeL8OQ5MecfKxP4tdAa3TrMU0vLHpzRE1Api+RA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.60.0.tgz",
+      "integrity": "sha512-3XMMQBkXr5PTH9P/KsDzBI2MFX20YP6ZXLexSh/8C4XC/WJ8ag99xGX03Vc1fUJZty5TomZngHScgN8lg6hlWQ==",
       "requires": {
-        "@gomomento/generated-types-webtext": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types-webtext": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",

--- a/examples/web/cache/package.json
+++ b/examples/web/cache/package.json
@@ -29,7 +29,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.58.0",
+    "@gomomento/sdk-web": "^1.60.0",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -3,6 +3,7 @@ import {
   DeleteVectorIndex,
   ListVectorIndexes,
   PreviewVectorIndexClient,
+  VectorCountItems,
   VectorSearch,
   VectorSearchAndFetchVectors,
   VectorDeleteItemBatch,
@@ -50,6 +51,15 @@ async function example_API_DeleteIndex(vectorClient: PreviewVectorIndexClient) {
     throw new Error(
       `An error occurred while attempting to delete index 'test-index': ${result.errorCode()}: ${result.toString()}`
     );
+  }
+}
+
+async function example_API_CountItems(vectorClient: PreviewVectorIndexClient) {
+  const result = await vectorClient.countItems('test-index');
+  if (result instanceof VectorCountItems.Success) {
+    console.log(`Found ${result.itemCount()} items`);
+  } else if (result instanceof VectorCountItems.Error) {
+    throw new Error(`An error occurred while counting items in index: ${result.errorCode()}: ${result.toString()}`);
   }
 }
 
@@ -133,6 +143,7 @@ async function main() {
   });
   await example_API_CreateIndex(vectorClient);
   await example_API_ListIndexes(vectorClient);
+  await example_API_CountItems(vectorClient);
   await example_API_UpsertItemBatch(vectorClient);
   await example_API_Search(vectorClient);
   await example_API_SearchAndFetchVectors(vectorClient);

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.58.0",
+        "@gomomento/sdk-web": "^1.60.0",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -82,18 +82,18 @@
       }
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.97.1.tgz",
-      "integrity": "sha512-7Rjz2gPwyRo3L/bnU5eo0a0g7LjijF3pDDkN4yParUOO+DMbuRe4LTBtuvMVU3p1rmp6Y2LXr/9o7av8MW9wWg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.102.1.tgz",
+      "integrity": "sha512-wvmhU6o1oYdx4YJQmYgHa2KPHmVE253Po2lnCGftwtKSuqUsVSl/yWm8s5TmhYJ9ptG/3T9JoRgCGNMq6DmlZg==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.58.0.tgz",
-      "integrity": "sha512-kSkjKpkGJkG5hVmdIpFa48lRAyCqWgrl2uKiv/dmU2Tq3n2OeL8OQ5MecfKxP4tdAa3TrMU0vLHpzRE1Api+RA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.60.0.tgz",
+      "integrity": "sha512-3XMMQBkXr5PTH9P/KsDzBI2MFX20YP6ZXLexSh/8C4XC/WJ8ag99xGX03Vc1fUJZty5TomZngHScgN8lg6hlWQ==",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types-webtext": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -3314,30 +3314,30 @@
       }
     },
     "@gomomento/generated-types-webtext": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.97.1.tgz",
-      "integrity": "sha512-7Rjz2gPwyRo3L/bnU5eo0a0g7LjijF3pDDkN4yParUOO+DMbuRe4LTBtuvMVU3p1rmp6Y2LXr/9o7av8MW9wWg==",
+      "version": "0.102.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.102.1.tgz",
+      "integrity": "sha512-wvmhU6o1oYdx4YJQmYgHa2KPHmVE253Po2lnCGftwtKSuqUsVSl/yWm8s5TmhYJ9ptG/3T9JoRgCGNMq6DmlZg==",
       "requires": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.58.0.tgz",
-      "integrity": "sha512-Sk1Br+2yl6C0XLuK0zBN3ijVJR82fhGAJYAwaL8cCU3n8PReHwCQ8ohS2Jqw8+FujOH61QDCLYqZjmBoh3C1+w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.60.0.tgz",
+      "integrity": "sha512-27/bgzYCzi1dK5iaMM8PTz68dKCZdEq7mE4istFIVSpRDeY6z6PlmhNVvGBigueXAq+nzk89T9bX+yxXwHza6A==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.58.0.tgz",
-      "integrity": "sha512-kSkjKpkGJkG5hVmdIpFa48lRAyCqWgrl2uKiv/dmU2Tq3n2OeL8OQ5MecfKxP4tdAa3TrMU0vLHpzRE1Api+RA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.60.0.tgz",
+      "integrity": "sha512-3XMMQBkXr5PTH9P/KsDzBI2MFX20YP6ZXLexSh/8C4XC/WJ8ag99xGX03Vc1fUJZty5TomZngHScgN8lg6hlWQ==",
       "requires": {
-        "@gomomento/generated-types-webtext": "0.97.1",
-        "@gomomento/sdk-core": "1.58.0",
+        "@gomomento/generated-types-webtext": "0.102.1",
+        "@gomomento/sdk-core": "1.60.0",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.58.0",
+    "@gomomento/sdk-web": "^1.60.0",
     "jsdom": "22.1.0"
   }
 }


### PR DESCRIPTION
Add example snippets for MVI `countItems` in both the Web and Node.js vector index examples.

Because the cache examples sdk dependencies were out of date for latest leaderboard changes, we also updated those.