### PR TITLE
feat: add mvi delete by filter overload

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-data-client.ts
@@ -10,6 +10,7 @@ import {
   VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
+  VectorFilterExpression,
   vectorFilters as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
@@ -226,7 +227,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async deleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -241,11 +242,15 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   private async sendDeleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
+    const filterProtobuf =
+      filter instanceof VectorFilterExpression
+        ? VectorIndexDataClient.buildFilterExpression(filter)
+        : VectorIndexDataClient.idsToFilterExpression(filter);
     const request = new vectorindex._DeleteItemBatchRequest({
       index_name: indexName,
-      filter: VectorIndexDataClient.idsToFilterExpression(filter),
+      filter: filterProtobuf,
     });
     return await new Promise((resolve, reject) => {
       this.client.DeleteItemBatch(

--- a/packages/client-sdk-web/src/internal/vector-index-data-client.ts
+++ b/packages/client-sdk-web/src/internal/vector-index-data-client.ts
@@ -10,6 +10,7 @@ import {
   VECTOR_DEFAULT_TOPK,
   VectorCountItems,
   VectorDeleteItemBatch,
+  VectorFilterExpression,
   vectorFilters as F,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
@@ -211,7 +212,7 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   public async deleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     try {
       validateIndexName(indexName);
@@ -226,11 +227,15 @@ export class VectorIndexDataClient implements IVectorIndexDataClient {
 
   private async sendDeleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     const request = new vectorindex._DeleteItemBatchRequest();
     request.setIndexName(indexName);
-    request.setFilter(VectorIndexDataClient.idsToFilterExpression(filter));
+    const filterProtobuf =
+      filter instanceof VectorFilterExpression
+        ? VectorIndexDataClient.buildFilterExpression(filter)
+        : VectorIndexDataClient.idsToFilterExpression(filter);
+    request.setFilter(filterProtobuf);
 
     return await new Promise((resolve, reject) => {
       this.client.deleteItemBatch(

--- a/packages/core/src/clients/IVectorIndexClient.ts
+++ b/packages/core/src/clients/IVectorIndexClient.ts
@@ -70,7 +70,7 @@ export interface IVectorIndexClient extends IVectorIndexControlClient {
 
   deleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
 
   getItemBatch(

--- a/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
+++ b/packages/core/src/internal/clients/vector/AbstractVectorIndexClient.ts
@@ -4,6 +4,7 @@ import {
   ListVectorIndexes,
   VectorCountItems,
   VectorDeleteItemBatch,
+  VectorFilterExpression,
   VectorGetItemBatch,
   VectorGetItemMetadataBatch,
   VectorSearch,
@@ -188,14 +189,15 @@ export abstract class AbstractVectorIndexClient
    * Deletes any and all items with the given IDs from the index.
    *
    * @param {string} indexName - Name of the index to delete the items from.
-   * @param {Array<string>} filter - The IDs of the items to be deleted from the index.
+   * @param {VectorFilterExpression | Array<string>} filter - A filter expression to match the items to be deleted
+   * or an array of item IDs to be deleted.
    * @returns {Promise<VectorDeleteItemBatch.Response>}
    * {@link VectorDeleteItemBatch.Success} on success.
    * {@link VectorDeleteItemBatch.Error} on error.
    */
   public async deleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response> {
     return await this.dataClient.deleteItemBatch(indexName, filter);
   }

--- a/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
+++ b/packages/core/src/internal/clients/vector/IVectorIndexDataClient.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../messages/responses/vector';
 import {VectorIndexItem} from '../../../messages/vector-index';
 import {SearchOptions} from '../../../clients/IVectorIndexClient';
+import {VectorFilterExpression} from '../../../messages/vector-index-filters';
 
 export interface IVectorIndexDataClient {
   countItems(indexName: string): Promise<VectorCountItems.Response>;
@@ -32,7 +33,7 @@ export interface IVectorIndexDataClient {
 
   deleteItemBatch(
     indexName: string,
-    filter: Array<string>
+    filter: VectorFilterExpression | Array<string>
   ): Promise<VectorDeleteItemBatch.Response>;
 
   getItemBatch(


### PR DESCRIPTION
Adds an overload MVI `deleteItemBatch` to allow users to delete items by not just a list of ids, but also a more general filter expression. We maintain the option of providing a list of ids for convenience. This PR adds integration tests and updates the documentation.