### PR TITLE
refactor: rename mvi parameter ids to filter in get/delete

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -226,7 +226,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async deleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -236,16 +236,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorDeleteItemBatch.Error(err)
       );
     }
-    return await this.sendDeleteItemBatch(indexName, ids);
+    return await this.sendDeleteItemBatch(indexName, filter);
   }
 
   private async sendDeleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     const request = new vectorindex._DeleteItemBatchRequest({
       index_name: indexName,
-      filter: VectorIndexDataClient.idsToFilterExpression(ids),
+      filter: VectorIndexDataClient.idsToFilterExpression(filter),
     });
     return await new Promise((resolve, reject) => {
       this.client.DeleteItemBatch(
@@ -697,7 +697,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async getItemBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -707,16 +707,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorGetItemBatch.Error(err)
       );
     }
-    return await this.sendGetItemBatch(indexName, ids);
+    return await this.sendGetItemBatch(indexName, filter);
   }
 
   private async sendGetItemBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemBatch.Response> {
     const request = new vectorindex._GetItemBatchRequest({
       index_name: indexName,
-      filter: VectorIndexDataClient.idsToFilterExpression(ids),
+      filter: VectorIndexDataClient.idsToFilterExpression(filter),
       metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),
@@ -764,7 +764,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async getItemMetadataBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemMetadataBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -774,16 +774,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorGetItemMetadataBatch.Error(err)
       );
     }
-    return await this.sendGetItemMetadataBatch(indexName, ids);
+    return await this.sendGetItemMetadataBatch(indexName, filter);
   }
 
   private async sendGetItemMetadataBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemMetadataBatch.Response> {
     const request = new vectorindex._GetItemMetadataBatchRequest({
       index_name: indexName,
-      filter: VectorIndexDataClient.idsToFilterExpression(ids),
+      filter: VectorIndexDataClient.idsToFilterExpression(filter),
       metadata_fields: VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
       }),

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -211,7 +211,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async deleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -221,16 +221,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorDeleteItemBatch.Error(err)
       );
     }
-    return await this.sendDeleteItemBatch(indexName, ids);
+    return await this.sendDeleteItemBatch(indexName, filter);
   }
 
   private async sendDeleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     const request = new vectorindex._DeleteItemBatchRequest();
     request.setIndexName(indexName);
-    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(filter));
 
     return await new Promise((resolve, reject) => {
       this.client.deleteItemBatch(
@@ -689,7 +689,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async getItemBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -699,16 +699,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorGetItemBatch.Error(err)
       );
     }
-    return await this.sendGetItemBatch(indexName, ids);
+    return await this.sendGetItemBatch(indexName, filter);
   }
 
   private async sendGetItemBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemBatch.Response> {
     const request = new vectorindex._GetItemBatchRequest();
     request.setIndexName(indexName);
-    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(filter));
     request.setMetadataFields(
       VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,
@@ -761,7 +761,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async getItemMetadataBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemMetadataBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -771,16 +771,16 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
         err => new VectorGetItemMetadataBatch.Error(err)
       );
     }
