### PR TITLE
fix: make sure cache and vector control clients set grpc channel options too

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -30,6 +30,7 @@ import {
   CacheLimits,
   TopicLimits,
 } from '@gomomento/sdk-core/dist/src/messages/cache-info';
+import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 
 export interface ControlClientProps {
   configuration: Configuration;
@@ -62,11 +63,16 @@ export class CacheControlClient {
     this.logger.debug(
       `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
     );
+    const grpcConfig = props.configuration
+      .getTransportStrategy()
+      .getGrpcConfig();
+    const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
         new grpcControl.ScsControlClient(
           props.credentialProvider.getControlEndpoint(),
-          ChannelCredentials.createSsl()
+          ChannelCredentials.createSsl(),
+          channelOptions
         ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration

--- a/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/vector-index-control-client.ts
@@ -29,6 +29,7 @@ import {
   VectorSimilarityMetric,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import grpcControl = control.control_client;
+import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 
 export interface ControlClientProps {
   configuration: VectorIndexConfiguration;
@@ -61,11 +62,16 @@ export class VectorIndexControlClient implements IVectorIndexControlClient {
     this.logger.debug(
       `Creating control client using endpoint: '${props.credentialProvider.getControlEndpoint()}`
     );
+    const grpcConfig = props.configuration
+      .getTransportStrategy()
+      .getGrpcConfig();
+    const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
         new grpcControl.ScsControlClient(
           props.credentialProvider.getControlEndpoint(),
-          ChannelCredentials.createSsl()
+          ChannelCredentials.createSsl(),
+          channelOptions
         ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration


### PR DESCRIPTION
Should configure grpc channel options the same on control and data clients for now.
Had noticed they were missing from the cache and vector control clients in this sdk while implementing these in other ones.