### PR TITLE
chore: bump gRPC versions

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.106.0",
+        "@gomomento/generated-types": "0.106.1",
         "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.9.0",
+        "@grpc/grpc-js": "1.10.0",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
@@ -1031,11 +1031,11 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.106.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.106.0.tgz",
-      "integrity": "sha512-M1cezMBfNxsftF+pX7nu+1Axr79zuHgXckM9P5ovA0B+beIo622PVg5h3jgw3ub1JFasKi80WeOOJMDqkUsz9A==",
+      "version": "0.106.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.106.1.tgz",
+      "integrity": "sha512-ZU4UwavbZArUoF/5nlRnKgriSZ1CJTNcYa/LhIlOcUuCGIBKi4W1+/rd/q/M5g9SspMdTawywRgncGYqwjrUpw==",
       "dependencies": {
-        "@grpc/grpc-js": "1.9.0",
+        "@grpc/grpc-js": "1.10.0",
         "google-protobuf": "3.21.2",
         "grpc-tools": "^1.12.4",
         "protoc-gen-ts": "^0.8.6"
@@ -1046,11 +1046,11 @@
       "link": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
+      "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -6221,9 +6221,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -52,9 +52,9 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.106.0",
+    "@gomomento/generated-types": "0.106.1",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.9.0",
+    "@grpc/grpc-js": "1.10.0",
     "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"


### PR DESCRIPTION
gRPC 1.9.14 release had a couple fixes relevant to issues we were seeing with reconnections:

- https://github.com/grpc/grpc-node/issues/2620
- https://github.com/grpc/grpc-node/pull/2643
- https://github.com/grpc/grpc-node/pull/2644