### PR TITLE
feat: implement mvi search filters

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -331,7 +331,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): vectorindex._FilterExpression | undefined {
     if (filterExpression === undefined) {
       return undefined;
-    } else if (filterExpression instanceof F.VectorAndExpression) {
+    } else if (filterExpression instanceof F.VectorFilterAndExpression) {
       return new vectorindex._FilterExpression({
         and_expression: new vectorindex._AndExpression({
           first_expression: VectorIndexDataClient.buildFilterExpression(
@@ -342,7 +342,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           ),
         }),
       });
-    } else if (filterExpression instanceof F.VectorOrExpression) {
+    } else if (filterExpression instanceof F.VectorFilterOrExpression) {
       return new vectorindex._FilterExpression({
         or_expression: new vectorindex._OrExpression({
           first_expression: VectorIndexDataClient.buildFilterExpression(
@@ -353,7 +353,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           ),
         }),
       });
-    } else if (filterExpression instanceof F.VectorNotExpression) {
+    } else if (filterExpression instanceof F.VectorFilterNotExpression) {
       return new vectorindex._FilterExpression({
         not_expression: new vectorindex._NotExpression({
           expression_to_negate: VectorIndexDataClient.buildFilterExpression(
@@ -361,7 +361,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           ),
         }),
       });
-    } else if (filterExpression instanceof F.VectorEqualsExpression) {
+    } else if (filterExpression instanceof F.VectorFilterEqualsExpression) {
       // test if the Value is a string or a number
       if (typeof filterExpression.Value === 'string') {
         return new vectorindex._FilterExpression({

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -362,7 +362,6 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         }),
       });
     } else if (filterExpression instanceof F.VectorFilterEqualsExpression) {
-      // test if the Value is a string or a number
       if (typeof filterExpression.Value === 'string') {
         return new vectorindex._FilterExpression({
           equals_expression: new vectorindex._EqualsExpression({

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -1,23 +1,24 @@
 import {version} from '../../package.json';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
 import {
+  ALL_VECTOR_METADATA,
   CredentialProvider,
   InvalidArgumentError,
   MomentoLogger,
   MomentoLoggerFactory,
   SearchOptions,
+  VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
-  VectorIndexMetadata,
-  VectorIndexItem,
-  VectorUpsertItemBatch,
-  VectorIndexStoredItem,
+  vectorFilters as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
-  ALL_VECTOR_METADATA,
-  VECTOR_DEFAULT_TOPK,
+  VectorIndexItem,
+  VectorIndexMetadata,
+  VectorIndexStoredItem,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '@gomomento/sdk-core';
 import {VectorIndexConfiguration} from '../config/vector-index-configuration';
 import {ChannelCredentials, Interceptor} from '@grpc/grpc-js';
@@ -297,7 +298,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     return await this.sendSearch(indexName, queryVector, options);
   }
 
-  private static prepareMetadataRequest(
+  private static buildMetadataRequest(
     options?: SearchOptions
   ): vectorindex._MetadataRequest {
     const metadataRequest = new vectorindex._MetadataRequest();
@@ -323,6 +324,85 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     } else {
       request.no_score_threshold = new vectorindex._NoScoreThreshold();
     }
+  }
+
+  private static buildFilterExpression(
+    filterExpression?: F.VectorFilterExpression
+  ): vectorindex._FilterExpression | undefined {
+    if (filterExpression === undefined) {
+      return undefined;
+    } else if (filterExpression instanceof F.VectorAndExpression) {
+      return new vectorindex._FilterExpression({
+        and_expression: new vectorindex._AndExpression({
+          first_expression: VectorIndexDataClient.buildFilterExpression(
+            filterExpression.FirstExpression
+          ),
+          second_expression: VectorIndexDataClient.buildFilterExpression(
+            filterExpression.SecondExpression
+          ),
+        }),
+      });
+    } else if (filterExpression instanceof F.VectorOrExpression) {
+      return new vectorindex._FilterExpression({
+        or_expression: new vectorindex._OrExpression({
+          first_expression: VectorIndexDataClient.buildFilterExpression(
+            filterExpression.FirstExpression
+          ),
+          second_expression: VectorIndexDataClient.buildFilterExpression(
+            filterExpression.SecondExpression
+          ),
+        }),
+      });
+    } else if (filterExpression instanceof F.VectorNotExpression) {
+      return new vectorindex._FilterExpression({
+        not_expression: new vectorindex._NotExpression({
+          expression_to_negate: VectorIndexDataClient.buildFilterExpression(
+            filterExpression.Expression
+          ),
+        }),
+      });
+    } else if (filterExpression instanceof F.VectorEqualsExpression) {
+      // test if the Value is a string or a number
+      if (typeof filterExpression.Value === 'string') {
+        return new vectorindex._FilterExpression({
+          equals_expression: new vectorindex._EqualsExpression({
+            field: filterExpression.Field,
+            string_value: filterExpression.Value,
+          }),
+        });
+      } else if (typeof filterExpression.Value === 'number') {
+        if (Number.isInteger(filterExpression.Value)) {
+          return new vectorindex._FilterExpression({
+            equals_expression: new vectorindex._EqualsExpression({
+              field: filterExpression.Field,
+              integer_value: filterExpression.Value,
+            }),
+          });
+        } else {
+          return new vectorindex._FilterExpression({
+            equals_expression: new vectorindex._EqualsExpression({
+              field: filterExpression.Field,
+              float_value: filterExpression.Value,
+            }),
+          });
+        }
+      } else if (typeof filterExpression.Value === 'boolean') {
+        return new vectorindex._FilterExpression({
+          equals_expression: new vectorindex._EqualsExpression({
+            field: filterExpression.Field,
+            boolean_value: filterExpression.Value,
+          }),
+        });
+      } else {
+        throw new InvalidArgumentError(
+          `Filter value for field '${
+            filterExpression.Field
+          }' is not a valid type. Value is of type '${typeof filterExpression.Value} and is not a string, number, or boolean.'`
+        );
+      }
+    }
+
+    throw new InvalidArgumentError('Filter expression is not a valid type.');
   }
 
   private static deserializeMetadata(
@@ -364,7 +444,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       index_name: indexName,
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
-      metadata_fields: VectorIndexDataClient.prepareMetadataRequest(options),
+      metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
+      filter_expression: VectorIndexDataClient.buildFilterExpression(
+        options?.filterExpression
+      ),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);
 
@@ -438,7 +521,10 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       index_name: indexName,
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
-      metadata_fields: VectorIndexDataClient.prepareMetadataRequest(options),
+      metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
+      filter_expression: VectorIndexDataClient.buildFilterExpression(
+        options?.filterExpression
+      ),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);
 
@@ -504,7 +590,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemBatchRequest({
       index_name: indexName,
       ids: ids,
-      metadata_fields: VectorIndexDataClient.prepareMetadataRequest({
+      metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),
     });
@@ -586,7 +672,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     const request = new vectorindex._GetItemMetadataBatchRequest({
       index_name: indexName,
       ids: ids,
-      metadata_fields: VectorIndexDataClient.prepareMetadataRequest({
+      metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),
     });

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -352,6 +352,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     } else if (filterExpression instanceof F.VectorFilterEqualsExpression) {
       const equals = new vectorindex._EqualsExpression();
       equals.setField(filterExpression.Field);
+
       if (typeof filterExpression.Value === 'string') {
         equals.setStringValue(filterExpression.Value);
       } else if (typeof filterExpression.Value === 'number') {
@@ -369,6 +370,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
           }' is not a valid type. Value is of type '${typeof filterExpression.Value} and is not a string, number, or boolean.'`
         );
       }
+
       const expression = new vectorindex._FilterExpression();
       expression.setEqualsExpression(equals);
       return expression;

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -2,22 +2,23 @@ import {VectorIndexClient} from '@gomomento/generated-types-webtext/dist/Vectori
 import * as vectorindex from '@gomomento/generated-types-webtext/dist/vectorindex_pb';
 import {IVectorIndexDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/vector/IVectorIndexDataClient';
 import {
+  ALL_VECTOR_METADATA,
+  InvalidArgumentError,
   MomentoLogger,
   SearchOptions,
+  UnknownError,
+  VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
-  VectorIndexMetadata,
-  VectorIndexItem,
-  VectorUpsertItemBatch,
-  VectorIndexStoredItem,
+  vectorFilters as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
-  InvalidArgumentError,
-  UnknownError,
-  ALL_VECTOR_METADATA,
-  VECTOR_DEFAULT_TOPK,
+  VectorIndexItem,
+  VectorIndexMetadata,
+  VectorIndexStoredItem,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '@gomomento/sdk-core';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {
@@ -273,7 +274,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     return await this.sendSearch(indexName, queryVector, options);
   }
 
-  private static prepareMetadataRequest(
+  private static buildMetadataRequest(
     options?: SearchOptions
   ): vectorindex._MetadataRequest {
     const metadataRequest = new vectorindex._MetadataRequest();
@@ -301,6 +302,79 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     } else {
       request.setNoScoreThreshold(new vectorindex._NoScoreThreshold());
     }
+  }
+
+  private static buildFilterExpression(
+    filterExpression?: F.VectorFilterExpression
+  ): vectorindex._FilterExpression | undefined {
+    if (filterExpression === undefined) {
+      return undefined;
+    }
+
+    if (filterExpression instanceof F.VectorAndExpression) {
+      const and = new vectorindex._AndExpression();
+      and.setFirstExpression(
+        VectorIndexDataClient.buildFilterExpression(
+          filterExpression.FirstExpression
+        )
+      );
+      and.setSecondExpression(
+        VectorIndexDataClient.buildFilterExpression(
+          filterExpression.SecondExpression
+        )
+      );
+      const expression = new vectorindex._FilterExpression();
+      expression.setAndExpression(and);
+      return expression;
+    } else if (filterExpression instanceof F.VectorOrExpression) {
+      const or = new vectorindex._OrExpression();
+      or.setFirstExpression(
+        VectorIndexDataClient.buildFilterExpression(
+          filterExpression.FirstExpression
+        )
+      );
+      or.setSecondExpression(
+        VectorIndexDataClient.buildFilterExpression(
+          filterExpression.SecondExpression
+        )
+      );
+      const expression = new vectorindex._FilterExpression();
+      expression.setOrExpression(or);
+      return expression;
+    } else if (filterExpression instanceof F.VectorNotExpression) {
+      const not = new vectorindex._NotExpression();
+      not.setExpressionToNegate(
+        VectorIndexDataClient.buildFilterExpression(filterExpression.Expression)
+      );
+      const expression = new vectorindex._FilterExpression();
+      expression.setNotExpression(not);
+      return expression;
+    } else if (filterExpression instanceof F.VectorEqualsExpression) {
+      const equals = new vectorindex._EqualsExpression();
+      equals.setField(filterExpression.Field);
+      if (typeof filterExpression.Value === 'string') {
+        equals.setStringValue(filterExpression.Value);
+      } else if (typeof filterExpression.Value === 'number') {
+        if (Number.isInteger(filterExpression.Value)) {
+          equals.setIntegerValue(filterExpression.Value);
+        } else {
+          equals.setFloatValue(filterExpression.Value);
+        }
+      } else if (typeof filterExpression.Value === 'boolean') {
+        equals.setBooleanValue(filterExpression.Value);
+      } else {
+        throw new InvalidArgumentError(
+          `Filter value for field '${
+            filterExpression.Field
+          }' is not a valid type. Value is of type '${typeof filterExpression.Value} and is not a string, number, or boolean.'`
+        );
+      }
+      const expression = new vectorindex._FilterExpression();
+      expression.setEqualsExpression(equals);
+      return expression;
+    }
+
+    throw new InvalidArgumentError('Filter expression is not a valid type.');
   }
 
   private static deserializeMetadata(
@@ -345,9 +419,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     request.setQueryVector(vector);
     request.setTopK(options?.topK ?? VECTOR_DEFAULT_TOPK);
     request.setMetadataFields(
-      VectorIndexDataClient.prepareMetadataRequest(options)
+      VectorIndexDataClient.buildMetadataRequest(options)
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
+    request.setFilterExpression(
+      VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
+    );
 
     return await new Promise((resolve, reject) => {
       this.client.search(
@@ -425,9 +502,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     request.setQueryVector(vector);
     request.setTopK(options?.topK ?? VECTOR_DEFAULT_TOPK);
     request.setMetadataFields(
-      VectorIndexDataClient.prepareMetadataRequest(options)
+      VectorIndexDataClient.buildMetadataRequest(options)
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
+    request.setFilterExpression(
+      VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
+    );
 
     return await new Promise((resolve, reject) => {
       this.client.searchAndFetchVectors(
@@ -495,7 +575,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     request.setIndexName(indexName);
     request.setIdsList(ids);
     request.setMetadataFields(
-      VectorIndexDataClient.prepareMetadataRequest({
+      VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       })
     );
@@ -584,7 +664,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     request.setIndexName(indexName);
     request.setIdsList(ids);
     request.setMetadataFields(
-      VectorIndexDataClient.prepareMetadataRequest({
+      VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       })
     );

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -311,7 +311,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       return undefined;
     }
 
-    if (filterExpression instanceof F.VectorAndExpression) {
+    if (filterExpression instanceof F.VectorFilterAndExpression) {
       const and = new vectorindex._AndExpression();
       and.setFirstExpression(
         VectorIndexDataClient.buildFilterExpression(
@@ -326,7 +326,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       const expression = new vectorindex._FilterExpression();
       expression.setAndExpression(and);
       return expression;
-    } else if (filterExpression instanceof F.VectorOrExpression) {
+    } else if (filterExpression instanceof F.VectorFilterOrExpression) {
       const or = new vectorindex._OrExpression();
       or.setFirstExpression(
         VectorIndexDataClient.buildFilterExpression(
@@ -341,7 +341,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       const expression = new vectorindex._FilterExpression();
       expression.setOrExpression(or);
       return expression;
-    } else if (filterExpression instanceof F.VectorNotExpression) {
+    } else if (filterExpression instanceof F.VectorFilterNotExpression) {
       const not = new vectorindex._NotExpression();
       not.setExpressionToNegate(
         VectorIndexDataClient.buildFilterExpression(filterExpression.Expression)
@@ -349,7 +349,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       const expression = new vectorindex._FilterExpression();
       expression.setNotExpression(not);
       return expression;
-    } else if (filterExpression instanceof F.VectorEqualsExpression) {
+    } else if (filterExpression instanceof F.VectorFilterEqualsExpression) {
       const equals = new vectorindex._EqualsExpression();
       equals.setField(filterExpression.Field);
       if (typeof filterExpression.Value === 'string') {

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -7,7 +7,7 @@ import {
   VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
-  VectorFilterExpressionFactory as F,
+  VectorFilterExpressions as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
   VectorIndexItem,

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1116,6 +1116,36 @@ export function runVectorDataPlaneTest(
               expectedIds: ['test_item_2'],
               testCaseName: 'bool inequality',
             },
+            {
+              filterExpression: F.and(
+                F.equals('str', 'value1'),
+                F.equals('int', 0)
+              ),
+              expectedIds: ['test_item_1'],
+              testCaseName: 'and',
+            },
+            {
+              filterExpression: F.equals('str', 'value1').and(
+                F.equals('int', 0)
+              ),
+              expectedIds: ['test_item_1'],
+              testCaseName: 'and-chained',
+            },
+            {
+              filterExpression: F.or(
+                F.equals('str', 'value1'),
+                F.equals('int', 5)
+              ),
+              expectedIds: ['test_item_1', 'test_item_2'],
+              testCaseName: 'or',
+            },
+            {
+              filterExpression: F.equals('str', 'value1').or(
+                F.equals('int', 5)
+              ),
+              expectedIds: ['test_item_1', 'test_item_2'],
+              testCaseName: 'or-chained',
+            },
           ]) {
             const searchResponse = await vectorClient.search(
               indexName,

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -7,7 +7,7 @@ import {
   VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
-  VectorFilterExpression as F,
+  VectorFilterExpressionFactory as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
   VectorIndexItem,
@@ -1108,6 +1108,11 @@ export function runVectorDataPlaneTest(
             },
             {
               filterExpression: F.not(F.equals('bool', true)),
+              expectedIds: ['test_item_2'],
+              testCaseName: 'bool inequality',
+            },
+            {
+              filterExpression: F.equals('bool', true).not(),
               expectedIds: ['test_item_2'],
               testCaseName: 'bool inequality',
             },

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -9,6 +9,7 @@ import {
   VectorGetItemMetadataBatch,
 } from '../messages/responses/vector';
 import {VectorIndexItem} from '../messages/vector-index';
+import {VectorFilterExpression} from '../messages/vector-index-filters';
 
 /**
  * A special value to request all metadata fields.
@@ -41,6 +42,10 @@ export interface SearchOptions {
    *   are excluded.
    */
   scoreThreshold?: number;
+  /**
+   * A filter expression to filter results by. Defaults to no filter.
+   */
+  filterExpression?: VectorFilterExpression;
 }
 
 export interface IVectorIndexClient extends IVectorIndexControlClient {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,7 +76,7 @@ export {
 export * as vectorFilters from './messages/vector-index-filters';
 export {
   VectorFilterExpression,
-  VectorFilterExpressionFactory,
+  VectorFilterExpressions,
 } from './messages/vector-index-filters';
 
 // Leaderboard Response Types

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,7 +74,10 @@ export {
   VectorIndexStoredItem,
 } from './messages/vector-index';
 export * as vectorFilters from './messages/vector-index-filters';
-export {VectorFilterExpression} from './messages/vector-index-filters';
+export {
+  VectorFilterExpression,
+  VectorFilterExpressionFactory,
+} from './messages/vector-index-filters';
 
 // Leaderboard Response Types
 export * as leaderboard from './messages/responses/leaderboard';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,8 @@ export {
   VectorIndexItem,
   VectorIndexStoredItem,
 } from './messages/vector-index';
+export * as vectorFilters from './messages/vector-index-filters';
+export {VectorFilterExpression} from './messages/vector-index-filters';
 
 // Leaderboard Response Types
 export * as leaderboard from './messages/responses/leaderboard';

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -1,5 +1,5 @@
 /**
- * Base class for all vector index filters.
+ * Base class for all vector index filter expressions.
  */
 export abstract class VectorFilterExpression {
   public abstract toString(): string;

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -5,6 +5,40 @@ export abstract class VectorFilterExpression {
   public abstract toString(): string;
 
   /**
+   * Creates an AND expression between this expression and another one.
+   * @param other The other expression.
+   * @returns The AND expression.
+   */
+  public and(other: VectorFilterExpression): VectorFilterAndExpression {
+    return VectorFilterExpressionFactory.and(this, other);
+  }
+
+  /**
+   * Creates an OR expression between this expression and another one.
+   * @param other The other expression.
+   * @returns The OR expression.
+   */
+  public or(other: VectorFilterExpression): VectorFilterOrExpression {
+    return VectorFilterExpressionFactory.or(this, other);
+  }
+
+  /**
+   * Negates this expression.
+   * @returns The negated expression.
+   */
+  public not(): VectorFilterNotExpression {
+    return VectorFilterExpressionFactory.not(this);
+  }
+}
+
+/**
+ * Factory for creating vector filter expressions.
+ */
+export class VectorFilterExpressionFactory {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  /**
    * Creates an {@link VectorFilterAndExpression} between two vector filter expressions.
    * @param firstExpression The first expression.
    * @param secondExpression The second expression.

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -1,0 +1,160 @@
+/**
+ * Base class for all vector index filters.
+ */
+export abstract class VectorFilterExpression {
+  public abstract toString(): string;
+
+  /**
+   * Creates an {@link VectorAndExpression} between two vector filter expressions.
+   * @param firstExpression The first expression.
+   * @param secondExpression The second expression.
+   * @returns The AND expression.
+   */
+  public static and(
+    firstExpression: VectorFilterExpression,
+    secondExpression: VectorFilterExpression
+  ): VectorFilterExpression {
+    return new VectorAndExpression(firstExpression, secondExpression);
+  }
+
+  /**
+   * Creates an {@link VectorOrExpression} between a field and a value.
+   * @param firstExpression The first expression.
+   * @param secondExpression The second expression.
+   * @returns The OR expression.
+   */
+  public static or(
+    firstExpression: VectorFilterExpression,
+    secondExpression: VectorFilterExpression
+  ): VectorFilterExpression {
+    return new VectorOrExpression(firstExpression, secondExpression);
+  }
+
+  /**
+   * Creates a {@link VectorNotExpression} expression of a vector filter expression.
+   * @param expression The expression.
+   * @returns The NOT expression.
+   */
+  public static not(
+    expression: VectorFilterExpression
+  ): VectorFilterExpression {
+    return new VectorNotExpression(expression);
+  }
+
+  /**
+   * Creates a {@link VectorEqualsExpression} between a field and a value.
+   * @param field The field.
+   * @param value The value.
+   * @returns The equals expression.
+   */
+  public static equals(
+    field: string,
+    value: string | number | boolean
+  ): VectorFilterExpression {
+    return new VectorEqualsExpression(field, value);
+  }
+}
+
+/**
+ * Represents an AND expression between two vector filter expressions.
+ */
+export class VectorAndExpression extends VectorFilterExpression {
+  private readonly firstExpression: VectorFilterExpression;
+  private readonly secondExpression: VectorFilterExpression;
+
+  constructor(
+    firstExpression: VectorFilterExpression,
+    secondExpression: VectorFilterExpression
+  ) {
+    super();
+    this.firstExpression = firstExpression;
+    this.secondExpression = secondExpression;
+  }
+
+  public get FirstExpression(): VectorFilterExpression {
+    return this.firstExpression;
+  }
+
+  public get SecondExpression(): VectorFilterExpression {
+    return this.secondExpression;
+  }
+
+  public override toString(): string {
+    return `(${this.firstExpression.toString()} AND ${this.secondExpression.toString()})`;
+  }
+}
+
+/**
+ * Represents an OR expression between two vector filter expressions.
+ */
+export class VectorOrExpression extends VectorFilterExpression {
+  private readonly firstExpression: VectorFilterExpression;
+  private readonly secondExpression: VectorFilterExpression;
+
+  constructor(
+    firstExpression: VectorFilterExpression,
+    secondExpression: VectorFilterExpression
+  ) {
+    super();
+    this.firstExpression = firstExpression;
+    this.secondExpression = secondExpression;
+  }
+
+  public get FirstExpression(): VectorFilterExpression {
+    return this.firstExpression;
+  }
+
+  public get SecondExpression(): VectorFilterExpression {
+    return this.secondExpression;
+  }
+
+  public override toString(): string {
+    return `(${this.firstExpression.toString()} OR ${this.secondExpression.toString()})`;
+  }
+}
+
+/**
+ * Represents a NOT expression of a vector filter expression.
+ */
+export class VectorNotExpression extends VectorFilterExpression {
+  private readonly expression: VectorFilterExpression;
+
+  constructor(expression: VectorFilterExpression) {
+    super();
+    this.expression = expression;
+  }
+
+  public get Expression(): VectorFilterExpression {
+    return this.expression;
+  }
+
+  public override toString(): string {
+    return `NOT ${this.expression.toString()}`;
+  }
+}
+
+/**
+ * Represents an equals expression between a field and a value.
+ */
+export class VectorEqualsExpression extends VectorFilterExpression {
+  private readonly field: string;
+  private readonly value: string | number | boolean;
+
+  constructor(field: string, value: string | number | boolean) {
+    super();
+    this.field = field;
+    this.value = value;
+  }
+
+  public get Field(): string {
+    return this.field;
+  }
+
+  public get Value(): string | number | boolean {
+    return this.value;
+  }
+
+  public override toString(): string {
+    return `${this.field}=${this.value.toString()}`;
+  }
+}

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -5,7 +5,7 @@ export abstract class VectorFilterExpression {
   public abstract toString(): string;
 
   /**
-   * Creates an {@link VectorAndExpression} between two vector filter expressions.
+   * Creates an {@link VectorFilterAndExpression} between two vector filter expressions.
    * @param firstExpression The first expression.
    * @param secondExpression The second expression.
    * @returns The AND expression.
@@ -14,11 +14,11 @@ export abstract class VectorFilterExpression {
     firstExpression: VectorFilterExpression,
     secondExpression: VectorFilterExpression
   ): VectorFilterExpression {
-    return new VectorAndExpression(firstExpression, secondExpression);
+    return new VectorFilterAndExpression(firstExpression, secondExpression);
   }
 
   /**
-   * Creates an {@link VectorOrExpression} between a field and a value.
+   * Creates an {@link VectorFilterOrExpression} between a field and a value.
    * @param firstExpression The first expression.
    * @param secondExpression The second expression.
    * @returns The OR expression.
@@ -27,22 +27,22 @@ export abstract class VectorFilterExpression {
     firstExpression: VectorFilterExpression,
     secondExpression: VectorFilterExpression
   ): VectorFilterExpression {
-    return new VectorOrExpression(firstExpression, secondExpression);
+    return new VectorFilterOrExpression(firstExpression, secondExpression);
   }
 
   /**
-   * Creates a {@link VectorNotExpression} expression of a vector filter expression.
+   * Creates a {@link VectorFilterNotExpression} expression of a vector filter expression.
    * @param expression The expression.
    * @returns The NOT expression.
    */
   public static not(
     expression: VectorFilterExpression
   ): VectorFilterExpression {
-    return new VectorNotExpression(expression);
+    return new VectorFilterNotExpression(expression);
   }
 
   /**
-   * Creates a {@link VectorEqualsExpression} between a field and a value.
+   * Creates a {@link VectorFilterEqualsExpression} between a field and a value.
    * @param field The field.
    * @param value The value.
    * @returns The equals expression.
@@ -51,14 +51,14 @@ export abstract class VectorFilterExpression {
     field: string,
     value: string | number | boolean
   ): VectorFilterExpression {
-    return new VectorEqualsExpression(field, value);
+    return new VectorFilterEqualsExpression(field, value);
   }
 }
 
 /**
  * Represents an AND expression between two vector filter expressions.
  */
-export class VectorAndExpression extends VectorFilterExpression {
+export class VectorFilterAndExpression extends VectorFilterExpression {
   private readonly firstExpression: VectorFilterExpression;
   private readonly secondExpression: VectorFilterExpression;
 
@@ -87,7 +87,7 @@ export class VectorAndExpression extends VectorFilterExpression {
 /**
  * Represents an OR expression between two vector filter expressions.
  */
-export class VectorOrExpression extends VectorFilterExpression {
+export class VectorFilterOrExpression extends VectorFilterExpression {
   private readonly firstExpression: VectorFilterExpression;
   private readonly secondExpression: VectorFilterExpression;
 
@@ -116,7 +116,7 @@ export class VectorOrExpression extends VectorFilterExpression {
 /**
  * Represents a NOT expression of a vector filter expression.
  */
-export class VectorNotExpression extends VectorFilterExpression {
+export class VectorFilterNotExpression extends VectorFilterExpression {
   private readonly expression: VectorFilterExpression;
 
   constructor(expression: VectorFilterExpression) {
@@ -136,7 +136,7 @@ export class VectorNotExpression extends VectorFilterExpression {
 /**
  * Represents an equals expression between a field and a value.
  */
-export class VectorEqualsExpression extends VectorFilterExpression {
+export class VectorFilterEqualsExpression extends VectorFilterExpression {
   private readonly field: string;
   private readonly value: string | number | boolean;
 

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -13,7 +13,7 @@ export abstract class VectorFilterExpression {
   public static and(
     firstExpression: VectorFilterExpression,
     secondExpression: VectorFilterExpression
-  ): VectorFilterExpression {
+  ): VectorFilterAndExpression {
     return new VectorFilterAndExpression(firstExpression, secondExpression);
   }
 
@@ -26,7 +26,7 @@ export abstract class VectorFilterExpression {
   public static or(
     firstExpression: VectorFilterExpression,
     secondExpression: VectorFilterExpression
-  ): VectorFilterExpression {
+  ): VectorFilterOrExpression {
     return new VectorFilterOrExpression(firstExpression, secondExpression);
   }
 
@@ -37,7 +37,7 @@ export abstract class VectorFilterExpression {
    */
   public static not(
     expression: VectorFilterExpression
-  ): VectorFilterExpression {
+  ): VectorFilterNotExpression {
     return new VectorFilterNotExpression(expression);
   }
 
@@ -50,7 +50,7 @@ export abstract class VectorFilterExpression {
   public static equals(
     field: string,
     value: string | number | boolean
-  ): VectorFilterExpression {
+  ): VectorFilterEqualsExpression {
     return new VectorFilterEqualsExpression(field, value);
   }
 }

--- a/packages/core/src/messages/vector-index-filters.ts
+++ b/packages/core/src/messages/vector-index-filters.ts
@@ -10,7 +10,7 @@ export abstract class VectorFilterExpression {
    * @returns The AND expression.
    */
   public and(other: VectorFilterExpression): VectorFilterAndExpression {
-    return VectorFilterExpressionFactory.and(this, other);
+    return VectorFilterExpressions.and(this, other);
   }
 
   /**
@@ -19,7 +19,7 @@ export abstract class VectorFilterExpression {
    * @returns The OR expression.
    */
   public or(other: VectorFilterExpression): VectorFilterOrExpression {
-    return VectorFilterExpressionFactory.or(this, other);
+    return VectorFilterExpressions.or(this, other);
   }
 
   /**
@@ -27,14 +27,14 @@ export abstract class VectorFilterExpression {
    * @returns The negated expression.
    */
   public not(): VectorFilterNotExpression {
-    return VectorFilterExpressionFactory.not(this);
+    return VectorFilterExpressions.not(this);
   }
 }
 
 /**
  * Factory for creating vector filter expressions.
  */
-export class VectorFilterExpressionFactory {
+export class VectorFilterExpressions {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {}
 


### PR DESCRIPTION
Adds filter expression data types and implementation for `search` and
`searchAndFetchVectors`. Includes search filters for equality checks and logical expressions. A followup PR will include the exhaustive set of comparison operators.
