### PR TITLE
chore: add endpoint prefix

### DIFF
--- a/packages/common-integration-tests/src/create-delete-list-cache.ts
+++ b/packages/common-integration-tests/src/create-delete-list-cache.ts
@@ -74,9 +74,9 @@ export function runCreateDeleteListCacheTests(cacheClient: ICacheClient) {
 
           // checking that cache limits are equal to or greater than default limits
           expectWithMessage(() => {
-            expect(cache.getCacheLimits().maxThroughputKbps).toEqual(
-              expectedThroughputLimit
-            );
+            expect(
+              cache.getCacheLimits().maxThroughputKbps
+            ).toBeGreaterThanOrEqual(expectedThroughputLimit);
           }, `invalid throughput_throttling_limit (${cache.getCacheLimits().maxThroughputKbps}). ${limitsMessage}`);
           expectWithMessage(() => {
             expect(cache.getCacheLimits().maxItemSizeKb).toEqual(

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -7,6 +7,7 @@ import {
 
 export interface BaseEndpointOverride {
   baseEndpoint: string;
+  endpointPrefix?: string;
 }
 
 export type EndpointOverrides = BaseEndpointOverride | AllEndpoints;
@@ -195,7 +196,7 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
     } else if (isBaseEndpointOverride(props.endpointOverrides)) {
       this.endpointsOverridden = true;
       this.allEndpoints = populateAllEndpointsFromBaseEndpoint(
-        props.endpointOverrides.baseEndpoint
+        props.endpointOverrides
       );
     } else {
       throw new Error(

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -46,7 +46,7 @@ export function populateAllEndpointsFromBaseEndpoint(
   endpointOverride: BaseEndpointOverride
 ): AllEndpoints {
   let prefix = '';
-  if (endpointOverride.endpointPrefix !== undefined) {
+  if (endpointOverride.endpointPrefix) {
     prefix = `${endpointOverride.endpointPrefix}.`;
   }
   return {

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -3,6 +3,7 @@ import jwtDecode from 'jwt-decode';
 import {isBase64} from './validators';
 import {decodeFromBase64} from './string';
 import {PredefinedScope} from '../../auth/tokens/permission-scope';
+import {BaseEndpointOverride} from '../../auth';
 
 export interface LegacyClaims {
   /**
@@ -42,13 +43,17 @@ export interface AllEndpoints {
 }
 
 export function populateAllEndpointsFromBaseEndpoint(
-  baseEndpoint: string
+  endpointOverride: BaseEndpointOverride
 ): AllEndpoints {
+  let prefix = '';
+  if (endpointOverride.endpointPrefix !== undefined) {
+    prefix = `${endpointOverride.endpointPrefix}.`;
+  }
   return {
-    controlEndpoint: `control.${baseEndpoint}`,
-    cacheEndpoint: `cache.${baseEndpoint}`,
-    tokenEndpoint: `token.${baseEndpoint}`,
-    vectorEndpoint: `vector.${baseEndpoint}`,
+    controlEndpoint: `${prefix}control.${endpointOverride.baseEndpoint}`,
+    cacheEndpoint: `${prefix}cache.${endpointOverride.baseEndpoint}`,
+    tokenEndpoint: `${prefix}token.${endpointOverride.baseEndpoint}`,
+    vectorEndpoint: `${prefix}vector.${endpointOverride.baseEndpoint}`,
   };
 }
 
@@ -75,7 +80,9 @@ export const decodeAuthToken = (token?: string): TokenAndEndpoints => {
         throw new InvalidArgumentError('failed to parse token');
       }
       return {
-        ...populateAllEndpointsFromBaseEndpoint(base64DecodedToken.endpoint),
+        ...populateAllEndpointsFromBaseEndpoint({
+          baseEndpoint: base64DecodedToken.endpoint,
+        }),
         authToken: base64DecodedToken.api_key,
       };
     } else {

--- a/packages/core/test/unit/auth/credential-provider.test.ts
+++ b/packages/core/test/unit/auth/credential-provider.test.ts
@@ -242,4 +242,39 @@ describe('EnvMomentoTokenProvider', () => {
     expect(v1AuthProvider.getVectorEndpoint()).toEqual('vector.foo');
     expect(v1AuthProvider.areEndpointsOverridden()).toEqual(true);
   });
+
+  it('supports adding a prefix to baseEndpoint derived endpoints', () => {
+    const testEnvVarName = 'TEST_AUTH_TOKEN_ENV_VAR';
+    process.env[testEnvVarName] = fakeTestLegacyToken;
+    const legacyAuthProvider = CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: testEnvVarName,
+      endpointOverrides: {
+        baseEndpoint: 'foo',
+        endpointPrefix: 'prefix',
+      },
+    });
+    expect(legacyAuthProvider.getAuthToken()).toEqual(fakeTestLegacyToken);
+    expect(legacyAuthProvider.getControlEndpoint()).toEqual(
+      'prefix.control.foo'
+    );
+    expect(legacyAuthProvider.getCacheEndpoint()).toEqual('prefix.cache.foo');
+    expect(legacyAuthProvider.getTokenEndpoint()).toEqual('prefix.token.foo');
+    expect(legacyAuthProvider.getVectorEndpoint()).toEqual('prefix.vector.foo');
+    expect(legacyAuthProvider.areEndpointsOverridden()).toEqual(true);
+
+    process.env[testEnvVarName] = base64EncodedFakeV1AuthToken;
+    const v1AuthProvider = CredentialProvider.fromEnvironmentVariable({
+      environmentVariableName: testEnvVarName,
+      endpointOverrides: {
+        baseEndpoint: 'foo',
+        endpointPrefix: 'prefix',
+      },
+    });
+    expect(v1AuthProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);
+    expect(v1AuthProvider.getControlEndpoint()).toEqual('prefix.control.foo');
+    expect(v1AuthProvider.getCacheEndpoint()).toEqual('prefix.cache.foo');
+    expect(v1AuthProvider.getTokenEndpoint()).toEqual('prefix.token.foo');
+    expect(v1AuthProvider.getVectorEndpoint()).toEqual('prefix.vector.foo');
+    expect(v1AuthProvider.areEndpointsOverridden()).toEqual(true);
+  });
 });


### PR DESCRIPTION
Although the Web SDK contains logic to automatically prefix its endpoints with `web.` when computing them from an API key, it declines to apply that logic to endpoint overrides passed in by the user. This is problematic when using a `BaseEndpointOverride`, where endpoint URIs are dynamically computed from a common base string. This commit extends the `BaseEndpointOverride` to include an `endpointPrefix`, allowing users to supply a prefix top be prepended to each computed URI.

Similar to #1165 this PR relaxes a test assertion about throttling limits. This is intended to be a temporary change while the limits in the test environment are in flux.