### PR TITLE
chore: DRY up nodejs grpc channel configuration

### DIFF
--- a/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/leaderboard-configurations.ts
@@ -51,6 +51,9 @@ export class Laptop extends LeaderboardClientConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      keepAlivePermitWithoutCalls: 1,
+      keepAliveTimeMs: 5000,
+      keepAliveTimeoutMs: 1000,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,

--- a/packages/client-sdk-nodejs/src/config/vector-index-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/vector-index-configurations.ts
@@ -49,6 +49,9 @@ export class Laptop extends VectorIndexClientConfiguration {
     const grpcConfig: GrpcConfiguration = new StaticGrpcConfiguration({
       deadlineMillis: deadlineMillis,
       maxSessionMemoryMb: defaultMaxSessionMemoryMb,
+      keepAlivePermitWithoutCalls: 1,
+      keepAliveTimeMs: 5000,
+      keepAliveTimeoutMs: 1000,
     });
     const transportStrategy: TransportStrategy = new StaticTransportStrategy({
       grpcConfiguration: grpcConfig,

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -97,6 +97,7 @@ import grpcCache = cache.cache_client;
 import _Unbounded = cache_client._Unbounded;
 import ECacheResult = cache_client.ECacheResult;
 import _ItemGetTypeResponse = cache_client._ItemGetTypeResponse;
+import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 
 export const CONNECTION_ID_KEY = Symbol('connectionID');
 
@@ -136,32 +137,7 @@ export class CacheDataClient implements IDataClient {
       `Creating cache client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
     );
 
-    const channelOptions: Record<string, number> = {
-      // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
-      // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
-      'grpc-node.max_session_memory': grpcConfig.getMaxSessionMemoryMb(),
-      // This flag controls whether channels use a shared global pool of subchannels, or whether
-      // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
-      // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
-      // than one grpc client.
-      'grpc.use_local_subchannel_pool': 1,
-    };
-
-    if (grpcConfig.getKeepAlivePermitWithoutCalls() !== undefined) {
-      channelOptions['grpc.keepalive_permit_without_calls'] = <number>(
-        grpcConfig.getKeepAlivePermitWithoutCalls()
-      );
-    }
-    if (grpcConfig.getKeepAliveTimeMS() !== undefined) {
-      channelOptions['grpc.keepalive_time_ms'] = <number>(
-        grpcConfig.getKeepAliveTimeMS()
-      );
-    }
-    if (grpcConfig.getKeepAliveTimeoutMS() !== undefined) {
-      channelOptions['grpc.keepalive_timeout_ms'] = <number>(
-        grpcConfig.getKeepAliveTimeoutMS()
-      );
-    }
+    const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
 
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () => {

--- a/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
@@ -1,0 +1,35 @@
+import {GrpcConfiguration} from '../../config/transport';
+import {ChannelOptions} from '@grpc/grpc-js';
+
+export function grpcChannelOptionsFromGrpcConfig(
+  grpcConfig: GrpcConfiguration
+): ChannelOptions {
+  const channelOptions: Record<string, number> = {
+    // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
+    // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
+    'grpc-node.max_session_memory': grpcConfig.getMaxSessionMemoryMb(),
+    // This flag controls whether channels use a shared global pool of subchannels, or whether
+    // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
+    // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
+    // than one grpc client.
+    'grpc.use_local_subchannel_pool': 1,
+  };
+
+  if (grpcConfig.getKeepAlivePermitWithoutCalls() !== undefined) {
+    channelOptions['grpc.keepalive_permit_without_calls'] = <number>(
+      grpcConfig.getKeepAlivePermitWithoutCalls()
+    );
+  }
+  if (grpcConfig.getKeepAliveTimeMS() !== undefined) {
+    channelOptions['grpc.keepalive_time_ms'] = <number>(
+      grpcConfig.getKeepAliveTimeMS()
+    );
+  }
+  if (grpcConfig.getKeepAliveTimeoutMS() !== undefined) {
+    channelOptions['grpc.keepalive_timeout_ms'] = <number>(
+      grpcConfig.getKeepAliveTimeoutMS()
+    );
+  }
+
+  return channelOptions;
+}

--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -32,6 +32,7 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {UnknownError} from '@gomomento/sdk-core/dist/src/errors';
 import {VectorIndexClientPropsWithConfig} from './vector-index-client-props-with-config';
+import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 
 export class VectorIndexDataClient implements IVectorIndexDataClient {
   private readonly configuration: VectorIndexConfiguration;
@@ -59,25 +60,12 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
       `Creating vector index client using endpoint: '${this.credentialProvider.getVectorEndpoint()}'`
     );
 
+    const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
+
     this.client = new vectorindex.VectorIndexClient(
       this.credentialProvider.getVectorEndpoint(),
       ChannelCredentials.createSsl(),
-      {
-        // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
-        // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
-        'grpc-node.max_session_memory': grpcConfig.getMaxSessionMemoryMb(),
-        // This flag controls whether channels use a shared global pool of subchannels, or whether
-        // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
-        // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
-        // than one grpc client.
-        'grpc.use_local_subchannel_pool': 1,
-        // The following settings are based on https://github.com/grpc/grpc/blob/e35db43c07f27cc13ec061520da1ed185f36abd4/doc/keepalive.md ,
-        // and guidance provided on various github issues for grpc-node. They will enable keepalive pings when a
-        // client connection is idle.
-        'grpc.keepalive_permit_without_calls': 1,
-        'grpc.keepalive_timeout_ms': 1000,
-        'grpc.keepalive_time_ms': 5000,
-      }
+      channelOptions
     );
 
     this.interceptors = this.initializeInterceptors(


### PR DESCRIPTION
Prior to this commit we had several different places in the code where
we were manually constructing an instance of grpc-js's `ChannelOptions`.

This commit creates a helper function to consolidate the construction
in a single spot; we accept an instance of our `GrpcConfiguraion` as input.
As we add support for more of the different grpc settings over time, this
will become increasingly more important.
