### PR TITLE
feat: setBatch and getBatch

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -66,6 +66,8 @@ import * as CacheKeysExist from '@gomomento/sdk-core/dist/src/messages/responses
 import * as CacheUpdateTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-update';
 import * as CacheIncreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-increase';
 import * as CacheDecreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-decrease';
+import * as GetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-get';
+import * as SetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-set';
 
 // TopicClient Response Types
 import * as TopicPublish from '@gomomento/sdk-core/dist/src/messages/responses/topic-publish';
@@ -326,6 +328,8 @@ export {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
+  GetBatch,
+  SetBatch,
   // TopicClient
   TopicConfigurations,
   TopicConfiguration,

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -738,7 +738,7 @@ export class CacheDataClient implements IDataClient {
 
   public async getBatch(
     cacheName: string,
-    keys: string[] | Uint8Array[]
+    keys: Array<string | Uint8Array>
   ): Promise<GetBatch.Response> {
     try {
       validateCacheName(cacheName);

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -5,7 +5,12 @@ import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
 import {ClientTimeoutInterceptor} from './grpc/client-timeout-interceptor';
 import {createRetryInterceptorIfEnabled} from './grpc/retry-interceptor';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
-import {ChannelCredentials, Interceptor, Metadata} from '@grpc/grpc-js';
+import {
+  ChannelCredentials,
+  Interceptor,
+  Metadata,
+  ServiceError,
+} from '@grpc/grpc-js';
 import {
   CacheDecreaseTtl,
   CacheDelete,
@@ -99,6 +104,7 @@ import _Unbounded = cache_client._Unbounded;
 import ECacheResult = cache_client.ECacheResult;
 import _ItemGetTypeResponse = cache_client._ItemGetTypeResponse;
 import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
+import {GetBatch, SetBatch} from '@gomomento/sdk-core';
 
 export const CONNECTION_ID_KEY = Symbol('connectionID');
 
@@ -717,6 +723,165 @@ export class CacheDataClient implements IDataClient {
           }
         }
       );
+    });
+  }
+
+  public async getBatch(
+    cacheName: string,
+    keys: string[] | Uint8Array[]
+  ): Promise<GetBatch.Response> {
+    try {
+      validateCacheName(cacheName);
+    } catch (err) {
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GetBatch.Error(err)
+      );
+    }
+    this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
+    const result = await this.sendGetBatch(
+      cacheName,
+      keys.map(key => this.convert(key))
+    );
+    this.logger.trace(`'getBatch' request result: ${result.toString()}`);
+    return result;
+  }
+
+  private async sendGetBatch(
+    cacheName: string,
+    keys: Uint8Array[]
+  ): Promise<GetBatch.Response> {
+    const getRequests = [];
+    for (const k of keys) {
+      const getRequest = new grpcCache._GetRequest({
+        cache_key: k,
+      });
+      getRequests.push(getRequest);
+    }
+    const request = new grpcCache._GetBatchRequest({
+      items: getRequests,
+    });
+    const metadata = this.createMetadata(cacheName);
+
+    const call = this.clientWrapper.getClient().GetBatch(request, metadata, {
+      interceptors: this.interceptors,
+    });
+
+    return await new Promise((resolve, reject) => {
+      const results: CacheGet.Response[] = [];
+      call.on('data', (getResponse: grpcCache._GetResponse) => {
+        const result = getResponse.result;
+        switch (result) {
+          case grpcCache.ECacheResult.Hit:
+            results.push(new CacheGet.Hit(getResponse.cache_body));
+            break;
+          case grpcCache.ECacheResult.Miss:
+            results.push(new CacheGet.Miss());
+            break;
+          default:
+            results.push(
+              new CacheGet.Error(new UnknownError(getResponse.message))
+            );
+        }
+      });
+
+      call.on('end', () => {
+        resolve(new GetBatch.Success(results));
+      });
+
+      call.on('error', (err: ServiceError | null) => {
+        this.cacheServiceErrorMapper.resolveOrRejectError({
+          err: err,
+          errorResponseFactoryFn: e => new GetBatch.Error(e),
+          resolveFn: resolve,
+          rejectFn: reject,
+        });
+      });
+    });
+  }
+
+  public async setBatch(
+    cacheName: string,
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    ttl?: number
+  ): Promise<SetBatch.Response> {
+    try {
+      validateCacheName(cacheName);
+      if (ttl !== undefined) {
+        validateTtlSeconds(ttl);
+      }
+    } catch (err) {
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new SetBatch.Error(err)
+      );
+    }
+
+    const itemsToUse = this.convertSetBatchElements(items);
+
+    const ttlToUse = ttl || this.defaultTtlSeconds;
+    this.logger.trace(
+      `Issuing 'setBatch' request; items length: ${
+        itemsToUse.length
+      }, ttl: ${ttlToUse.toString()}`
+    );
+
+    return await this.sendSetBatch(cacheName, itemsToUse, ttlToUse);
+  }
+
+  private async sendSetBatch(
+    cacheName: string,
+    items: Record<string, Uint8Array>[],
+    ttlSeconds: number
+  ): Promise<SetBatch.Response> {
+    const setRequests = [];
+    for (const item of items) {
+      const setRequest = new grpcCache._SetRequest({
+        cache_key: item.key,
+        cache_body: item.value,
+        ttl_milliseconds: ttlSeconds * 1000,
+      });
+      setRequests.push(setRequest);
+    }
+    const request = new grpcCache._SetBatchRequest({
+      items: setRequests,
+    });
+
+    const metadata = this.createMetadata(cacheName);
+
+    const call = this.clientWrapper.getClient().SetBatch(request, metadata, {
+      interceptors: this.interceptors,
+    });
+
+    return await new Promise((resolve, reject) => {
+      const results: CacheSet.Response[] = [];
+      call.on('data', (setResponse: grpcCache._SetResponse) => {
+        const result = setResponse.result;
+        switch (result) {
+          case grpcCache.ECacheResult.Ok:
+            results.push(new CacheSet.Success());
+            break;
+          default:
+            results.push(
+              new CacheSet.Error(new UnknownError(setResponse.message))
+            );
+        }
+      });
+
+      call.on('end', () => {
+        resolve(new SetBatch.Success(results));
+      });
+
+      call.on('error', (err: ServiceError | null) => {
+        this.cacheServiceErrorMapper.resolveOrRejectError({
+          err: err,
+          errorResponseFactoryFn: e => new SetBatch.Error(e),
+          resolveFn: resolve,
+          rejectFn: reject,
+        });
+      });
     });
   }
 
