### PR TITLE
chore: add mvi example snippets for filter expressions

### DIFF
--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -1,18 +1,19 @@
 import {
+  ALL_VECTOR_METADATA,
   CreateVectorIndex,
   CredentialProvider,
   DeleteVectorIndex,
   ListVectorIndexes,
   PreviewVectorIndexClient,
   VectorCountItems,
+  VectorDeleteItemBatch,
+  VectorFilterExpressions as F,
+  VectorGetItemBatch,
+  VectorGetItemMetadataBatch,
   VectorIndexConfigurations,
   VectorSearch,
   VectorSearchAndFetchVectors,
   VectorUpsertItemBatch,
-  VectorDeleteItemBatch,
-  VectorGetItemBatch,
-  VectorGetItemMetadataBatch,
-  ALL_VECTOR_METADATA,
 } from '@gomomento/sdk';
 
 function example_API_InstantiateVectorClient() {
@@ -141,6 +142,66 @@ async function example_API_SearchAndFetchVectors(vectorClient: PreviewVectorInde
   }
 }
 
+function example_API_FilterExpressionOverview() {
+  /*
+   * For convenience, the filter expressions can be imported as follows:
+   * import { VectorFilterExpressions as F } from '@gomomento/sdk';
+   *
+   * To demonstrate the various filter expressions, suppose we have a
+   * dataset of movies with the following schema:
+   * {
+   *  movie_title: string,
+   *  year: int,
+   *  gross_revenue_millions: float,
+   *  in_theaters: bool,
+   *  actors: list<string>,
+   *  directors: list<string>,
+   * }
+   */
+
+  // Is the movie titled "The Matrix"?
+  F.equals('movie_title', 'The Matrix');
+
+  // Is the movie not titled "The Matrix"?
+  F.not(F.equals('movie_title', 'The Matrix'));
+
+  // Was the movie released in 1999?
+  F.equals('year', 1999);
+
+  // Did the movie gross 463.5 million dollars?
+  F.equals('gross_revenue_millions', 463.5);
+
+  // Was the movie in theaters?
+  F.equals('in_theaters', true);
+
+  // Was the movie not in theaters?
+  F.greaterThan('year', 1990);
+
+  // Was the movie released after 2020?
+  F.greaterThanOrEqual('year', 2020);
+
+  // Was the movie released before 2000?
+  F.lessThan('year', 2000);
+
+  // Was the movie released in or before 2000?
+  F.lessThanOrEqual('year', 2000);
+
+  // Was "Keanu Reeves" one of the actors?
+  F.listContains('actors', 'Keanu Reeves');
+
+  // Is the ID one of the following?
+  F.idInSet(['tt0133093', 'tt0234215', 'tt0242653']);
+
+  // Was the movie directed by "Lana Wachowski" and released after 2000?
+  F.and(F.listContains('directors', 'Lana Wachowski'), F.greaterThan('year', 2000));
+
+  // Was the movie directed by "Lana Wachowski" or released after 2000?
+  F.or(F.listContains('directors', 'Lana Wachowski'), F.greaterThan('year', 2000));
+
+  // Was "Keanu Reeves" not one of the actors?
+  F.not(F.listContains('actors', 'Keanu Reeves'));
+}
+
 async function main() {
   const vectorClient = new PreviewVectorIndexClient({
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
@@ -157,6 +218,7 @@ async function main() {
   await example_API_Search(vectorClient);
   await example_API_SearchAndFetchVectors(vectorClient);
   await example_API_GetItemBatch(vectorClient);
+  example_API_FilterExpressionOverview();
   await example_API_GetItemMetadataBatch(vectorClient);
   await example_API_DeleteItemBatch(vectorClient);
   await example_API_DeleteIndex(vectorClient);

--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -174,10 +174,10 @@ function example_API_FilterExpressionOverview() {
   // Was the movie in theaters?
   F.equals('in_theaters', true);
 
-  // Was the movie not in theaters?
+  // Was the movie released after 1990?
   F.greaterThan('year', 1990);
 
-  // Was the movie released after 2020?
+  // Was the movie released in or after 2020?
   F.greaterThanOrEqual('year', 2020);
 
   // Was the movie released before 2000?

--- a/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
+++ b/examples/nodejs/vector-index/doc-example-files/doc-examples-nodejs-apis.ts
@@ -218,8 +218,8 @@ async function main() {
   await example_API_Search(vectorClient);
   await example_API_SearchAndFetchVectors(vectorClient);
   await example_API_GetItemBatch(vectorClient);
-  example_API_FilterExpressionOverview();
   await example_API_GetItemMetadataBatch(vectorClient);
+  example_API_FilterExpressionOverview();
   await example_API_DeleteItemBatch(vectorClient);
   await example_API_DeleteIndex(vectorClient);
 }

--- a/examples/nodejs/vector-index/package-lock.json
+++ b/examples/nodejs/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk": "^1.63.0",
+        "@gomomento/sdk": "^1.63.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -93,12 +93,12 @@
       }
     },
     "node_modules/@gomomento/sdk": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.63.0.tgz",
-      "integrity": "sha512-O9wWQglg9UEm2sAdkN+zMgRaCMl1DLqTTXQ6cS7UltQPgm035AumaH0WYbaooloKyM65doZqqawxhwGrCJ0ydw==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.63.1.tgz",
+      "integrity": "sha512-vkHao2z/VUbXgVpyttzzXdiE8/eDGe7N5KZk05Q+/vY7+XJe27D1EyRA0lon/x/vFhOEltSfJafcIxWBTotV/Q==",
       "dependencies": {
         "@gomomento/generated-types": "0.105.3",
-        "@gomomento/sdk-core": "1.63.0",
+        "@gomomento/sdk-core": "1.63.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.0.tgz",
-      "integrity": "sha512-dZn6Q37cqeJIakVnfy67x4SSbhUvcEy6hnZoweuQT570FrwF0JsWNweTwMKMUbtlVYf73V72566g/vdpMhjjDQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.1.tgz",
+      "integrity": "sha512-fnece/Nfwnqpz41o8mtq38niptCVq0x+ORdh4/eLqfQKIXViI7mjJCp65Y8omc82z9mbGwoljbrY73Yazkdv8g==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -3889,12 +3889,12 @@
       }
     },
     "@gomomento/sdk": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.63.0.tgz",
-      "integrity": "sha512-O9wWQglg9UEm2sAdkN+zMgRaCMl1DLqTTXQ6cS7UltQPgm035AumaH0WYbaooloKyM65doZqqawxhwGrCJ0ydw==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk/-/sdk-1.63.1.tgz",
+      "integrity": "sha512-vkHao2z/VUbXgVpyttzzXdiE8/eDGe7N5KZk05Q+/vY7+XJe27D1EyRA0lon/x/vFhOEltSfJafcIxWBTotV/Q==",
       "requires": {
         "@gomomento/generated-types": "0.105.3",
-        "@gomomento/sdk-core": "1.63.0",
+        "@gomomento/sdk-core": "1.63.1",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
@@ -3902,9 +3902,9 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.0.tgz",
-      "integrity": "sha512-dZn6Q37cqeJIakVnfy67x4SSbhUvcEy6hnZoweuQT570FrwF0JsWNweTwMKMUbtlVYf73V72566g/vdpMhjjDQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.1.tgz",
+      "integrity": "sha512-fnece/Nfwnqpz41o8mtq38niptCVq0x+ORdh4/eLqfQKIXViI7mjJCp65Y8omc82z9mbGwoljbrY73Yazkdv8g==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"

--- a/examples/nodejs/vector-index/package.json
+++ b/examples/nodejs/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk": "^1.63.0",
+    "@gomomento/sdk": "^1.63.1",
     "jsdom": "22.1.0"
   }
 }

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -166,10 +166,10 @@ function example_API_FilterExpressionOverview() {
   // Was the movie in theaters?
   F.equals('in_theaters', true);
 
-  // Was the movie not in theaters?
+  // Was the movie released after 1990?
   F.greaterThan('year', 1990);
 
-  // Was the movie released after 2020?
+  // Was the movie released in or after 2020?
   F.greaterThanOrEqual('year', 2020);
 
   // Was the movie released before 2000?

--- a/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
+++ b/examples/web/vector-index/doc-example-files/doc-examples-web-apis.ts
@@ -1,18 +1,19 @@
 import {
+  ALL_VECTOR_METADATA,
+  Configurations,
   CreateVectorIndex,
+  CredentialProvider,
   DeleteVectorIndex,
   ListVectorIndexes,
   PreviewVectorIndexClient,
   VectorCountItems,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
   VectorDeleteItemBatch,
-  VectorUpsertItemBatch,
+  VectorFilterExpressions as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
-  ALL_VECTOR_METADATA,
-  Configurations,
-  CredentialProvider,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '@gomomento/sdk-web';
 import {initJSDom} from '../utils/jsdom';
 
@@ -133,6 +134,66 @@ async function example_API_SearchAndFetchVectors(vectorClient: PreviewVectorInde
   }
 }
 
+function example_API_FilterExpressionOverview() {
+  /*
+   * For convenience, the filter expressions can be imported as follows:
+   * import { VectorFilterExpressions as F } from '@gomomento/sdk';
+   *
+   * To demonstrate the various filter expressions, suppose we have a
+   * dataset of movies with the following schema:
+   * {
+   *  movie_title: string,
+   *  year: int,
+   *  gross_revenue_millions: float,
+   *  in_theaters: bool,
+   *  actors: list<string>,
+   *  directors: list<string>,
+   * }
+   */
+
+  // Is the movie titled "The Matrix"?
+  F.equals('movie_title', 'The Matrix');
+
+  // Is the movie not titled "The Matrix"?
+  F.not(F.equals('movie_title', 'The Matrix'));
+
+  // Was the movie released in 1999?
+  F.equals('year', 1999);
+
+  // Did the movie gross 463.5 million dollars?
+  F.equals('gross_revenue_millions', 463.5);
+
+  // Was the movie in theaters?
+  F.equals('in_theaters', true);
+
+  // Was the movie not in theaters?
+  F.greaterThan('year', 1990);
+
+  // Was the movie released after 2020?
+  F.greaterThanOrEqual('year', 2020);
+
+  // Was the movie released before 2000?
+  F.lessThan('year', 2000);
+
+  // Was the movie released in or before 2000?
+  F.lessThanOrEqual('year', 2000);
+
+  // Was "Keanu Reeves" one of the actors?
+  F.listContains('actors', 'Keanu Reeves');
+
+  // Is the ID one of the following?
+  F.idInSet(['tt0133093', 'tt0234215', 'tt0242653']);
+
+  // Was the movie directed by "Lana Wachowski" and released after 2000?
+  F.and(F.listContains('directors', 'Lana Wachowski'), F.greaterThan('year', 2000));
+
+  // Was the movie directed by "Lana Wachowski" or released after 2000?
+  F.or(F.listContains('directors', 'Lana Wachowski'), F.greaterThan('year', 2000));
+
+  // Was "Keanu Reeves" not one of the actors?
+  F.not(F.listContains('actors', 'Keanu Reeves'));
+}
+
 async function main() {
   // Because the Momento Web SDK is intended for use in a browser, we use the JSDom library to set up an environment
   // that will allow us to use it in a node.js program.
@@ -149,6 +210,7 @@ async function main() {
   await example_API_SearchAndFetchVectors(vectorClient);
   await example_API_GetItemBatch(vectorClient);
   await example_API_GetItemMetadataBatch(vectorClient);
+  example_API_FilterExpressionOverview();
   await example_API_DeleteItemBatch(vectorClient);
   await example_API_DeleteIndex(vectorClient);
 }

--- a/examples/web/vector-index/package-lock.json
+++ b/examples/web/vector-index/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@gomomento/sdk-web": "^1.63.0",
+        "@gomomento/sdk-web": "^1.63.1",
         "jsdom": "22.1.0"
       },
       "devDependencies": {
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@gomomento/sdk-core": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.0.tgz",
-      "integrity": "sha512-dZn6Q37cqeJIakVnfy67x4SSbhUvcEy6hnZoweuQT570FrwF0JsWNweTwMKMUbtlVYf73V72566g/vdpMhjjDQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.1.tgz",
+      "integrity": "sha512-fnece/Nfwnqpz41o8mtq38niptCVq0x+ORdh4/eLqfQKIXViI7mjJCp65Y8omc82z9mbGwoljbrY73Yazkdv8g==",
       "dependencies": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
@@ -103,12 +103,12 @@
       }
     },
     "node_modules/@gomomento/sdk-web": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.63.0.tgz",
-      "integrity": "sha512-e3VEMemWAWN/xETImuWYhuF7A4TkKk+Men0ZROhc8GpX31YyT2jQLUy7Dwe4phNYl/yGWt3xO2lxIWsvgqE6EQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.63.1.tgz",
+      "integrity": "sha512-slJ4KctKFYSzCWikVuACDQMsstYA1I0Gz/y/SFTrj1gtlCK5gTg74qjX9tpsG2eW2Xy4DMW1jal8HDuhvQ2+hQ==",
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.105.3",
-        "@gomomento/sdk-core": "1.63.0",
+        "@gomomento/sdk-core": "1.63.1",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
@@ -3323,21 +3323,21 @@
       }
     },
     "@gomomento/sdk-core": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.0.tgz",
