### PR TITLE
chore: export vector filter names from sdks

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -80,10 +80,21 @@ import * as RefreshApiKey from '@gomomento/sdk-core/dist/src/messages/responses/
 import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/responses/generate-disposable-token';
 
 // VectorClient Request Types
-export {ALL_VECTOR_METADATA, VectorSimilarityMetric} from '@gomomento/sdk-core';
+export {
+  ALL_VECTOR_METADATA,
+  VectorSimilarityMetric,
+  VectorFilterExpression,
+  VectorFilterExpressions,
+} from '@gomomento/sdk-core';
 
 // VectorClient Response Types
-export {vector, VectorIndexItem} from '@gomomento/sdk-core';
+export {
+  vector,
+  vectorFilters,
+  VectorIndexMetadata,
+  VectorIndexItem,
+  VectorIndexStoredItem,
+} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
 
 // LeaderboardClient Response Types

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -157,10 +157,21 @@ import {
 } from './config/leaderboard-configuration';
 
 // VectorClient Request Types
-export {ALL_VECTOR_METADATA, VectorSimilarityMetric} from '@gomomento/sdk-core';
+export {
+  ALL_VECTOR_METADATA,
+  VectorSimilarityMetric,
+  VectorFilterExpression,
+  VectorFilterExpressions,
+} from '@gomomento/sdk-core';
 
 // VectorClient Response Types
-export {vector, VectorIndexItem} from '@gomomento/sdk-core';
+export {
+  vector,
+  vectorFilters,
+  VectorIndexMetadata,
+  VectorIndexItem,
+  VectorIndexStoredItem,
+} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/vector';
 
 export {


### PR DESCRIPTION
In the previous release we exported the vector filter names from core
but not from the SDKs. This PR corrects that.