@@ -3175,6 +3340,28 @@ export class CacheDataClient implements IDataClient {
             score: element[1],
           })
       );
+    }
+  }
+
+  private convertSetBatchElements(
+    elements:
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Record<string, string | Uint8Array>
+  ): Record<string, Uint8Array>[] {
+    if (elements instanceof Map) {
+      return [...elements.entries()].map(element => {
+        return {
+          key: this.convert(element[0]),
+          value: this.convert(element[1]),
+        };
+      });
+    } else {
+      return Object.entries(elements).map(element => {
+        return {
+          key: this.convert(element[0]),
+          value: this.convert(element[1]),
+        };
+      });
     }
   }
 

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -796,7 +796,7 @@ export class CacheDataClient implements IDataClient {
       });
 
       call.on('end', () => {
-        resolve(new GetBatch.Success(results));
+        resolve(new GetBatch.Success(results, keys));
       });
 
       call.on('error', (err: ServiceError | null) => {

--- a/packages/client-sdk-nodejs/test/integration/shared/batch-get-set.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/batch-get-set.test.ts
@@ -1,0 +1,11 @@
+import {runBatchGetSetTests} from '@gomomento/common-integration-tests';
+import {SetupIntegrationTest} from '../integration-setup';
+
+const {cacheClient, cacheClientWithThrowOnErrors, integrationTestCacheName} =
+  SetupIntegrationTest();
+
+runBatchGetSetTests(
+  cacheClient,
+  cacheClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "^0.106.0",
+        "@gomomento/generated-types-webtext": "0.106.1",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -1034,9 +1034,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.106.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.106.0.tgz",
-      "integrity": "sha512-b8OqrGuqsRqpbhUS6tnlqZD2dVZO2GRRfp16m7zVOZDbq7pdA8nYwWCT0GxfiqgIcDWPSGzAUoeqEdCp4hs0Sw==",
+      "version": "0.106.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.106.1.tgz",
+      "integrity": "sha512-H2+9WB/NfqccCz9c4dkqW4mBEkodOjpGwBON6qbGoKMpPV15YG67x3XRuMVl3eEqTj1vxC3Kb/diPN7vKoiI8g==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -56,7 +56,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.106.0",
+    "@gomomento/generated-types-webtext": "0.106.1",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -53,7 +53,7 @@ import {
   CacheDictionaryLength,
 } from '..';
 import {Configuration} from '../config/configuration';
-import {Request, UnaryResponse} from 'grpc-web';
+import {Request, RpcError, UnaryResponse} from 'grpc-web';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {
   _DictionaryFieldValuePair,
@@ -105,6 +105,9 @@ import {
   ECacheResult,
   _UpdateTtlRequest,
   _DictionaryLengthRequest,
+  _GetBatchRequest,
+  _SetBatchRequest,
+  _SetResponse,
 } from '@gomomento/generated-types-webtext/dist/cacheclient_pb';
 import {IDataClient} from '@gomomento/sdk-core/dist/src/internal/clients';
 import {
@@ -130,6 +133,7 @@ import {
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {middlewaresInterceptor} from './grpc/middlewares-interceptor';
 import {MiddlewareRequestHandlerContext} from '../config/middleware/middleware';
+import {GetBatch, SetBatch} from '@gomomento/sdk-core';
 
 export interface DataClientProps {
   configuration: Configuration;
@@ -409,6 +413,162 @@ export class CacheDataClient<
           }
         }
       );
+    });
+  }
+
+  public async getBatch(
+    cacheName: string,
+    keys: string[] | Uint8Array[]
+  ): Promise<GetBatch.Response> {
+    try {
+      validateCacheName(cacheName);
+    } catch (err) {
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new GetBatch.Error(err)
+      );
+    }
+    this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
+    const result = await this.sendGetBatch(
+      cacheName,
+      keys.map(key => convertToB64String(key))
+    );
+    this.logger.trace(`'getBatch' request result: ${result.toString()}`);
+    return result;
+  }
+
+  private async sendGetBatch(
+    cacheName: string,
+    keys: string[]
+  ): Promise<GetBatch.Response> {
+    const getRequests = [];
+    for (const k of keys) {
+      const getRequest = new _GetRequest();
+      getRequest.setCacheKey(k);
+      getRequests.push(getRequest);
+    }
+    const request = new _GetBatchRequest();
+    request.setItemsList(getRequests);
+
+    const call = this.clientWrapper.getBatch(request, {
+      ...this.clientMetadataProvider.createClientMetadata(),
+      ...createCallMetadata(cacheName, this.deadlineMillis),
+    });
+
+    return await new Promise((resolve, reject) => {
+      const results: CacheGet.Response[] = [];
+      call.on('data', getResponse => {
+        const result = getResponse.getResult();
+        switch (result) {
+          case ECacheResult.HIT:
+            results.push(new CacheGet.Hit(getResponse.getCacheBody_asU8()));
+            break;
+          case ECacheResult.MISS:
+            results.push(new CacheGet.Miss());
+            break;
+          default:
+            results.push(
+              new CacheGet.Error(new UnknownError(getResponse.getMessage()))
+            );
+        }
+      });
+
+      call.on('end', () => {
+        resolve(new GetBatch.Success(results));
+      });
+
+      call.on('error', (err: RpcError) => {
+        this.cacheServiceErrorMapper.resolveOrRejectError({
+          err: err,
+          errorResponseFactoryFn: e => new GetBatch.Error(e),
+          resolveFn: resolve,
+          rejectFn: reject,
+        });
+      });
+    });
+  }
+
+  public async setBatch(
+    cacheName: string,
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    ttl?: number
+  ): Promise<SetBatch.Response> {
+    try {
+      validateCacheName(cacheName);
+      if (ttl !== undefined) {
+        validateTtlSeconds(ttl);
+      }
+    } catch (err) {
+      return this.cacheServiceErrorMapper.returnOrThrowError(
+        err as Error,
+        err => new SetBatch.Error(err)
+      );
+    }
+
+    const itemsToUse = this.convertSetBatchElements(items);
+
+    const ttlToUse = ttl || this.defaultTtlSeconds;
+    this.logger.trace(
+      `Issuing 'setBatch' request; items length: ${
+        itemsToUse.length
+      }, ttl: ${ttlToUse.toString()}`
+    );
+
+    return await this.sendSetBatch(cacheName, itemsToUse, ttlToUse);
+  }
+
+  private async sendSetBatch(
+    cacheName: string,
+    items: Record<string, string>[],
+    ttlSeconds: number
+  ): Promise<SetBatch.Response> {
+    const setRequests = [];
+    for (const item of items) {
+      const setRequest = new _SetRequest();
+      setRequest.setCacheKey(item.key);
+      setRequest.setCacheBody(item.value);
+      setRequest.setTtlMilliseconds(
+        this.convertSecondsToMilliseconds(ttlSeconds)
+      );
+      setRequests.push(setRequest);
+    }
+    const request = new _SetBatchRequest();
+    request.setItemsList(setRequests);
+
+    const call = this.clientWrapper.setBatch(request, {
+      ...this.clientMetadataProvider.createClientMetadata(),
+      ...createCallMetadata(cacheName, this.deadlineMillis),
+    });
+
+    return await new Promise((resolve, reject) => {
+      const results: CacheSet.Response[] = [];
+      call.on('data', setResponse => {
+        const result = setResponse.getResult();
+        switch (result) {
+          case ECacheResult.OK:
+            results.push(new CacheSet.Success());
+            break;
+          default:
+            results.push(
+              new CacheSet.Error(new UnknownError(setResponse.getMessage()))
+            );
+        }
+      });
+
+      call.on('end', () => {
+        resolve(new SetBatch.Success(results));
+      });
+
+      call.on('error', (err: RpcError) => {
+        this.cacheServiceErrorMapper.resolveOrRejectError({
+          err: err,
+          errorResponseFactoryFn: e => new SetBatch.Error(e),
+          resolveFn: resolve,
+          rejectFn: reject,
+        });
+      });
     });
   }
 
