### PR TITLE
refactor: mvi filter expression rename

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "^0.105.1",
+        "@gomomento/generated-types": "^0.105.3",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
@@ -1031,9 +1031,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.105.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.105.1.tgz",
-      "integrity": "sha512-H1uctvlPWzl6/mEo1pbxOe3/8Sq+pTfH6sHt0ND6BVoA7xjBndE5/mF1eAQnVRc5Lo1u0PNO6HVNFc+xfT11HQ==",
+      "version": "0.105.3",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.105.3.tgz",
+      "integrity": "sha512-4pJ3AZEom373JBXVs04OTpMVqEG44JAoLWmwmo3ia1mTJuvD36XjsNopKbuCvult8B5Wd7zHvuGCpGzZWO9PmQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -52,7 +52,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.105.1",
+    "@gomomento/generated-types": "0.105.3",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -573,9 +573,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
-      filter: VectorIndexDataClient.buildFilterExpression(
-        options?.filterExpression
-      ),
+      filter: VectorIndexDataClient.buildFilterExpression(options?.filter),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);
 
@@ -650,9 +648,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
-      filter: VectorIndexDataClient.buildFilterExpression(
-        options?.filterExpression
-      ),
+      filter: VectorIndexDataClient.buildFilterExpression(options?.filter),
     });
     VectorIndexDataClient.applyScoreThreshold(request, options);
 

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -573,7 +573,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
-      filter_expression: VectorIndexDataClient.buildFilterExpression(
+      filter: VectorIndexDataClient.buildFilterExpression(
         options?.filterExpression
       ),
     });
@@ -650,7 +650,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       query_vector: new vectorindex._Vector({elements: queryVector}),
       top_k: options?.topK ?? VECTOR_DEFAULT_TOPK,
       metadata_fields: VectorIndexDataClient.buildMetadataRequest(options),