-      "integrity": "sha512-dZn6Q37cqeJIakVnfy67x4SSbhUvcEy6hnZoweuQT570FrwF0JsWNweTwMKMUbtlVYf73V72566g/vdpMhjjDQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-core/-/sdk-core-1.63.1.tgz",
+      "integrity": "sha512-fnece/Nfwnqpz41o8mtq38niptCVq0x+ORdh4/eLqfQKIXViI7mjJCp65Y8omc82z9mbGwoljbrY73Yazkdv8g==",
       "requires": {
         "buffer": "6.0.3",
         "jwt-decode": "3.1.2"
       }
     },
     "@gomomento/sdk-web": {
-      "version": "1.63.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.63.0.tgz",
-      "integrity": "sha512-e3VEMemWAWN/xETImuWYhuF7A4TkKk+Men0ZROhc8GpX31YyT2jQLUy7Dwe4phNYl/yGWt3xO2lxIWsvgqE6EQ==",
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/sdk-web/-/sdk-web-1.63.1.tgz",
+      "integrity": "sha512-slJ4KctKFYSzCWikVuACDQMsstYA1I0Gz/y/SFTrj1gtlCK5gTg74qjX9tpsG2eW2Xy4DMW1jal8HDuhvQ2+hQ==",
       "requires": {
         "@gomomento/generated-types-webtext": "0.105.3",
-        "@gomomento/sdk-core": "1.63.0",
+        "@gomomento/sdk-core": "1.63.1",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",

--- a/examples/web/vector-index/package.json
+++ b/examples/web/vector-index/package.json
@@ -26,7 +26,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@gomomento/sdk-web": "^1.63.0",
+    "@gomomento/sdk-web": "^1.63.1",
     "jsdom": "22.1.0"
   }
 }


### PR DESCRIPTION
This PR adds an example snippet demonstrating vector index filter expressions. Because each filter expression type is (in my opinion) straigthforward on its own, I add a holistic example showing many expressions over a single metadata schema.