### PR TITLE
fix: implement default topk behavior for mvi search methods

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -16,6 +16,8 @@ import {
   VectorIndexStoredItem,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
+  ALL_VECTOR_METADATA,
+  VECTOR_DEFAULT_TOPK,
 } from '@gomomento/sdk-core';
 import {VectorIndexConfiguration} from '../config/vector-index-configuration';
 import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
@@ -28,7 +30,6 @@ import {
   validateTopK,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {UnknownError} from '@gomomento/sdk-core/dist/src/errors';
-import {ALL_VECTOR_METADATA} from '@gomomento/sdk-core/dist/src/clients/IVectorIndexClient';
 import {VectorIndexClientPropsWithConfig} from './vector-index-client-props-with-config';
 
 export class VectorIndexDataClient implements IVectorIndexDataClient {
@@ -362,7 +363,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._SearchRequest({
       index_name: indexName,
       query_vector: new vectorindex._Vector({elements: queryVector}),
-      top_k: options?.topK,
+      top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.prepareMetadataRequest(options),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);
@@ -436,7 +437,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._SearchAndFetchVectorsRequest({
       index_name: indexName,
       query_vector: new vectorindex._Vector({elements: queryVector}),
-      top_k: options?.topK,
+      top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.prepareMetadataRequest(options),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -16,6 +16,8 @@ import {
   VectorGetItemMetadataBatch,
   InvalidArgumentError,
   UnknownError,
+  ALL_VECTOR_METADATA,
+  VECTOR_DEFAULT_TOPK,
 } from '@gomomento/sdk-core';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {
@@ -24,7 +26,6 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {getWebVectorEndpoint} from '../utils/web-client-utils';
-import {ALL_VECTOR_METADATA} from '@gomomento/sdk-core/dist/src/clients/IVectorIndexClient';
 import {VectorIndexClientPropsWithConfig} from './vector-index-client-props-with-config';
 
 export class VectorIndexDataClient implements IVectorIndexDataClient {
@@ -342,9 +343,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const vector = new vectorindex._Vector();
     vector.setElementsList(queryVector);
     request.setQueryVector(vector);
-    if (options?.topK !== undefined) {
-      request.setTopK(options.topK);
-    }
+    request.setTopK(options?.topK ?? VECTOR_DEFAULT_TOPK);
     request.setMetadataFields(
       VectorIndexDataClient.prepareMetadataRequest(options)
     );
@@ -424,9 +423,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const vector = new vectorindex._Vector();
     vector.setElementsList(queryVector);
     request.setQueryVector(vector);
-    if (options?.topK !== undefined) {
-      request.setTopK(options.topK);
-    }
+    request.setTopK(options?.topK ?? VECTOR_DEFAULT_TOPK);
     request.setMetadataFields(
       VectorIndexDataClient.prepareMetadataRequest(options)
     );

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -16,11 +16,16 @@ import {VectorIndexItem} from '../messages/vector-index';
 export const ALL_VECTOR_METADATA = Symbol('ALL_VECTOR_METADATA');
 
 /**
+ * The default number of results to return.
+ */
+export const VECTOR_DEFAULT_TOPK = 10;
+
+/**
  * Options for the search operation.
  */
 export interface SearchOptions {
   /**
-   * The number of results to return. Defaults to 10.
+   * The number of results to return. Defaults to {@link VECTOR_DEFAULT_TOPK}.
    */
   topK?: number;
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,6 +145,7 @@ export {
   IVectorIndexClient,
   SearchOptions,
   ALL_VECTOR_METADATA,
+  VECTOR_DEFAULT_TOPK,
 } from './clients/IVectorIndexClient';
 
 export {VectorSimilarityMetric} from './internal/clients';


### PR DESCRIPTION
- chore: extract vector search topk to constant
- test: add integration test to exercise default topk
- fix: use default topk in nodejs vector client
- fix: use default topk in web client