-      filter_expression: VectorIndexDataClient.buildFilterExpression(
+      filter: VectorIndexDataClient.buildFilterExpression(
         options?.filterExpression
       ),
     });

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "^0.105.1",
+        "@gomomento/generated-types-webtext": "^0.105.3",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1034,9 +1034,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.105.1",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.105.1.tgz",
-      "integrity": "sha512-9382PdcY3RT22wq3+DpI9NFV3FwGcEvmBinohVxF6PJGRmYBtvPTQE1v9Mvwa/mG4SRlKSovg3XH1SwrmClV4g==",
+      "version": "0.105.3",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.105.3.tgz",
+      "integrity": "sha512-e5ik8oERplvdtCtjLbfNVa/6ppEzTiO9A6jMRJQTDatMPD7fWOOoJ8QjE7Xt+FxU6GdqE45n+nM3wkrqZz2PNQ==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -56,7 +56,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.105.1",
+    "@gomomento/generated-types-webtext": "0.105.3",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -541,7 +541,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       VectorIndexDataClient.buildMetadataRequest(options)
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
-    request.setFilterExpression(
+    request.setFilter(
       VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
     );
 
@@ -624,7 +624,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       VectorIndexDataClient.buildMetadataRequest(options)
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
-    request.setFilterExpression(
+    request.setFilter(
       VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
     );
 

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -542,7 +542,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
     request.setFilter(
-      VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
+      VectorIndexDataClient.buildFilterExpression(options?.filter)
     );
 
     return await new Promise((resolve, reject) => {
@@ -625,7 +625,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     );
     VectorIndexDataClient.applyScoreThreshold(request, options);
     request.setFilter(
-      VectorIndexDataClient.buildFilterExpression(options?.filterExpression)
+      VectorIndexDataClient.buildFilterExpression(options?.filter)
     );
 
     return await new Promise((resolve, reject) => {

--- a/packages/common-integration-tests/src/vector-data-plane.ts
+++ b/packages/common-integration-tests/src/vector-data-plane.ts
@@ -1080,153 +1080,139 @@ export function runVectorDataPlaneTest(
 
           await sleep(2_000);
 
-          for (const {filterExpression, expectedIds, testCaseName} of [
+          for (const {filter, expectedIds, testCaseName} of [
             {
-              filterExpression: F.equals('str', 'value1'),
+              filter: F.equals('str', 'value1'),
               expectedIds: ['test_item_1'],
               testCaseName: 'string equality',
             },
             {
-              filterExpression: F.not(F.equals('str', 'value1')),
+              filter: F.not(F.equals('str', 'value1')),
               expectedIds: ['test_item_2', 'test_item_3'],
               testCaseName: 'string inequality',
             },
             {
-              filterExpression: F.equals('int', 0),
+              filter: F.equals('int', 0),
               expectedIds: ['test_item_1'],
               testCaseName: 'int equality',
             },
             {
-              filterExpression: F.equals('float', 0.0),
+              filter: F.equals('float', 0.0),
               expectedIds: ['test_item_1'],
               testCaseName: 'float equality',
             },
             {
-              filterExpression: F.equals('bool', true),
+              filter: F.equals('bool', true),
               expectedIds: ['test_item_1', 'test_item_3'],
               testCaseName: 'bool equality',
             },
             {
-              filterExpression: F.not(F.equals('bool', true)),
+              filter: F.not(F.equals('bool', true)),
               expectedIds: ['test_item_2'],
               testCaseName: 'bool inequality',
             },
             {
-              filterExpression: F.equals('bool', true).not(),
+              filter: F.equals('bool', true).not(),
               expectedIds: ['test_item_2'],
               testCaseName: 'bool inequality',
             },
             {
-              filterExpression: F.greaterThan('int', 5),
+              filter: F.greaterThan('int', 5),
               expectedIds: ['test_item_3'],
               testCaseName: 'int greater than',
             },
             {
-              filterExpression: F.greaterThanOrEqual('int', 5),
+              filter: F.greaterThanOrEqual('int', 5),
               expectedIds: ['test_item_2', 'test_item_3'],
               testCaseName: 'int greater than or equal',
             },
             {
-              filterExpression: F.greaterThan('float', 5.0),
+              filter: F.greaterThan('float', 5.0),
               expectedIds: ['test_item_3'],
               testCaseName: 'float greater than',
             },
             {
-              filterExpression: F.greaterThanOrEqual('float', 5.0),
+              filter: F.greaterThanOrEqual('float', 5.0),
               expectedIds: ['test_item_2', 'test_item_3'],
               testCaseName: 'float greater than or equal',
             },
             {
-              filterExpression: F.lessThan('int', 5),
+              filter: F.lessThan('int', 5),
               expectedIds: ['test_item_1'],
               testCaseName: 'int less than',
             },
             {
-              filterExpression: F.lessThanOrEqual('int', 5),
+              filter: F.lessThanOrEqual('int', 5),
               expectedIds: ['test_item_1', 'test_item_2'],
               testCaseName: 'int less than or equal',
             },
             {
-              filterExpression: F.lessThan('float', 5.0),
+              filter: F.lessThan('float', 5.0),
               expectedIds: ['test_item_1'],
               testCaseName: 'float less than',
             },
             {
-              filterExpression: F.lessThanOrEqual('float', 5.0),
+              filter: F.lessThanOrEqual('float', 5.0),
               expectedIds: ['test_item_1', 'test_item_2'],
               testCaseName: 'float less than or equal',
             },
             {
-              filterExpression: F.listContains('tags', 'a'),
+              filter: F.listContains('tags', 'a'),
               expectedIds: ['test_item_1', 'test_item_2', 'test_item_3'],
               testCaseName: 'list contains a',
             },
             {
-              filterExpression: F.listContains('tags', 'b'),
+              filter: F.listContains('tags', 'b'),
               expectedIds: ['test_item_1', 'test_item_2'],
               testCaseName: 'list contains b',
             },
             {
-              filterExpression: F.listContains('tags', 'm'),
+              filter: F.listContains('tags', 'm'),
               expectedIds: [],
               testCaseName: 'list contains m',
             },
             {
-              filterExpression: F.and(
-                F.equals('str', 'value1'),
-                F.equals('int', 0)
-              ),
+              filter: F.and(F.equals('str', 'value1'), F.equals('int', 0)),
               expectedIds: ['test_item_1'],
               testCaseName: 'and',
             },
             {
-              filterExpression: F.equals('str', 'value1').and(
-                F.equals('int', 0)
-              ),
+              filter: F.equals('str', 'value1').and(F.equals('int', 0)),
               expectedIds: ['test_item_1'],
               testCaseName: 'and-chained',
             },
             {
-              filterExpression: F.or(
-                F.equals('str', 'value1'),
-                F.equals('int', 5)
-              ),
+              filter: F.or(F.equals('str', 'value1'), F.equals('int', 5)),
               expectedIds: ['test_item_1', 'test_item_2'],
               testCaseName: 'or',
             },
             {
-              filterExpression: F.equals('str', 'value1').or(
-                F.equals('int', 5)
-              ),
+              filter: F.equals('str', 'value1').or(F.equals('int', 5)),
               expectedIds: ['test_item_1', 'test_item_2'],
               testCaseName: 'or-chained',
             },
             {
-              filterExpression: F.listContains('tags', 'b').and(
-                F.greaterThan('int', 1)
-              ),
+              filter: F.listContains('tags', 'b').and(F.greaterThan('int', 1)),
               expectedIds: ['test_item_2'],
               testCaseName: 'list contains b and int greater than 1',
             },
             {
-              filterExpression: F.listContains('tags', 'b').or(
-                F.greaterThan('int', 1)
-              ),
+              filter: F.listContains('tags', 'b').or(F.greaterThan('int', 1)),
               expectedIds: ['test_item_1', 'test_item_2', 'test_item_3'],
               testCaseName: 'list contains b or int greater than 1',
             },
             {
-              filterExpression: F.idInSet([]),
+              filter: F.idInSet([]),
               expectedIds: [],
               testCaseName: 'id in empty set',
             },
             {
-              filterExpression: F.idInSet(['not there']),
+              filter: F.idInSet(['not there']),
               expectedIds: [],
               testCaseName: 'id not in set not there',
             },
             {
-              filterExpression: F.idInSet(['test_item_1', 'test_item_3']),
+              filter: F.idInSet(['test_item_1', 'test_item_3']),
               expectedIds: ['test_item_1', 'test_item_3'],
               testCaseName: 'id in set test_item_1 test_item_3',
             },
@@ -1234,7 +1220,7 @@ export function runVectorDataPlaneTest(
             const searchResponse = await vectorClient.search(
               indexName,
               [2.0, 2.0],
-              {filterExpression}
+              {filter}
             );
             expectWithMessage(() => {
               expect(searchResponse).toBeInstanceOf(VectorSearch.Success);
@@ -1246,7 +1232,7 @@ export function runVectorDataPlaneTest(
 
             const searchAndFetchVectorsResponse =
               await vectorClient.searchAndFetchVectors(indexName, [2.0, 2.0], {
-                filterExpression,
+                filter,
               });
             expectWithMessage(() => {
               expect(searchAndFetchVectorsResponse).toBeInstanceOf(

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -1,12 +1,12 @@
 import {IVectorIndexControlClient} from '../internal/clients';
 import {
   VectorCountItems,
-  VectorUpsertItemBatch,
   VectorDeleteItemBatch,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '../messages/responses/vector';
 import {VectorIndexItem} from '../messages/vector-index';
 import {VectorFilterExpression} from '../messages/vector-index-filters';
@@ -45,11 +45,12 @@ export interface SearchOptions {
   /**
    * A filter expression to filter results by. Defaults to no filter.
    */
-  filterExpression?: VectorFilterExpression;
+  filter?: VectorFilterExpression;
 }
 
 export interface IVectorIndexClient extends IVectorIndexControlClient {
   countItems(indexName: string): Promise<VectorCountItems.Response>;
+
   upsertItemBatch(
     indexName: string,
     items: Array<VectorIndexItem>


### PR DESCRIPTION
In preparation for a broader usage of filters, which could be a list
of ids or a filter expression, we rename the `filterExpression`
argument to `filter`.