@@ -3513,6 +3673,28 @@ export class CacheDataClient<
           .setValue(convertToB64String(element[0]))
           .setScore(element[1])
       );
+    }
+  }
+
+  private convertSetBatchElements(
+    elements:
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Record<string, string | Uint8Array>
+  ): Record<string, string>[] {
+    if (elements instanceof Map) {
+      return [...elements.entries()].map(element => {
+        return {
+          key: convertToB64String(element[0]),
+          value: convertToB64String(element[1]),
+        };
+      });
+    } else {
+      return Object.entries(elements).map(element => {
+        return {
+          key: convertToB64String(element[0]),
+          value: convertToB64String(element[1]),
+        };
+      });
     }
   }
 

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -474,7 +474,12 @@ export class CacheDataClient<
       });
 
       call.on('end', () => {
-        resolve(new GetBatch.Success(results));
+        resolve(
+          new GetBatch.Success(
+            results,
+            keys.map(key => this.convertToUint8Array(key))
+          )
+        );
       });
 
       call.on('error', (err: RpcError) => {

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -418,7 +418,7 @@ export class CacheDataClient<
 
   public async getBatch(
     cacheName: string,
-    keys: string[] | Uint8Array[]
+    keys: Array<string | Uint8Array>
   ): Promise<GetBatch.Response> {
     try {
       validateCacheName(cacheName);

--- a/packages/client-sdk-web/test/integration/shared/batch-get-set.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/batch-get-set.test.ts
@@ -1,0 +1,11 @@
+import {runBatchGetSetTests} from '@gomomento/common-integration-tests';
+import {SetupIntegrationTest} from '../integration-setup';
+
+const {cacheClient, cacheClientWithThrowOnErrors, integrationTestCacheName} =
+  SetupIntegrationTest();
+
+runBatchGetSetTests(
+  cacheClient,
+  cacheClientWithThrowOnErrors,
+  integrationTestCacheName
+);

--- a/packages/common-integration-tests/src/batch-get-set.ts
+++ b/packages/common-integration-tests/src/batch-get-set.ts
@@ -1,0 +1,292 @@
+import {
+  CacheGet,
+  CacheSet,
+  GetBatch,
+  ICacheClient,
+  SetBatch,
+} from '@gomomento/sdk-core';
+import {expectWithMessage} from './common-int-test-utils';
+import {delay} from './auth-client';
+
+export function runBatchGetSetTests(
+  cacheClient: ICacheClient,
+  cacheClientWithThrowOnErrors: ICacheClient,
+  integrationTestCacheName: string
+) {
+  describe('#batch get and set', () => {
+    it('getBatch happy path with all misses', async () => {
+      const keys = ['a', 'b', 'c', '1', '2', '3'];
+      const response = await cacheClient.getBatch(
+        integrationTestCacheName,
+        keys
+      );
+
+      // Check get batch response
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(GetBatch.Success);
+      }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
+
+      // Check each response in the batch
+      const getResults = response.results();
+      if (getResults === undefined) {
+        fail('expected getResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(getResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${getResults.toString()}`);
+
+        for (const [index, resp] of getResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheGet.Miss);
+          }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
+        }
+      }
+    });
+
+    it('setBatch happy path', async () => {
+      // Set some values and check set batch response
+      const items = new Map<string, string>([
+        ['a', 'apple'],
+        ['b', 'berry'],
+        ['c', 'cantaloupe'],
+        ['1', 'first'],
+        ['2', 'second'],
+        ['3', 'third'],
+      ]);
+      const response = await cacheClient.setBatch(
+        integrationTestCacheName,
+        items
+      );
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(SetBatch.Success);
+      }, `expected SUCCESS, received ${response.toString()}`);
+
+      // Check each response in the set batch
+      const setResults = response.results();
+      const keys = [...items.keys()];
+      if (setResults === undefined) {
+        fail('expected setResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(setResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${setResults.toString()}`);
+
+        for (const [index, resp] of setResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheSet.Success);
+          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
+        }
+      }
+    });
+
+    it('setBatch happy path with ttl', async () => {
+      // Set some values and check set batch response
+      const items = new Map<string, string>([
+        ['a', 'apple'],
+        ['b', 'berry'],
+        ['c', 'cantaloupe'],
+        ['1', 'first'],
+        ['2', 'second'],
+        ['3', 'third'],
+      ]);
+      const response = await cacheClient.setBatch(
+        integrationTestCacheName,
+        items,
+        {ttl: 3}
+      );
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(SetBatch.Success);
+      }, `expected SUCCESS, received ${response.toString()}`);
+
+      // Check each response in the set batch
+      const setResults = response.results();
+      const keys = [...items.keys()];
+      if (setResults === undefined) {
+        fail('expected setResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(setResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${setResults.toString()}`);
+
+        for (const [index, resp] of setResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheSet.Success);
+          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
+        }
+      }
+
+      await delay(5000);
+
+      // Fetch values and check get batch response
+      const getResponse = await cacheClient.getBatch(
+        integrationTestCacheName,
+        keys
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+      }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
+
+      // Check each response in the get batch
+      const getResults = getResponse.results();
+      if (getResults === undefined) {
+        fail('expected getResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(getResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${getResults.toString()}`);
+
+        for (const [index, resp] of getResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheGet.Miss);
+          }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
+        }
+      }
+    });
+
+    it('getBatch happy path with all hits', async () => {
+      // Set some values and check set batch response
+      const items = new Map<string, string>([
+        ['a', 'apple'],
+        ['b', 'berry'],
+        ['c', 'cantaloupe'],
+        ['1', 'first'],
+        ['2', 'second'],
+        ['3', 'third'],
+      ]);
+      const setResponse = await cacheClient.setBatch(
+        integrationTestCacheName,
+        items
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(SetBatch.Success);
+      }, `expected SUCCESS, received ${setResponse.toString()}`);
+
+      // Check each response in the set batch
+      const setResults = setResponse.results();
+      const keys = [...items.keys()];
+      if (setResults === undefined) {
+        fail('expected setResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(setResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${setResults.toString()}`);
+
+        for (const [index, resp] of setResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheSet.Success);
+          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
+        }
+
+        // Fetch values and check get batch response
+        const getResponse = await cacheClient.getBatch(
+          integrationTestCacheName,
+          keys
+        );
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(GetBatch.Success);
+        }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
+
+        // Check each response in the get batch
+        const getResults = getResponse.results();
+        if (getResults === undefined) {
+          fail('expected getResults array to be defined');
+        } else {
+          expectWithMessage(() => {
+            expect(getResults.length).toEqual(keys.length);
+          }, `expected non-empty results, received ${getResults.toString()}`);
+
+          for (const [index, resp] of getResults.entries()) {
+            const key = keys[index];
+            expectWithMessage(() => {
+              expect(resp).toBeInstanceOf(CacheGet.Hit);
+            }, `expected HIT for getting key ${key}, received ${resp.toString()}`);
+
+            const expectedValue = items.get(key) ?? 'value not in items map';
+            const receivedValue =
+              resp.value() ?? 'value could not be retrieved from response';
+            expectWithMessage(() => {
+              expect(receivedValue).toEqual(expectedValue);
+            }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
+          }
+        }
+      }
+    });
+
+    it('getBatch happy path with some hits and misses', async () => {
+      // Set some values and check set batch response
+      const items = new Map<string, string>([
+        ['a', 'alligator'],
+        ['b', 'bear'],
+        ['c', 'cougar'],
+        ['e', 'elephant'],
+        ['f', 'flamingo'],
+        ['g', 'gorilla'],
+      ]);
+      const setResponse = await cacheClient.setBatch(
+        integrationTestCacheName,
+        items
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(SetBatch.Success);
+      }, `expected SUCCESS, received ${setResponse.toString()}`);
+
+      // Check each response in the set batch
+      const setResults = setResponse.results();
+      if (setResults === undefined) {
+        fail('expected setResults array to be defined');
+      } else {
+        const keys = [...items.keys()];
+        expectWithMessage(() => {
+          expect(setResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${setResults.toString()}`);
+
+        for (const [index, resp] of setResults.entries()) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheSet.Success);
+          }, `expected SUCCESS for key ${keys[index]} but received ${resp.toString()}`);
+        }
+      }
+
+      // Fetch values and check get batch response
+      const keys = ['a', 'b', 'c', '10', '11', '12'];
+      const getResponse = await cacheClient.getBatch(
+        integrationTestCacheName,
+        keys
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+      }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
+
+      // Check each response in the get batch
+      const getResults = getResponse.results();
+      if (getResults === undefined) {
+        fail('expected getResults array to be defined');
+      } else {
+        expectWithMessage(() => {
+          expect(getResults.length).toEqual(keys.length);
+        }, `expected non-empty results, received ${getResults.toString()}`);
+
+        for (const [index, resp] of getResults.entries()) {
+          const key = keys[index];
+
+          if (['a', 'b', 'c'].includes(key)) {
+            expectWithMessage(() => {
+              expect(resp).toBeInstanceOf(CacheGet.Hit);
+            }, `expected HIT for key ${key} but received ${resp.toString()}`);
+
+            const expectedValue = items.get(key) ?? 'value not in items map';
+            const receivedValue =
+              resp.value() ?? 'value could not be retrieved from response';
+            expectWithMessage(() => {
+              expect(receivedValue).toEqual(expectedValue);
+            }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
+          } else {
+            expectWithMessage(() => {
+              expect(resp).toBeInstanceOf(CacheGet.Miss);
+            }, `expected MISS for key ${key} but received ${resp.toString()}`);
+          }
+        }
+      }
+    });
+  });
+}

--- a/packages/common-integration-tests/src/batch-get-set.ts
+++ b/packages/common-integration-tests/src/batch-get-set.ts
@@ -27,19 +27,15 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
 
       // Check each response in the batch
-      const getResults = response.results();
-      if (getResults === undefined) {
-        fail('expected getResults array to be defined');
-      } else {
-        expectWithMessage(() => {
-          expect(getResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${getResults.toString()}`);
+      const getResults = (response as GetBatch.Success).results();
+      expectWithMessage(() => {
+        expect(getResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${getResults.toString()}`);
 
-        for (const [index, resp] of getResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheGet.Miss);
-          }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
-        }
+      for (const [index, resp] of getResults.entries()) {
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheGet.Miss);
+        }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
       }
     });
 
@@ -62,20 +58,16 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS, received ${response.toString()}`);
 
       // Check each response in the set batch
-      const setResults = response.results();
+      const setResults = (response as SetBatch.Success).results();
       const keys = [...items.keys()];
-      if (setResults === undefined) {
-        fail('expected setResults array to be defined');
-      } else {
-        expectWithMessage(() => {
-          expect(setResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${setResults.toString()}`);
+      expectWithMessage(() => {
+        expect(setResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${setResults.toString()}`);
 
-        for (const [index, resp] of setResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheSet.Success);
-          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
-        }
+      for (const [index, resp] of setResults.entries()) {
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
       }
     });
 
@@ -99,20 +91,16 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS, received ${response.toString()}`);
 
       // Check each response in the set batch
-      const setResults = response.results();
+      const setResults = (response as SetBatch.Success).results();
       const keys = [...items.keys()];
-      if (setResults === undefined) {
-        fail('expected setResults array to be defined');
-      } else {
-        expectWithMessage(() => {
-          expect(setResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${setResults.toString()}`);
+      expectWithMessage(() => {
+        expect(setResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${setResults.toString()}`);
 
-        for (const [index, resp] of setResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheSet.Success);
-          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
-        }
+      for (const [index, resp] of setResults.entries()) {
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
       }
 
       await delay(5000);
@@ -127,19 +115,15 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
       // Check each response in the get batch
-      const getResults = getResponse.results();
-      if (getResults === undefined) {
-        fail('expected getResults array to be defined');
-      } else {
-        expectWithMessage(() => {
-          expect(getResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${getResults.toString()}`);
+      const getResults = (getResponse as GetBatch.Success).results();
+      expectWithMessage(() => {
+        expect(getResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${getResults.toString()}`);
 
-        for (const [index, resp] of getResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheGet.Miss);
-          }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
-        }
+      for (const [index, resp] of getResults.entries()) {
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheGet.Miss);
+        }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
       }
     });
 
@@ -162,53 +146,45 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS, received ${setResponse.toString()}`);
 
       // Check each response in the set batch
-      const setResults = setResponse.results();
+      const setResults = (setResponse as SetBatch.Success).results();
       const keys = [...items.keys()];
-      if (setResults === undefined) {
-        fail('expected setResults array to be defined');
-      } else {
+      expectWithMessage(() => {
+        expect(setResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${setResults.toString()}`);
+
+      for (const [index, resp] of setResults.entries()) {
         expectWithMessage(() => {
-          expect(setResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${setResults.toString()}`);
+          expect(resp).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
+      }
 
-        for (const [index, resp] of setResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheSet.Success);
-          }, `expected SUCCESS for setting key ${keys[index]} but received ${resp.toString()}`);
-        }
+      // Fetch values and check get batch response
+      const getResponse = await cacheClient.getBatch(
+        integrationTestCacheName,
+        keys
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+      }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
-        // Fetch values and check get batch response
-        const getResponse = await cacheClient.getBatch(
-          integrationTestCacheName,
-          keys
-        );
+      // Check each response in the get batch
+      const getResults = (getResponse as GetBatch.Success).results();
+      expectWithMessage(() => {
+        expect(getResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${getResults.toString()}`);
+
+      for (const [index, resp] of getResults.entries()) {
+        const key = keys[index];
         expectWithMessage(() => {
-          expect(getResponse).toBeInstanceOf(GetBatch.Success);
-        }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
+          expect(resp).toBeInstanceOf(CacheGet.Hit);
+        }, `expected HIT for getting key ${key}, received ${resp.toString()}`);
 
-        // Check each response in the get batch
-        const getResults = getResponse.results();
-        if (getResults === undefined) {
-          fail('expected getResults array to be defined');
-        } else {
-          expectWithMessage(() => {
-            expect(getResults.length).toEqual(keys.length);
-          }, `expected non-empty results, received ${getResults.toString()}`);
-
-          for (const [index, resp] of getResults.entries()) {
-            const key = keys[index];
-            expectWithMessage(() => {
-              expect(resp).toBeInstanceOf(CacheGet.Hit);
-            }, `expected HIT for getting key ${key}, received ${resp.toString()}`);
-
-            const expectedValue = items.get(key) ?? 'value not in items map';
-            const receivedValue =
-              resp.value() ?? 'value could not be retrieved from response';
-            expectWithMessage(() => {
-              expect(receivedValue).toEqual(expectedValue);
-            }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
-          }
-        }
+        const expectedValue = items.get(key) ?? 'value not in items map';
+        const receivedValue =
+          resp.value() ?? 'value could not be retrieved from response';
+        expectWithMessage(() => {
+          expect(receivedValue).toEqual(expectedValue);
+        }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
       }
     });
 
@@ -231,20 +207,16 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS, received ${setResponse.toString()}`);
 
       // Check each response in the set batch
-      const setResults = setResponse.results();
-      if (setResults === undefined) {
-        fail('expected setResults array to be defined');
-      } else {
-        const keys = [...items.keys()];
-        expectWithMessage(() => {
-          expect(setResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${setResults.toString()}`);
+      const setResults = (setResponse as SetBatch.Success).results();
+      const setKeys = [...items.keys()];
+      expectWithMessage(() => {
+        expect(setResults.length).toEqual(setKeys.length);
+      }, `expected non-empty results, received ${setResults.toString()}`);
 
-        for (const [index, resp] of setResults.entries()) {
-          expectWithMessage(() => {
-            expect(resp).toBeInstanceOf(CacheSet.Success);
-          }, `expected SUCCESS for key ${keys[index]} but received ${resp.toString()}`);
-        }
+      for (const [index, resp] of setResults.entries()) {
+        expectWithMessage(() => {
+          expect(resp).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS for key ${setKeys[index]} but received ${resp.toString()}`);
       }
 
       // Fetch values and check get batch response
@@ -258,33 +230,29 @@ export function runBatchGetSetTests(
       }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
       // Check each response in the get batch
-      const getResults = getResponse.results();
-      if (getResults === undefined) {
-        fail('expected getResults array to be defined');
-      } else {
-        expectWithMessage(() => {
-          expect(getResults.length).toEqual(keys.length);
-        }, `expected non-empty results, received ${getResults.toString()}`);
+      const getResults = (getResponse as GetBatch.Success).results();
+      expectWithMessage(() => {
+        expect(getResults.length).toEqual(keys.length);
+      }, `expected non-empty results, received ${getResults.toString()}`);
 
-        for (const [index, resp] of getResults.entries()) {
-          const key = keys[index];
+      for (const [index, resp] of getResults.entries()) {
+        const key = keys[index];
 
-          if (['a', 'b', 'c'].includes(key)) {
-            expectWithMessage(() => {
-              expect(resp).toBeInstanceOf(CacheGet.Hit);
-            }, `expected HIT for key ${key} but received ${resp.toString()}`);
+        if (['a', 'b', 'c'].includes(key)) {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheGet.Hit);
+          }, `expected HIT for key ${key} but received ${resp.toString()}`);
 
-            const expectedValue = items.get(key) ?? 'value not in items map';
-            const receivedValue =
-              resp.value() ?? 'value could not be retrieved from response';
-            expectWithMessage(() => {
-              expect(receivedValue).toEqual(expectedValue);
-            }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
-          } else {
-            expectWithMessage(() => {
-              expect(resp).toBeInstanceOf(CacheGet.Miss);
-            }, `expected MISS for key ${key} but received ${resp.toString()}`);
-          }
+          const expectedValue = items.get(key) ?? 'value not in items map';
+          const receivedValue =
+            resp.value() ?? 'value could not be retrieved from response';
+          expectWithMessage(() => {
+            expect(receivedValue).toEqual(expectedValue);
+          }, `expected key ${key} to be set to ${expectedValue} but received ${receivedValue}`);
+        } else {
+          expectWithMessage(() => {
+            expect(resp).toBeInstanceOf(CacheGet.Miss);
+          }, `expected MISS for key ${key} but received ${resp.toString()}`);
         }
       }
     });

--- a/packages/common-integration-tests/src/index.ts
+++ b/packages/common-integration-tests/src/index.ts
@@ -14,3 +14,4 @@ export * from './vector-control-plane';
 export * from './vector-data-plane';
 export * from './leaderboard-client';
 export * from './webhooks';
+export * from './batch-get-set';

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -45,6 +45,8 @@ import {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   CacheDictionaryGetFields,
+  GetBatch,
+  SetBatch,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -63,6 +65,7 @@ import {IMomentoCache} from './IMomentoCache';
 // Type aliases to differentiate the different methods' optional arguments.
 export type SetOptions = ScalarCallOptions;
 export type SetIfNotExistsOptions = ScalarCallOptions;
+export type SetBatchOptions = ScalarCallOptions;
 export type ListConcatenateBackOptions = FrontTruncatableCallOptions;
 export type ListConcatenateFrontOptions = BackTruncatableCallOptions;
 export type ListPushBackOptions = FrontTruncatableCallOptions;
@@ -106,6 +109,17 @@ export interface ICacheClient extends IControlClient, IPingClient {
     field: string | Uint8Array,
     options?: SetIfNotExistsOptions
   ): Promise<CacheSetIfNotExists.Response>;
+  getBatch(
+    cacheName: string,
+    keys: string[] | Uint8Array[]
+  ): Promise<GetBatch.Response>;
+  setBatch(
+    cacheName: string,
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    options?: SetBatchOptions
+  ): Promise<SetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;
   setAddElement(
     cacheName: string,

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -111,7 +111,7 @@ export interface ICacheClient extends IControlClient, IPingClient {
   ): Promise<CacheSetIfNotExists.Response>;
   getBatch(
     cacheName: string,
-    keys: string[] | Uint8Array[]
+    keys: Array<string | Uint8Array>
   ): Promise<GetBatch.Response>;
   setBatch(
     cacheName: string,

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -45,6 +45,8 @@ import {
   CacheDecreaseTtl,
   CacheDictionaryGetFields,
   CacheDictionaryLength,
+  GetBatch,
+  SetBatch,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -61,6 +63,7 @@ import {
 // Type aliases to differentiate the different methods' optional arguments.
 export type SetOptions = ScalarCallOptions;
 export type SetIfNotExistsOptions = ScalarCallOptions;
+export type SetBatchOptions = ScalarCallOptions;
 export type ListConcatenateBackOptions = FrontTruncatableCallOptions;
 export type ListConcatenateFrontOptions = BackTruncatableCallOptions;
 export type ListPushBackOptions = FrontTruncatableCallOptions;
@@ -96,6 +99,13 @@ export interface IMomentoCache {
     field: string | Uint8Array,
     options?: SetIfNotExistsOptions
   ): Promise<CacheSetIfNotExists.Response>;
+  getBatch(keys: string[] | Uint8Array[]): Promise<GetBatch.Response>;
+  setBatch(
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    options?: SetBatchOptions
+  ): Promise<SetBatch.Response>;
   setFetch(setName: string): Promise<CacheSetFetch.Response>;
   setAddElement(
     setName: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,8 @@ import * as CacheKeysExist from './messages/responses/cache-keys-exist';
 import * as CacheUpdateTtl from './messages/responses/cache-ttl-update';
 import * as CacheIncreaseTtl from './messages/responses/cache-ttl-increase';
 import * as CacheDecreaseTtl from './messages/responses/cache-ttl-decrease';
+import * as SetBatch from './messages/responses/cache-batch-set';
+import * as GetBatch from './messages/responses/cache-batch-get';
 
 // TopicClient Response Types
 import * as TopicPublish from './messages/responses/topic-publish';
@@ -268,6 +270,8 @@ export {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   CacheInfo,
+  SetBatch,
+  GetBatch,
   // TopicClient Response Types
   TopicPublish,
   TopicSubscribe,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -223,7 +223,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    */
   public async getBatch(
     cacheName: string,
-    keys: string[] | Uint8Array[]
+    keys: Array<string | Uint8Array>
   ): Promise<GetBatch.Response> {
     return await this.getNextDataClient().getBatch(cacheName, keys);
   }

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -53,6 +53,8 @@ import {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
+  GetBatch,
+  SetBatch,
 } from '../../../index';
 import {ListFetchCallOptions, ListRetainCallOptions} from '../../../utils';
 import {
@@ -72,6 +74,7 @@ import {
   SortedSetFetchByScoreOptions,
   SortedSetIncrementOptions,
   SortedSetLengthByScoreOptions,
+  SetBatchOptions,
 } from '../../../clients/ICacheClient';
 import {IControlClient} from './IControlClient';
 import {IDataClient} from './IDataClient';
@@ -207,6 +210,46 @@ export abstract class AbstractCacheClient implements ICacheClient {
   ): Promise<CacheDelete.Response> {
     const client = this.getNextDataClient();
     return await client.delete(cacheName, key);
+  }
+
+  /**
+   * Gets the value stored for the given keys.
+   *
+   * @param {string} cacheName - The cache to perform the lookup in.
+   * @param {string[] | Uint8Array[]} keys - The list of keys to look up.
+   * @returns {Promise<GetBatch.Response>} -
+   * {@link GetBatch.Success} containing the values if they were found.
+   * {@link GetBatch.Error} on failure.
+   */
+  public async getBatch(
+    cacheName: string,
+    keys: string[] | Uint8Array[]
+  ): Promise<GetBatch.Response> {
+    return await this.getNextDataClient().getBatch(cacheName, keys);
+  }
+
+  /**
+   * Associates the given keys with the given values. If a value for the key is
+   * already present it is replaced with the new value.
+   *
+   * @param {string} cacheName - The cache to store the values in.
+   * @param {Record<string, string | Uint8Array> | Map<string | Uint8Array, string | Uint8Array>} items - The key-value pairs to be stored.
+   * @param {SetOptions} [options]
+   * @param {number} [options.ttl] - The time to live for the items in the cache.
+   * Uses the client's default TTL if this is not supplied.
+   * @returns {Promise<CacheSet.Response>} -
+   * {@link SetBatch.Success} on success.
+   * {@link SetBatch.Error} on failure.
+   */
+  public async setBatch(
+    cacheName: string,
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    options?: SetBatchOptions
+  ): Promise<SetBatch.Response> {
+    const client = this.getNextDataClient();
+    return await client.setBatch(cacheName, items, options?.ttl);
   }
 
   /**

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -45,6 +45,8 @@ import {
   CacheDecreaseTtl,
   CacheDictionaryLength,
   CacheDictionaryGetFields,
+  SetBatch,
+  GetBatch,
 } from '../../../index';
 
 export interface IDataClient {
@@ -71,6 +73,17 @@ export interface IDataClient {
     field: string | Uint8Array,
     ttl?: number
   ): Promise<CacheSetIfNotExists.Response>;
+  getBatch(
+    cacheName: string,
+    keys: string[] | Uint8Array[]
+  ): Promise<GetBatch.Response>;
+  setBatch(
+    cacheName: string,
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    ttl?: number
+  ): Promise<SetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;
   setAddElements(
     cacheName: string,

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -75,7 +75,7 @@ export interface IDataClient {
   ): Promise<CacheSetIfNotExists.Response>;
   getBatch(
     cacheName: string,
-    keys: string[] | Uint8Array[]
+    keys: Array<string | Uint8Array>
   ): Promise<GetBatch.Response>;
   setBatch(
     cacheName: string,

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -47,6 +47,8 @@ import {
   CacheSortedSetRemoveElements,
   CacheDictionaryGetFields,
   CacheDictionaryLength,
+  GetBatch,
+  SetBatch,
 } from '../../../index';
 import {
   ScalarCallOptions,
@@ -64,6 +66,7 @@ import {IMomentoCache} from '../../../clients/IMomentoCache';
 // Type aliases to differentiate the different methods' optional arguments.
 export type SetOptions = ScalarCallOptions;
 export type SetIfNotExistsOptions = ScalarCallOptions;
+export type SetBatchOptions = ScalarCallOptions;
 export type ListConcatenateBackOptions = FrontTruncatableCallOptions;
 export type ListConcatenateFrontOptions = BackTruncatableCallOptions;
 export type ListPushBackOptions = FrontTruncatableCallOptions;
@@ -115,6 +118,17 @@ export class MomentoCache implements IMomentoCache {
     options?: SetIfNotExistsOptions
   ): Promise<CacheSetIfNotExists.Response> {
     return this.cacheClient.setIfNotExists(this.cacheName, key, field, options);
+  }
+  getBatch(keys: string[] | Uint8Array[]): Promise<GetBatch.Response> {
+    return this.cacheClient.getBatch(this.cacheName, keys);
+  }
+  setBatch(
+    items:
+      | Record<string, string | Uint8Array>
+      | Map<string | Uint8Array, string | Uint8Array>,
+    options?: SetBatchOptions
+  ): Promise<SetBatch.Response> {
+    return this.cacheClient.setBatch(this.cacheName, items, options);
   }
   setFetch(setName: string): Promise<CacheSetFetch.Response> {
     return this.cacheClient.setFetch(this.cacheName, setName);

--- a/packages/core/src/messages/responses/cache-batch-get.ts
+++ b/packages/core/src/messages/responses/cache-batch-get.ts
@@ -1,0 +1,97 @@
+import {SdkError} from '../../errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {truncateString} from '../../internal/utils';
+import {CacheGet} from '../..';
+
+/**
+ * Parent response type for a cache get batch request.  The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Success}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof BatchGet.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `BatchGet.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {
+  public values(): (string | undefined)[] | undefined {
+    if (this instanceof Success) {
+      return (this as Success).values();
+    }
+    return undefined;
+  }
+
+  public results(): CacheGet.Response[] | undefined {
+    if (this instanceof Success) {
+      return (this as Success).results();
+    }
+    return undefined;
+  }
+}
+
+class _Success extends Response {
+  private readonly body: CacheGet.Response[];
+  constructor(body: CacheGet.Response[]) {
+    super();
+    this.body = body;
+  }
+
+  /**
+   * Returns the data as a list of utf-8 strings, decoded from the underlying byte array.
+   * May contain nulls corresponding to cache misses.
+   * @returns {(string | undefined)[]}
+   */
+  public values(): (string | undefined)[] {
+    return this.body.map(getResponse => {
+      return getResponse.value();
+    });
+  }
+
+  public override toString(): string {
+    const display = this.values()
+      .map(value => (value !== undefined ? truncateString(value) : undefined))
+      .toString();
+    return `${super.toString()}: ${display}`;
+  }
+
+  /**
+   * Returns the status for each request in the batch as a list of CacheGet.Response objects.
+   * @returns {CacheGet.Response[]}
+   */
+  public results(): CacheGet.Response[] {
+    return this.body;
+  }
+}
+
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the cache get request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}

--- a/packages/core/src/messages/responses/cache-batch-set.ts
+++ b/packages/core/src/messages/responses/cache-batch-set.ts
@@ -1,0 +1,70 @@
+import {CacheSet} from '../..';
+import {SdkError} from '../../errors';
+import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+
+/**
+ * Parent response type for a cache set batch request.  The
+ * response object is resolved to a type-safe object of one of
+ * the following subtypes:
+ *
+ * - {Success}
+ * - {Error}
+ *
+ * `instanceof` type guards can be used to operate on the appropriate subtype.
+ * @example
+ * For example:
+ * ```
+ * if (response instanceof SetBatch.Error) {
+ *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
+ *   // `SetBatch.Error` in this block, so you will have access to the properties
+ *   // of the Error class; e.g. `response.errorCode()`.
+ * }
+ * ```
+ */
+export abstract class Response extends ResponseBase {
+  public results(): CacheSet.Response[] | undefined {
+    if (this instanceof Success) {
+      return (this as Success).results();
+    }
+    return undefined;
+  }
+}
+
+class _Success extends Response {
+  private readonly body: CacheSet.Response[];
+  constructor(body: CacheSet.Response[]) {
+    super();
+    this.body = body;
+  }
+
+  /**
+   * Returns the status for each request in the batch as a list of CacheGet.Response objects.
+   * @returns {CacheSet.Response[]}
+   */
+  public results(): CacheSet.Response[] {
+    return this.body;
+  }
+}
+
+/**
+ * Indicates a Successful cache set request.
+ */
+export class Success extends ResponseSuccess(_Success) {}
+
+class _Error extends Response {
+  constructor(protected _innerException: SdkError) {
+    super();
+  }
+}
+
+/**
+ * Indicates that an error occurred during the cache set request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends ResponseError(_Error) {}


### PR DESCRIPTION
Adds batch get and set APIs for [#674](https://github.com/momentohq/dev-eco-issue-tracker/issues/674)

Note: the streaming APIs use a different set of interceptors, this issue is still open: https://github.com/momentohq/client-sdk-javascript/issues/349 

Another note: this PR doesn't remove the [nodejs batchutils functions](https://github.com/momentohq/client-sdk-javascript/tree/main/packages/client-sdk-nodejs/src/batchutils)