### PR TITLE
fix: move check connection state inside the if block

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -81,11 +81,11 @@ export function middlewaresInterceptor(
             status: StatusObject,
             next: (status: StatusObject) => void
           ): void {
-            // getConnectivityState(true) will return state of connection and
-            // also try to connect if it's idle, false will just get the status
-            const connectionStatus =
-              grpcClient?.getChannel()?.getConnectivityState(false) ?? null;
             if (status.code === Status.DEADLINE_EXCEEDED) {
+              // getConnectivityState(true) will return state of connection and
+              // also try to connect if it's idle, false will just get the status
+              const connectionStatus =
+                grpcClient?.getChannel()?.getConnectivityState(false) ?? null;
               logger.debug(
                 `Received status: ${status.code} ${
                   status.details


### PR DESCRIPTION
Check connection state inside the if-block to avoid work during successful responses