### PR TITLE
feat: add close method to clients

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -105,8 +105,7 @@ export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMid
   private static elu: EventLoopUtilization;
   private static isLoggingStarted = false;
   static numActiveRequests = 0;
-  // this is typed as any because JS returns a number for intervalId but
-  // TS returns a NodeJS.Timeout.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static intervalId: any | null = null; // Store the interval ID
 
   constructor(loggerFactory: MomentoLoggerFactory) {

--- a/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
@@ -62,4 +62,5 @@ export interface Middleware {
   onNewRequest(
     context?: MiddlewareRequestHandlerContext
   ): MiddlewareRequestHandler;
+  close?(): void;
 }

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -74,6 +74,10 @@ export class CacheControlClient {
         .getMaxIdleMillis(),
     });
   }
+  close() {
+    this.logger.debug('Closing cache control client');
+    this.clientWrapper.getClient().close();
+  }
 
   public async createCache(name: string): Promise<CreateCache.Response> {
     try {

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -187,6 +187,11 @@ export class CacheDataClient implements IDataClient {
     );
     this.streamingInterceptors = this.initializeStreamingInterceptors(headers);
   }
+  close() {
+    this.logger.debug('Closing cache data client');
+    this.clientWrapper.getClient().close();
+  }
+
   public connect(timeoutSeconds = 10): Promise<void> {
     this.logger.debug('Attempting to eagerly connect to channel');
     const deadline = new Date();

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -112,11 +112,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
   close() {
     this.logger.debug('Closing leaderboard data clients');
     this.clientWrappers.map(wrapper => wrapper.getClient().close());
-    this.configuration.getMiddlewares().forEach(m => {
-      if (m.close) {
-        m.close();
-      }
-    });
   }
 
   private validateRequestTimeout(timeout?: number) {

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -109,6 +109,16 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     );
   }
 
+  close() {
+    this.logger.debug('Closing leaderboard data clients');
+    this.clientWrappers.map(wrapper => wrapper.getClient().close());
+    this.configuration.getMiddlewares().forEach(m => {
+      if (m.close) {
+        m.close();
+      }
+    });
+  }
+
   private validateRequestTimeout(timeout?: number) {
     this.logger.debug(`Request timeout ms: ${String(timeout)}`);
     if (timeout !== undefined && timeout <= 0) {

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -36,6 +36,10 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
     this.dataClient = new LeaderboardDataClient(propsWithConfig, '0'); // only creating one leaderboard client
   }
 
+  public close() {
+    this.dataClient.close();
+  }
+
   /**
    * Creates an instance of LeaderboardClient with 32-bit float scores.
    */

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -7,7 +7,7 @@ import {LeaderboardDataClient} from './internal/leaderboard-data-client';
 import {LeaderboardClientProps} from './leaderboard-client-props';
 import {Leaderboard} from './internal/leaderboard';
 import {ILeaderboardDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/leaderboard/ILeaderboardDataClient';
-import {Configuration, LeaderboardConfiguration, LeaderboardConfigurations} from './index';
+import {LeaderboardConfiguration, LeaderboardConfigurations} from './index';
 import {LeaderboardClientPropsWithConfig} from './internal/leaderboard-client-props-with-config';
 
 /**

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -48,7 +48,7 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
   }
 
   /**
-   * Creates an instance of LeaderboardClient with 32-bit float scores.
+   * Creates an instance of LeaderboardClient with floating point scores up until 53 bits of precision.
    */
   public leaderboard(cacheName: string, leaderboardName: string): ILeaderboard {
     return new Leaderboard(this.dataClient, cacheName, leaderboardName);

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -7,7 +7,7 @@ import {LeaderboardDataClient} from './internal/leaderboard-data-client';
 import {LeaderboardClientProps} from './leaderboard-client-props';
 import {Leaderboard} from './internal/leaderboard';
 import {ILeaderboardDataClient} from '@gomomento/sdk-core/dist/src/internal/clients/leaderboard/ILeaderboardDataClient';
-import {LeaderboardConfiguration, LeaderboardConfigurations} from './index';
+import {Configuration, LeaderboardConfiguration, LeaderboardConfigurations} from './index';
 import {LeaderboardClientPropsWithConfig} from './internal/leaderboard-client-props-with-config';
 
 /**
@@ -21,7 +21,8 @@ import {LeaderboardClientPropsWithConfig} from './internal/leaderboard-client-pr
  */
 export class PreviewLeaderboardClient implements ILeaderboardClient {
   protected readonly logger: MomentoLogger;
-  private dataClient: ILeaderboardDataClient;
+  private readonly dataClient: ILeaderboardDataClient;
+  private readonly configuration: LeaderboardConfiguration;
 
   constructor(props: LeaderboardClientProps) {
     const configuration =
@@ -30,6 +31,7 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
       ...props,
       configuration: configuration,
     };
+    this.configuration = configuration;
 
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento LeaderboardClient');
@@ -38,6 +40,11 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
 
   public close() {
     this.dataClient.close();
+    this.configuration.getMiddlewares().forEach(m => {
+      if (m.close) {
+        m.close();
+      }
+    });
   }
 
   /**

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -1,23 +1,18 @@
 import {expectWithMessage} from '@gomomento/common-integration-tests';
 
-import {GetBatch, ICacheClient} from '@gomomento/sdk-core';
+import {GetBatch} from '@gomomento/sdk-core';
 import {SetupIntegrationTestWithMiddleware} from './integration-setup';
 
 const {cacheClient, cacheName} = SetupIntegrationTestWithMiddleware();
 
-runTestWithClientCloseToMakeSureTestDoesntRunForever(cacheClient);
-export function runTestWithClientCloseToMakeSureTestDoesntRunForever(
-  cacheClient: ICacheClient
-) {
-  describe('dummy test to close client', () => {
-    it('getBatch happy path with all misses', async () => {
-      const keys = ['a', 'b', 'c', '1', '2', '3'];
-      const response = await cacheClient.getBatch(cacheName, keys);
+describe("Test exercises closing a client and jest doesn't hang", () => {
+  it('getBatch happy path with all misses', async () => {
+    const keys = ['a', 'b', 'c', '1', '2', '3'];
+    const response = await cacheClient.getBatch(cacheName, keys);
 
-      // Check get batch response
-      expectWithMessage(() => {
-        expect(response).toBeInstanceOf(GetBatch.Success);
-      }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
-    });
+    // Check get batch response
+    expectWithMessage(() => {
+      expect(response).toBeInstanceOf(GetBatch.Success);
+    }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
   });
-}
+});

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -1,0 +1,23 @@
+import {expectWithMessage} from '@gomomento/common-integration-tests';
+
+import {GetBatch, ICacheClient} from '@gomomento/sdk-core';
+import {SetupIntegrationTestWithMiddleware} from './integration-setup';
+
+const {cacheClient, cacheName} = SetupIntegrationTestWithMiddleware();
+
+runTestWithClientCloseToMakeSureTestDoesntRunForever(cacheClient);
+export function runTestWithClientCloseToMakeSureTestDoesntRunForever(
+  cacheClient: ICacheClient
+) {
+  describe('dummy test to close client', () => {
+    it('getBatch happy path with all misses', async () => {
+      const keys = ['a', 'b', 'c', '1', '2', '3'];
+      const response = await cacheClient.getBatch(cacheName, keys);
+
+      // Check get batch response
+      expectWithMessage(() => {
+        expect(response).toBeInstanceOf(GetBatch.Success);
+      }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
+    });
+  });
+}

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -13,6 +13,9 @@ import {
   VectorIndexConfigurations,
   PreviewLeaderboardClient,
   LeaderboardConfigurations,
+  ExperimentalMetricsLoggingMiddleware,
+  DefaultMomentoLoggerFactory,
+  DefaultMomentoLoggerLevel,
 } from '../../src';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 import {ITopicClient} from '@gomomento/sdk-core/dist/src/clients/ITopicClient';
@@ -80,6 +83,27 @@ export function integrationTestCacheClientProps(): CacheClientPropsWithConfig {
     credentialProvider: credsProvider(),
     defaultTtlSeconds: 1111,
   };
+}
+
+export function integrationTestCacheClientPropsWithExperimentalMetricsMiddleware(): CacheClientPropsWithConfig {
+  const loggerFactory = new DefaultMomentoLoggerFactory(
+    DefaultMomentoLoggerLevel.INFO
+  );
+  return {
+    configuration: Configurations.Laptop.latest()
+      .withClientTimeoutMillis(90000)
+      .withMiddlewares([
+        new ExperimentalMetricsLoggingMiddleware(loggerFactory),
+      ]),
+    credentialProvider: credsProvider(),
+    defaultTtlSeconds: 1111,
+  };
+}
+
+function momentoClientForTestingWithMiddleware(): CacheClient {
+  return new CacheClient(
+    integrationTestCacheClientPropsWithExperimentalMetricsMiddleware()
+  );
 }
 
 function momentoClientForTesting(): CacheClient {
@@ -185,6 +209,39 @@ export function SetupIntegrationTest(): {
     cacheClient: client,
     cacheClientWithThrowOnErrors: clientWithThrowOnErrors,
     integrationTestCacheName: cacheName,
+  };
+}
+
+export function SetupIntegrationTestWithMiddleware(): {
+  cacheClient: CacheClient;
+  cacheName: string;
+} {
+  const cacheName = testCacheName().concat('with-middleware');
+
+  beforeAll(async () => {
+    // Use a fresh client to avoid test interference with setup.
+    const momento = momentoClientForTestingWithMiddleware();
+    await deleteCacheIfExists(momento, cacheName);
+    const createResponse = await momento.createCache(cacheName);
+    if (createResponse instanceof CreateCache.Error) {
+      throw createResponse.innerException();
+    }
+  });
+
+  afterAll(async () => {
+    // Use a fresh client to avoid test interference with teardown.
+    const momento = momentoClientForTestingWithMiddleware();
+    const deleteResponse = await momento.deleteCache(cacheName);
+    if (deleteResponse instanceof DeleteCache.Error) {
+      throw deleteResponse.innerException();
+    }
+    momento.close();
+  });
+
+  const client = momentoClientForTestingWithMiddleware();
+  return {
+    cacheClient: client,
+    cacheName: cacheName,
   };
 }
 

--- a/packages/client-sdk-web/src/cache-client.ts
+++ b/packages/client-sdk-web/src/cache-client.ts
@@ -33,6 +33,11 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     const pingClient: IPingClient = createPingClient(propsWithConfiguration);
     super(controlClient, [dataClient], pingClient);
   }
+
+  public close() {
+    this.controlClient.close();
+    this.dataClients.map(dc => dc.close());
+  }
 }
 
 function createControlClient(

--- a/packages/client-sdk-web/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-control-client.ts
@@ -25,7 +25,6 @@ import {
   CacheLimits,
   TopicLimits,
 } from '@gomomento/sdk-core/dist/src/messages/cache-info';
-
 export interface ControlClientProps {
   configuration: Configuration;
   credentialProvider: CredentialProvider;
@@ -65,6 +64,13 @@ export class CacheControlClient<
       null,
       {}
     );
+  }
+
+  close() {
+    this.logger.debug('Closing cache control client');
+    // do nothing as gRPC web version doesn't expose a close() yet.
+    // this is needed as we have added close to `IControlClient` extended
+    // by both nodejs and web SDKs
   }
 
   public async createCache(name: string): Promise<CreateCache.Response> {

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -197,6 +197,13 @@ export class CacheDataClient<
     this.textEncoder = new TextEncoder();
   }
 
+  close() {
+    this.logger.debug('Closing cache control client');
+    // do nothing as gRPC web version doesn't expose a close() yet.
+    // this is needed as we have added close to `IControlClient` extended
+    // by both nodejs and web SDKs
+  }
+
   public async get(
     cacheName: string,
     key: string | Uint8Array

--- a/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
@@ -77,6 +77,13 @@ export class LeaderboardDataClient<
     );
   }
 
+  close() {
+    this.logger.debug('Closing cache control client');
+    // do nothing as gRPC web version doesn't expose a close() yet.
+    // this is needed as we have added close to `IControlClient` extended
+    // by both nodejs and web SDKs
+  }
+
   private convertMapOrRecordToElementsList(
     elements: Record<number, number> | Map<number, number>
   ): _Element[] {

--- a/packages/client-sdk-web/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-web/src/preview-leaderboard-client.ts
@@ -29,6 +29,10 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
     this.dataClient = new LeaderboardDataClient(propsWithConfig);
   }
 
+  close() {
+    this.dataClient.close();
+  }
+
   /**
    * Creates an instance of LeaderboardClient with 32-bit float scores.
    */

--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -62,7 +62,7 @@ export function runCreateDeleteListCacheTests(cacheClient: ICacheClient) {
           expect(knownCaches.length === 1).toBeTrue();
           const cache = knownCaches[0];
 
-          const expectedThroughputLimit = 1024;
+          const expectedThroughputLimit = 10240;
           const expectedItemSizeLimit = 4883;
           const expectedThrottlingLimit = 500;
           const expectedMaxTtl = 86400;

--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -63,8 +63,8 @@ export function runCreateDeleteListCacheTests(cacheClient: ICacheClient) {
           const cache = knownCaches[0];
 
           const expectedThroughputLimit = 1024;
-          const expectedItemSizeLimit = 1024;
-          const expectedThrottlingLimit = 100;
+          const expectedItemSizeLimit = 4883;
+          const expectedThrottlingLimit = 500;
           const expectedMaxTtl = 86400;
           const expectedPublishRate = 100;
           const expectedSubscriptionCount = 100;

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -343,4 +343,5 @@ export interface ICacheClient extends IControlClient, IPingClient {
     key: string | Uint8Array,
     ttlMilliseconds: number
   ): Promise<CacheDecreaseTtl.Response>;
+  close(): void;
 }

--- a/packages/core/src/clients/ILeaderboardClient.ts
+++ b/packages/core/src/clients/ILeaderboardClient.ts
@@ -2,4 +2,5 @@ import {ILeaderboard} from './ILeaderboard';
 
 export interface ILeaderboardClient {
   leaderboard(cacheName: string, leaderboardName: string): ILeaderboard;
+  close(): void;
 }

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -269,4 +269,5 @@ export interface IMomentoCache {
     key: string | Uint8Array,
     ttlMilliseconds: number
   ): Promise<CacheDecreaseTtl.Response>;
+  close(): void;
 }

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -1408,4 +1408,6 @@ export abstract class AbstractCacheClient implements ICacheClient {
       (this.nextDataClientIndex + 1) % this.dataClients.length;
     return client;
   }
+
+  abstract close(): void;
 }

--- a/packages/core/src/internal/clients/cache/IControlClient.ts
+++ b/packages/core/src/internal/clients/cache/IControlClient.ts
@@ -5,4 +5,5 @@ export interface IControlClient {
   deleteCache(cacheName: string): Promise<DeleteCache.Response>;
   listCaches(): Promise<ListCaches.Response>;
   flushCache(cacheName: string): Promise<CacheFlush.Response>;
+  close(): void;
 }

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -310,4 +310,5 @@ export interface IDataClient {
     key: string | Uint8Array,
     ttlMilliseconds: number
   ): Promise<CacheDecreaseTtl.Response>;
+  close(): void;
 }

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -497,4 +497,7 @@ export class MomentoCache implements IMomentoCache {
   ): Promise<CacheDecreaseTtl.Response> {
     return this.cacheClient.decreaseTtl(this.cacheName, key, ttlMilliseconds);
   }
+  close() {
+    this.cacheClient.close();
+  }
 }

--- a/packages/core/src/internal/clients/leaderboard/ILeaderboardDataClient.ts
+++ b/packages/core/src/internal/clients/leaderboard/ILeaderboardDataClient.ts
@@ -48,4 +48,5 @@ export interface ILeaderboardDataClient {
     cacheName: string,
     leaderboardName: string
   ): Promise<LeaderboardDelete.Response>;
+  close(): void;
 }


### PR DESCRIPTION
Adds close method to cache clients and middlewares. This allows for proper cleanup of resources, and also doesn't leave any background intervals lurking.