### PR TITLE
fix: add runtime check for JS in set api

### DIFF
--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -190,6 +190,9 @@ export abstract class AbstractCacheClient implements ICacheClient {
     value: string | Uint8Array,
     options?: SetOptions
   ): Promise<CacheSet.Response> {
+    if (typeof options === 'number') {
+      throw new Error('Options must be an object with a ttl property.');
+    }
     const client = this.getNextDataClient();
     return await client.set(cacheName, key, value, options?.ttl);
   }

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -54,7 +54,7 @@ import {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   GetBatch,
-  SetBatch,
+  SetBatch, InvalidArgumentError,
 } from '../../../index';
 import {ListFetchCallOptions, ListRetainCallOptions} from '../../../utils';
 import {
@@ -191,7 +191,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
     options?: SetOptions
   ): Promise<CacheSet.Response> {
     if (typeof options === 'number') {
-      throw new Error('Options must be an object with a ttl property.');
+      throw new InvalidArgumentError('Options must be an object with a ttl property.');
     }
     const client = this.getNextDataClient();
     return await client.set(cacheName, key, value, options?.ttl);

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -54,7 +54,8 @@ import {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   GetBatch,
-  SetBatch, InvalidArgumentError,
+  SetBatch,
+  InvalidArgumentError,
 } from '../../../index';
 import {ListFetchCallOptions, ListRetainCallOptions} from '../../../utils';
 import {
@@ -191,7 +192,9 @@ export abstract class AbstractCacheClient implements ICacheClient {
     options?: SetOptions
   ): Promise<CacheSet.Response> {
     if (typeof options === 'number') {
-      throw new InvalidArgumentError('Options must be an object with a ttl property.');
+      throw new InvalidArgumentError(
+        'Options must be an object with a ttl property.'
+      );
     }
     const client = this.getNextDataClient();
     return await client.set(cacheName, key, value, options?.ttl);


### PR DESCRIPTION
## PR Description:
I tested the set and getItemTtl in our nodejs sdk. I used default ttl to be 1 day and then set a key in cache passing the ttl to be 3 days. The getItemTtl returns 3 days.
Code ref:
```
const momento = await CacheClient.create({
    configuration: Configurations.InRegion.Default.v1(),
    credentialProvider: CredentialProvider.fromEnvironmentVariable({
      environmentVariableName: 'MOMENTO_API_KEY',
    }),
    defaultTtlSeconds: 86400,
  });

  const setResponse = await momento.set('test-js', 'test-key-2', 'test-value-2', {
    ttl: 259200
  });
  if (setResponse instanceof CacheSet.Success) {
    console.log('Key stored successfully!');
  } else {
    console.log(`Error setting key: ${setResponse.toString()}`);
  }

  const itemTtlResponse = await momento.itemGetTtl('test-js', 'test-key-2');
  if (itemTtlResponse instanceof CacheItemGetTtl.Hit) {
    console.log(itemTtlResponse.remainingTtlMillis());
  } else {
    console.log('cache miss/error');
  }
  ```
  Result:
> momento-nodejs-example@1.0.0 basic
> tsc && node dist/basic.js

Key stored successfully!
259199602
success!!

The difference that I see is the way CBS is setting the ttl:
```set("video-api.playlists", "developer-test", "Test Data For Developer Test on QA", 259200);```
instead of

```
await momento.set('test-js', 'test-key-2', 'test-value-2', {
    ttl: 259200
  });
```

It seems they are using js instead of ts.
I created a js file and ran the same example, I was able to repro the issue.

Hence, this commit is an attempt to post a release with a runtime check for JS in this case. 

## Reference:
https://gomomento.slack.com/archives/C037XLHFC79/p1709577122573569


  