### PR TITLE
chore: update log level during timeout to warn

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/middlewares-interceptor.ts
@@ -86,8 +86,8 @@ export function middlewaresInterceptor(
               // also try to connect if it's idle, false will just get the status
               const connectionStatus =
                 grpcClient?.getChannel()?.getConnectivityState(false) ?? null;
-              logger.debug(
-                `Received status: ${status.code} ${
+              logger.warn(
+                `Deadline Exceeded! Received status: ${status.code} ${
                   status.details
                 } and grpc connection status: ${
                   connectionStatus


### PR DESCRIPTION
This commit will allow us to look at the log for the gRPC connection status when a deadline/timeout is observed