### PR TITLE
refactor: use mvi filter fields for get/delete items

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "^0.105.3",
+        "@gomomento/generated-types": "0.106.0",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.9.0",
         "@types/google-protobuf": "3.15.10",
@@ -1031,9 +1031,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.105.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.105.3.tgz",
-      "integrity": "sha512-4pJ3AZEom373JBXVs04OTpMVqEG44JAoLWmwmo3ia1mTJuvD36XjsNopKbuCvult8B5Wd7zHvuGCpGzZWO9PmQ==",
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.106.0.tgz",
+      "integrity": "sha512-M1cezMBfNxsftF+pX7nu+1Axr79zuHgXckM9P5ovA0B+beIo622PVg5h3jgw3ub1JFasKi80WeOOJMDqkUsz9A==",
       "dependencies": {
         "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -52,7 +52,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.105.3",
+    "@gomomento/generated-types": "0.106.0",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.9.0",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -810,7 +810,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorGetItemMetadataBatch.Response> {
     const request = new vectorindex._GetItemMetadataBatchRequest({
       index_name: indexName,
-      ids: ids,
+      filter: VectorIndexDataClient.idsToFilterExpression(ids),
       metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -728,7 +728,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorGetItemBatch.Response> {
     const request = new vectorindex._GetItemBatchRequest({
       index_name: indexName,
-      ids: ids,
+      filter: VectorIndexDataClient.idsToFilterExpression(ids),
       metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -809,33 +809,18 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
             resolve(
               new VectorGetItemMetadataBatch.Success(
                 resp.item_metadata_response.reduce((acc, itemResponse) => {
-                  switch (itemResponse.response) {
-                    case 'hit':
-                      acc[itemResponse.hit.id] =
-                        VectorIndexDataClient.deserializeMetadata(
-                          itemResponse.hit.metadata,
-                          () =>
-                            resolve(
-                              new VectorGetItemMetadataBatch.Error(
-                                new UnknownError(
-                                  'GetItemMetadataBatch responded with an unknown result'
-                                )
-                              )
+                  acc[itemResponse.id] =
+                    VectorIndexDataClient.deserializeMetadata(
+                      itemResponse.metadata,
+                      () =>
+                        resolve(
+                          new VectorGetItemMetadataBatch.Error(
+                            new UnknownError(
+                              'GetItemMetadataBatch responded with an unknown result'
                             )
-                        );
-                      break;
-                    case 'miss':
-                      break;
-                    default:
-                      resolve(
-                        new VectorGetItemMetadataBatch.Error(
-                          new UnknownError(
-                            'GetItemMetadataBatch responded with an unknown result'
                           )
                         )
-                      );
-                      break;
-                  }
+                    );
                   return acc;
                 }, {} as Record<string, VectorIndexMetadata>)
               )

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -742,36 +742,21 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
             resolve(
               new VectorGetItemBatch.Success(
                 resp.item_response.reduce((acc, itemResponse) => {
-                  switch (itemResponse.response) {
-                    case 'hit':
-                      acc[itemResponse.hit.id] = {
-                        id: itemResponse.hit.id,
-                        vector: itemResponse.hit.vector.elements,
-                        metadata: VectorIndexDataClient.deserializeMetadata(
-                          itemResponse.hit.metadata,
-                          () =>
-                            resolve(
-                              new VectorGetItemBatch.Error(
-                                new UnknownError(
-                                  'GetItemBatch responded with an unknown result'
-                                )
-                              )
+                  acc[itemResponse.id] = {
+                    id: itemResponse.id,
+                    vector: itemResponse.vector.elements,
+                    metadata: VectorIndexDataClient.deserializeMetadata(
+                      itemResponse.metadata,
+                      () =>
+                        resolve(
+                          new VectorGetItemBatch.Error(
+                            new UnknownError(
+                              'GetItemBatch responded with an unknown result'
                             )
-                        ),
-                      };
-                      break;
-                    case 'miss':
-                      break;
-                    default:
-                      resolve(
-                        new VectorGetItemBatch.Error(
-                          new UnknownError(
-                            'GetItemBatch responded with an unknown result'
                           )
                         )
-                      );
-                      break;
-                  }
+                    ),
+                  };
                   return acc;
                 }, {} as Record<string, VectorIndexStoredItem>)
               )

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -534,7 +534,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   }
 
   /**
-   * Convert a list of ids to a filter expression requiring the id to be in the list.
+   * Convert a list of ids to a filter expression that matches the ids.
    * @param ids
    * @private
    */

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -257,7 +257,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorDeleteItemBatch.Response> {
     const request = new vectorindex._DeleteItemBatchRequest({
       index_name: indexName,
-      ids: ids,
+      filter: VectorIndexDataClient.idsToFilterExpression(ids),
     });
     return await new Promise((resolve, reject) => {
       this.client.DeleteItemBatch(
@@ -531,6 +531,21 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     }
 
     throw new InvalidArgumentError('Filter expression is not a valid type.');
+  }
+
+  /**
+   * Convert a list of ids to a filter expression requiring the id to be in the list.
+   * @param ids
+   * @private
+   */
+  private static idsToFilterExpression(
+    ids: string[]
+  ): vectorindex._FilterExpression {
+    return new vectorindex._FilterExpression({
+      id_in_set_expression: new vectorindex._IdInSetExpression({
+        ids: ids,
+      }),
+    });
   }
 
   private static deserializeMetadata(

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "^0.105.3",
+        "@gomomento/generated-types-webtext": "^0.106.0",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1034,9 +1034,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.105.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.105.3.tgz",
-      "integrity": "sha512-e5ik8oERplvdtCtjLbfNVa/6ppEzTiO9A6jMRJQTDatMPD7fWOOoJ8QjE7Xt+FxU6GdqE45n+nM3wkrqZz2PNQ==",
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.106.0.tgz",
+      "integrity": "sha512-b8OqrGuqsRqpbhUS6tnlqZD2dVZO2GRRfp16m7zVOZDbq7pdA8nYwWCT0GxfiqgIcDWPSGzAUoeqEdCp4hs0Sw==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -56,7 +56,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.105.3",
+    "@gomomento/generated-types-webtext": "0.106.0",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -230,7 +230,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorDeleteItemBatch.Response> {
     const request = new vectorindex._DeleteItemBatchRequest();
     request.setIndexName(indexName);
-    request.setIdsList(ids);
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
 
     return await new Promise((resolve, reject) => {
       this.client.deleteItemBatch(
@@ -494,6 +494,22 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
     }
 
     throw new InvalidArgumentError('Filter expression is not a valid type.');
+  }
+
+  /**
+   * Converts a list of ids to a filter expression that matches the ids.
+   * @param ids
+   * @private
+   */
+  private static idsToFilterExpression(
+    ids: string[]
+  ): vectorindex._FilterExpression {
+    const idInSet = new vectorindex._IdInSetExpression();
+    idInSet.setIdsList(ids);
+
+    const expression = new vectorindex._FilterExpression();
+    expression.setIdInSetExpression(idInSet);
+    return expression;
   }
 
   private static deserializeMetadata(

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -797,7 +797,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorGetItemMetadataBatch.Response> {
     const request = new vectorindex._GetItemMetadataBatchRequest();
     request.setIndexName(indexName);
-    request.setIdsList(ids);
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
     request.setMetadataFields(
       VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -801,35 +801,18 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
                 resp
                   .getItemMetadataResponseList()
                   .reduce((acc, itemResponse) => {
-                    let hit: vectorindex._ItemMetadataResponse._Hit | undefined;
-                    switch (itemResponse.getResponseCase()) {
-                      case vectorindex._ItemMetadataResponse.ResponseCase.HIT:
-                        hit = itemResponse.getHit();
-                        acc[hit?.getId() ?? ''] =
-                          VectorIndexDataClient.deserializeMetadata(
-                            hit?.getMetadataList() ?? [],
-                            () =>
-                              resolve(
-                                new VectorGetItemMetadataBatch.Error(
-                                  new UnknownError(
-                                    'GetItemMetadataBatch responded with an unknown result'
-                                  )
-                                )
+                    acc[itemResponse.getId()] =
+                      VectorIndexDataClient.deserializeMetadata(
+                        itemResponse.getMetadataList(),
+                        () =>
+                          resolve(
+                            new VectorGetItemMetadataBatch.Error(
+                              new UnknownError(
+                                'GetItemMetadataBatch responded with an unknown result'
                               )
-                          );
-                        break;
-                      case vectorindex._ItemResponse.ResponseCase.MISS:
-                        break;
-                      default:
-                        resolve(
-                          new VectorGetItemMetadataBatch.Error(
-                            new UnknownError(
-                              'GetItemMetadataBatch responded with an unknown result'
                             )
                           )
-                        );
-                        break;
-                    }
+                      );
                     return acc;
                   }, {} as Record<string, VectorIndexMetadata>)
               )

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -708,7 +708,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
   ): Promise<VectorGetItemBatch.Response> {
     const request = new vectorindex._GetItemBatchRequest();
     request.setIndexName(indexName);
-    request.setIdsList(ids);
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
     request.setMetadataFields(
       VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -727,38 +727,21 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
             resolve(
               new VectorGetItemBatch.Success(
                 resp.getItemResponseList().reduce((acc, itemResponse) => {
-                  let hit: vectorindex._ItemResponse._Hit | undefined;
-                  switch (itemResponse.getResponseCase()) {
-                    case vectorindex._ItemResponse.ResponseCase.HIT:
-                      hit = itemResponse.getHit();
-                      acc[hit?.getId() ?? ''] = {
-                        id: hit?.getId() ?? '',
-                        vector: hit?.getVector()?.getElementsList() ?? [],
-                        metadata: VectorIndexDataClient.deserializeMetadata(
-                          hit?.getMetadataList() ?? [],
-                          () =>
-                            resolve(
-                              new VectorGetItemBatch.Error(
-                                new UnknownError(
-                                  'GetItemBatch responded with an unknown result'
-                                )
-                              )
+                  acc[itemResponse.getId()] = {
+                    id: itemResponse.getId(),
+                    vector: itemResponse.getVector()?.getElementsList() ?? [],
+                    metadata: VectorIndexDataClient.deserializeMetadata(
+                      itemResponse.getMetadataList(),
+                      () =>
+                        resolve(
+                          new VectorGetItemBatch.Error(
+                            new UnknownError(
+                              'GetItemBatch responded with an unknown result'
                             )
-                        ),
-                      };
-                      break;
-                    case vectorindex._ItemResponse.ResponseCase.MISS:
-                      break;
-                    default:
-                      resolve(
-                        new VectorGetItemBatch.Error(
-                          new UnknownError(
-                            'GetItemBatch responded with an unknown result'
                           )
                         )
-                      );
-                      break;
-                  }
+                    ),
+                  };
                   return acc;
                 }, {} as Record<string, VectorIndexStoredItem>)
               )


### PR DESCRIPTION
We are in the process of migrating MVI delete item batch, get item batch, and get item metadata batch to use a filter expression to select items to delete (get) as opposed to a list of id's. For convenience, we will still allow users to select items with a list of id's from the top level methods. This PR migrates the backend.

As part of the migration we are also moving away from the hit/miss pattern for get item batch and get item metadata batch response messages. While the hit/miss pattern made sense for when we only selected items by id, it no longer makes sense for when a user supplies a general filter expression. What's more, previously when we read the hit/miss responses, we built an object containing only the hits, so the distinction wasn't as important.

In future PRs we will add overloads to also use a filter expression from delete and get item methods.