### PR TITLE
feat: add withClientTimeoutMillis and withMiddlewares to Leaderboard configs

### DIFF
--- a/packages/client-sdk-nodejs/src/config/leaderboard-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configuration.ts
@@ -19,6 +19,15 @@ export interface LeaderboardConfiguration {
   getTransportStrategy(): TransportStrategy;
 
   /**
+   * Convenience copy constructor that updates the client-side timeout setting in the TransportStrategy
+   * @param {number} clientTimeoutMillis
+   * @returns {LeaderboardConfiguration} a new Configuration object with its TransportStrategy updated to use the specified client timeout
+   */
+  withClientTimeoutMillis(
+    clientTimeoutMillis: number
+  ): LeaderboardConfiguration;
+
+  /**
    * Copy constructor for overriding TransportStrategy
    * @param {TransportStrategy} transportStrategy
    * @returns {Configuration} a new Configuration object with the specified TransportStrategy

--- a/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
@@ -45,7 +45,7 @@ export class Laptop extends LeaderboardClientConfiguration {
   static v1(
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
   ): LeaderboardConfiguration {
-    const deadlineMillis = 5000;
+    const deadlineMillis = 15000;
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,

--- a/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
@@ -11,12 +11,14 @@ import {
   TransportStrategy,
 } from './transport';
 import {DefaultMomentoLoggerFactory} from './logging/default-momento-logger';
+import {Middleware} from './middleware/middleware';
 
 // 4 minutes.  We want to remain comfortably underneath the idle timeout for AWS NLB, which is 350s.
 const defaultMaxIdleMillis = 4 * 60 * 1_000;
 const defaultMaxSessionMemoryMb = 256;
 const defaultLoggerFactory: MomentoLoggerFactory =
   new DefaultMomentoLoggerFactory();
+const defaultMiddlewares: Middleware[] = [];
 
 /**
  * Laptop config provides defaults suitable for a medium-to-high-latency dev environment.
@@ -58,6 +60,7 @@ export class Laptop extends LeaderboardClientConfiguration {
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
       throwOnErrors: false,
+      middlewares: defaultMiddlewares,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -33,7 +33,7 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
 
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento LeaderboardClient');
-    this.dataClient = new LeaderboardDataClient(propsWithConfig);
+    this.dataClient = new LeaderboardDataClient(propsWithConfig, '0'); // only creating one leaderboard client
   }
 
   /**


### PR DESCRIPTION
adds a couple more config options to leaderboard clients, now able to set a different client timeout (in milliseconds) and add middleware (such as the Momento metrics middleware)

can now enable metrics middleware and set a different timeout like so:
```
const loggerFactory = new DefaultMomentoLoggerFactory(DefaultMomentoLoggerLevel.TRACE);
const client = new PreviewLeaderboardClient({
  configuration: LeaderboardConfigurations.Laptop.v1(loggerFactory).withClientTimeoutMillis(2000).withMiddlewares([
    new ExperimentalMetricsLoggingMiddleware(loggerFactory),
  ]),
  credentialProvider: CredentialProvider.fromEnvironmentVariable({
    environmentVariableName: 'MOMENTO_API_KEY',
  }),
});
```