### PR TITLE
chore: increase jest test timeout to reduce flaky tests

### DIFF
--- a/packages/client-sdk-nodejs/jest.config.ts
+++ b/packages/client-sdk-nodejs/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 120000,
+  testTimeout: 240000,
   reporters: ["jest-ci-spec-reporter"]
 };
 

--- a/packages/client-sdk-web/jest.config.ts
+++ b/packages/client-sdk-web/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 120000,
+  testTimeout: 240000,
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451


### PR DESCRIPTION
Saw a lot of jest test timeouts while collecting test failure data over the last couple of weeks, particularly in the web SDK. Doubled the timeout for both just in case 