### PR TITLE
fix: add support for item sizes up to 5 mb.

### DIFF
--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -18,19 +18,49 @@ export interface GrpcConfigurationProps {
 
   /**
    * Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
    */
   keepAlivePermitWithoutCalls?: number;
 
   /**
    * After waiting for a duration of this time, if the keepalive ping sender does not receive the ping ack,
    * it will close the transport.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
    */
   keepAliveTimeoutMs?: number;
 
   /**
    * After a duration of this time the client/server pings its peer to see if the transport is still alive.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
    */
   keepAliveTimeMs?: number;
+
+  /**
+   * The maximum message length the client can send to the server.  If the client attempts to send a message larger than
+   * this size, it will result in a RESOURCE_EXHAUSTED error.
+   */
+  maxSendMessageLength?: number;
+
+  /**
+   * The maximum message length the client can receive from the server.  If the server attempts to send a message larger than
+   * this size, it will result in a RESOURCE_EXHAUSTED error.
+   */
+  maxReceiveMessageLength?: number;
 }
 
 /**
@@ -46,16 +76,34 @@ export interface GrpcConfiguration {
   getDeadlineMillis(): number;
 
   /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
    * @returns {number} 0 or 1, if it is permissible to send a keepalive/ping without any outstanding calls.
    */
   getKeepAlivePermitWithoutCalls(): number | undefined;
 
   /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
    * @returns {number} the time to wait for a response from a keepalive or ping.
    */
   getKeepAliveTimeoutMS(): number | undefined;
 
   /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
    * @returns {number} the interval at which to send the keepalive or ping.
    */
   getKeepAliveTimeMS(): number | undefined;
@@ -79,6 +127,18 @@ export interface GrpcConfiguration {
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified maximum memory
    */
   withMaxSessionMemoryMb(maxSessionMemoryMb: number): GrpcConfiguration;
+
+  /**
+   * The maximum message length the client can send to the server.  If the client attempts to send a message larger than
+   * this size, it will result in a RESOURCE_EXHAUSTED error.
+   */
+  getMaxSendMessageLength(): number | undefined;
+
+  /**
+   * The maximum message length the client can receive from the server.  If the server attempts to send a message larger than
+   * this size, it will result in a RESOURCE_EXHAUSTED error.
+   */
+  getMaxReceiveMessageLength(): number | undefined;
 
   /**
    * @returns {number} the number of internal clients a cache client will create to communicate with Momento. More of

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -82,6 +82,8 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly keepAlivePermitWithoutCalls?: number;
   private readonly keepAliveTimeoutMs?: number;
   private readonly keepAliveTimeMs?: number;
+  private readonly maxSendMessageLength?: number;
+  private readonly maxReceiveMessageLength?: number;
 
   constructor(props: GrpcConfigurationProps) {
     this.deadlineMillis = props.deadlineMillis;
@@ -95,6 +97,8 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     this.keepAliveTimeMs = props.keepAliveTimeMs;
     this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;
     this.keepAlivePermitWithoutCalls = props.keepAlivePermitWithoutCalls;
+    this.maxSendMessageLength = props.maxSendMessageLength;
+    this.maxReceiveMessageLength = props.maxReceiveMessageLength;
   }
 
   getDeadlineMillis(): number {
@@ -131,6 +135,14 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
       maxSessionMemoryMb: maxSessionMemoryMb,
       numClients: this.numClients,
     });
+  }
+
+  getMaxSendMessageLength(): number | undefined {
+    return this.maxSendMessageLength;
+  }
+
+  getMaxReceiveMessageLength(): number | undefined {
+    return this.maxReceiveMessageLength;
   }
 
   getNumClients(): number {

--- a/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
@@ -1,35 +1,39 @@
 import {GrpcConfiguration} from '../../config/transport';
 import {ChannelOptions} from '@grpc/grpc-js';
 
+// The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order to
+// support cases where users have requested a limit increase up to our maximum item size of 5mb.
+const DEFAULT_MAX_REQUEST_SIZE = 5_243_000;
+
 export function grpcChannelOptionsFromGrpcConfig(
   grpcConfig: GrpcConfiguration
 ): ChannelOptions {
-  const channelOptions: Record<string, number> = {
+  return {
     // default value for max session memory is 10mb.  Under high load, it is easy to exceed this,
     // after which point all requests will fail with a client-side RESOURCE_EXHAUSTED exception.
     'grpc-node.max_session_memory': grpcConfig.getMaxSessionMemoryMb(),
+
     // This flag controls whether channels use a shared global pool of subchannels, or whether
     // each channel gets its own subchannel pool.  The default value is 0, meaning a single global
     // pool.  Setting it to 1 provides significant performance improvements when we instantiate more
     // than one grpc client.
     'grpc.use_local_subchannel_pool': 1,
+
+    // The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order to
+    // support cases where users have requested a limit increase up to our maximum item size of 5mb.
+    'grpc.max_send_message_length':
+      grpcConfig.getMaxSendMessageLength() ?? DEFAULT_MAX_REQUEST_SIZE,
+    'grpc.max_receive_message_length':
+      grpcConfig.getMaxReceiveMessageLength() ?? DEFAULT_MAX_REQUEST_SIZE,
+
+    // NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+    // when the connection is idle. However, they are very problematic for lambda environments where the lambda
+    // runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+    // from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+    // Therefore, keep-alives should be disabled in lambda and similar environments.
+    'grpc.keepalive_permit_without_calls':
+      grpcConfig.getKeepAlivePermitWithoutCalls(),
+    'grpc.keepalive_time_ms': grpcConfig.getKeepAliveTimeMS(),
+    'grpc.keepalive_timeout_ms': grpcConfig.getKeepAliveTimeoutMS(),
   };
-
-  if (grpcConfig.getKeepAlivePermitWithoutCalls() !== undefined) {
-    channelOptions['grpc.keepalive_permit_without_calls'] = <number>(
-      grpcConfig.getKeepAlivePermitWithoutCalls()
-    );
-  }
-  if (grpcConfig.getKeepAliveTimeMS() !== undefined) {
-    channelOptions['grpc.keepalive_time_ms'] = <number>(
-      grpcConfig.getKeepAliveTimeMS()
-    );
-  }
-  if (grpcConfig.getKeepAliveTimeoutMS() !== undefined) {
-    channelOptions['grpc.keepalive_timeout_ms'] = <number>(
-      grpcConfig.getKeepAliveTimeoutMS()
-    );
-  }
-
-  return channelOptions;
 }


### PR DESCRIPTION
Prior to this commit, we were not explicitly setting the max size for grpc requests and responses. The default was 4mb, which meant that if a user had requested a limit increase to support 5mb item sizes, the SDK was not actually capable of serving those items back to them.

This commit adds configuration options to support setting different values for the max request and response size, and sets the defaults to 5mb to support those customers.