-    return await this.sendGetItemMetadataBatch(indexName, ids);
+    return await this.sendGetItemMetadataBatch(indexName, filter);
   }
 
   private async sendGetItemMetadataBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemMetadataBatch.Response> {
     const request = new vectorindex._GetItemMetadataBatchRequest();
     request.setIndexName(indexName);
-    request.setFilter(VectorIndexDataClient.idsToFilterExpression(ids));
+    request.setFilter(VectorIndexDataClient.idsToFilterExpression(filter));
     request.setMetadataFields(
       VectorIndexDataClient.buildMetadataRequest({
         metadataFields: ALL_VECTOR_METADATA,

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -70,17 +70,17 @@ export interface IVectorIndexClient extends IVectorIndexControlClient {
 
   deleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
 
   getItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorGetItemBatch.Response>;
 
   getItemMetadataBatch(
     indexName: string,
-    ids: Array<string>,
+    filter: Array<string>,
     metadataFields?: Array<string>
   ): Promise<VectorGetItemMetadataBatch.Response>;
 }

--- a/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
+++ b/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
@@ -3,12 +3,12 @@ import {
   DeleteVectorIndex,
   ListVectorIndexes,
   VectorCountItems,
-  VectorUpsertItemBatch,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
   VectorDeleteItemBatch,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '../../..';
 import {
   IVectorIndexClient,
@@ -188,47 +188,47 @@ export abstract class AbstractVectorIndexClient
    * Deletes any and all items with the given IDs from the index.
    *
    * @param {string} indexName - Name of the index to delete the items from.
-   * @param {Array<string>} ids - The IDs of the items to be deleted from the index.
+   * @param {Array<string>} filter - The IDs of the items to be deleted from the index.
    * @returns {Promise<VectorDeleteItemBatch.Response>}
    * {@link VectorDeleteItemBatch.Success} on success.
    * {@link VectorDeleteItemBatch.Error} on error.
    */
   public async deleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
-    return await this.dataClient.deleteItemBatch(indexName, ids);
+    return await this.dataClient.deleteItemBatch(indexName, filter);
   }
 
   /**
    * Gets a batch of items from a vector index by ID.
    *
    * @param indexName - Name of the index to get the items from.
-   * @param ids - The IDs of the items to be retrieved from the index.
+   * @param filter - The IDs of the items to be retrieved from the index.
    * @returns {Promise<VectorGetItemBatch.Response>}
    * {@link VectorGetItemBatch.Success} on success, with the found items.
    * {@link VectorGetItemBatch.Error} on error.
    */
   public async getItemBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemBatch.Response> {
-    return await this.dataClient.getItemBatch(indexName, ids);
+    return await this.dataClient.getItemBatch(indexName, filter);
   }
 
   /**
    * Gets metadata for a batch of items from a vector index by ID.
    *
    * @param indexName - Name of the index to get the items from.
-   * @param ids - The IDs of the items to be retrieved from the index.
+   * @param filter - The IDs of the items to be retrieved from the index.
    * @returns {Promise<VectorGetItemMetadataBatch.Response>}
    * {@link VectorGetItemMetadataBatch.Success} on success, with the found item metadata.
    * {@link VectorGetItemMetadataBatch.Error} on error.
    */
   public async getItemMetadataBatch(
     indexName: string,
-    ids: string[]
+    filter: string[]
   ): Promise<VectorGetItemMetadataBatch.Response> {
-    return await this.dataClient.getItemMetadataBatch(indexName, ids);
+    return await this.dataClient.getItemMetadataBatch(indexName, filter);
   }
 }

--- a/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
+++ b/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
@@ -83,7 +83,7 @@ export abstract class AbstractVectorIndexClient
   }
 
   /**
-   * Deletes a vector index and all the vectors stored in it.
+   * Deletes a vector index and all the items stored in it.
    *
    * @param {string} indexName - The name of the vector index to delete.
    * @returns {Promise<DeleteVectorIndex.Response>} -

--- a/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
+++ b/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
@@ -1,41 +1,47 @@
 import {
   VectorCountItems,
-  VectorUpsertItemBatch,
   VectorDeleteItemBatch,
-  VectorSearch,
-  VectorSearchAndFetchVectors,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
+  VectorSearch,
+  VectorSearchAndFetchVectors,
+  VectorUpsertItemBatch,
 } from '../../../messages/responses/vector';
 import {VectorIndexItem} from '../../../messages/vector-index';
 import {SearchOptions} from '../../../clients/IVectorIndexClient';
 
 export interface IVectorIndexDataClient {
   countItems(indexName: string): Promise<VectorCountItems.Response>;
+
   upsertItemBatch(
     indexName: string,
     items: Array<VectorIndexItem>
   ): Promise<VectorUpsertItemBatch.Response>;
+
   search(
     indexName: string,
     queryVector: Array<number>,
     options?: SearchOptions
   ): Promise<VectorSearch.Response>;
+
   searchAndFetchVectors(
     indexName: string,
     queryVector: Array<number>,
     options?: SearchOptions
   ): Promise<VectorSearchAndFetchVectors.Response>;
+
   deleteItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
+
   getItemBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorGetItemBatch.Response>;
+
   getItemMetadataBatch(
     indexName: string,
-    ids: Array<string>
+    filter: Array<string>
   ): Promise<VectorGetItemMetadataBatch.Response>;
 }


### PR DESCRIPTION
To standardize how we select items in get item batch, get item metadata batch, and delete item batch, we use the term filter in methods, whether selecting by ids or filter expression.