### PR TITLE
chore: increase jest and test cache client timeouts

### DIFF
--- a/packages/client-sdk-nodejs/jest.config.ts
+++ b/packages/client-sdk-nodejs/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 240000,
+  testTimeout: 480000,
   reporters: ["jest-ci-spec-reporter"]
 };
 

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -76,7 +76,7 @@ function sessionCredsProvider(): CredentialProvider {
 export function integrationTestCacheClientProps(): CacheClientPropsWithConfig {
   return {
     configuration:
-      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
+      Configurations.Laptop.latest().withClientTimeoutMillis(90000),
     credentialProvider: credsProvider(),
     defaultTtlSeconds: 1111,
   };
@@ -95,7 +95,7 @@ function momentoClientForTestingWithThrowOnErrors(): CacheClient {
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
     configuration:
-      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
+      Configurations.Laptop.latest().withClientTimeoutMillis(90000),
     credentialProvider: sessionCredsProvider(),
     defaultTtlSeconds: 1111,
   });

--- a/packages/client-sdk-web/jest.config.ts
+++ b/packages/client-sdk-web/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testTimeout: 240000,
+  testTimeout: 480000,
   setupFiles: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -68,7 +68,7 @@ function sessionCredsProvider(): CredentialProvider {
 function integrationTestCacheClientProps(): CacheClientPropsWithConfig {
   return {
     configuration:
-      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
+      Configurations.Laptop.latest().withClientTimeoutMillis(90000),
     credentialProvider: credsProvider(),
     defaultTtlSeconds: 1111,
   };
@@ -87,7 +87,7 @@ function momentoClientWithThrowOnErrorsForTesting(): CacheClient {
 function momentoClientForTestingWithSessionToken(): CacheClient {
   return new CacheClient({
     configuration:
-      Configurations.Laptop.latest().withClientTimeoutMillis(60000),
+      Configurations.Laptop.latest().withClientTimeoutMillis(90000),
     credentialProvider: sessionCredsProvider(),
     defaultTtlSeconds: 1111,
   });


### PR DESCRIPTION
Was still seeing occasional test failures related to jest test timeouts, mostly for vector tests in the web sdk, but doubling the timeout again here in both just in case. 

Also increasing the cache client timeout by 30 seconds after seeing timeout errors from different tests, figured there might be enough tests added recently that increasing the timeout a bit might be worth a shot.