### PR TITLE
chore: decouple event loop metrics into its own middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
@@ -1,0 +1,74 @@
+import {MomentoLogger, MomentoLoggerFactory} from '../../';
+import {MiddlewareRequestHandlerContext} from './middleware';
+import {
+  ExperimentalMetricsMiddleware,
+  ExperimentalMetricsMiddlewareRequestHandler,
+  ExperimentalRequestMetrics,
+} from './impl/experimental-metrics-middleware';
+
+class ExperimentalActiveRequestCountLoggingMiddlewareRequestHandler extends ExperimentalMetricsMiddlewareRequestHandler {
+  constructor(
+    parent: ExperimentalMetricsMiddleware,
+    logger: MomentoLogger,
+    context: MiddlewareRequestHandlerContext
+  ) {
+    super(parent, logger, context);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  emitMetrics(metrics: ExperimentalRequestMetrics): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * This middleware enables a periodic task to emit the active request count every second as a JSON
+ *
+ * See `advanced.ts` in the examples directory for an example of how to set up
+ * your {Configuration} to enable this middleware.
+ */
+export class ExperimentalActiveRequestCountLoggingMiddleware extends ExperimentalMetricsMiddleware {
+  private isLoggingStarted = false;
+  private readonly metricsLogInterval = 1000;
+  // this is typed as any because JS returns a number for intervalId but
+  // TS returns a NodeJS.Timeout.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private intervalId: any | null = null; // Store the interval ID
+
+  constructor(loggerFactory: MomentoLoggerFactory) {
+    super(
+      loggerFactory,
+      (p, l, c) =>
+        new ExperimentalActiveRequestCountLoggingMiddlewareRequestHandler(
+          p,
+          l,
+          c
+        )
+    );
+    if (!this.isLoggingStarted) {
+      this.isLoggingStarted = true;
+      this.startLogging();
+    }
+  }
+
+  private startLogging(): void {
+    this.intervalId = setInterval(() => {
+      const metrics = {
+        activeRequestCount: this.activeRequestCount(),
+        timestamp: Date.now(),
+      };
+      this.logger.info(JSON.stringify(metrics));
+    }, this.metricsLogInterval);
+  }
+
+  close() {
+    if (this.intervalId !== null) {
+      this.logger.debug('Stopping active request count metrics logging.');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.isLoggingStarted = false;
+      this.logger.debug('Active request count metrics logging stopped.');
+    }
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
@@ -15,6 +15,10 @@ class ExperimentalActiveRequestCountLoggingMiddlewareRequestHandler extends Expe
     super(parent, logger, context);
   }
 
+  protected recordMetrics(): void {
+    this.parent.decrementActiveRequestCount();
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   emitMetrics(metrics: ExperimentalRequestMetrics): Promise<void> {
     return Promise.resolve();

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
@@ -1,0 +1,163 @@
+import {
+  Middleware,
+  MiddlewareMessage,
+  MiddlewareMetadata,
+  MiddlewareRequestHandler,
+  MiddlewareStatus,
+} from './middleware';
+import {
+  EventLoopDelayMonitor,
+  EventLoopUtilization,
+  monitorEventLoopDelay,
+  performance,
+} from 'perf_hooks';
+import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
+
+interface StateMetrics {
+  /**
+   * The proportion of time the event loop was busy over the last second.
+   */
+  eventLoopUtilization: number;
+
+  /**
+   * The average event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMean: number;
+
+  /**
+   * The minimum event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMin: number;
+
+  /**
+   * The 50th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP50: number;
+
+  /**
+   * The 75th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP75: number;
+
+  /**
+   * The 90th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP90: number;
+
+  /**
+   * The 95th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP95: number;
+
+  /**
+   * The 99th percentile event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayP99: number;
+
+  /**
+   * The maximum event loop delay over the last second, measured in 20ms increments.
+   */
+  eventLoopDelayMax: number;
+
+  /**
+   * The timestamp when the state metrics got recorded
+   */
+  timestamp: number;
+}
+
+class ExperimentalEventLoopPerformanceMetricsMiddlewareRequestHandler
+  implements MiddlewareRequestHandler
+{
+  onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
+    return Promise.resolve(request);
+  }
+
+  onRequestMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null> {
+    return Promise.resolve(response);
+  }
+
+  onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus> {
+    return Promise.resolve(status);
+  }
+}
+
+/**
+ * This middleware enables event-loop performance metrics.It runs a periodic task specified by metricsLogInterval
+ * to gather various event-loop metrics that can be correlated with the overall application's performance. This is
+ * particularly helpful to analyze and correlate resource contention with higher network latencies.
+ */
+export class ExperimentalEventLoopPerformanceMetricsMiddleware
+  implements Middleware
+{
+  private readonly metricsLogInterval = 1000;
+  private readonly eventLoopDelayInterval = 20;
+  private eldMonitor: EventLoopDelayMonitor;
+  private elu: EventLoopUtilization;
+  private isLoggingStarted = false;
+  // this is typed as any because JS returns a number for intervalId but
+  // TS returns a NodeJS.Timeout.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private intervalId: any | null = null; // Store the interval ID
+  private readonly logger: MomentoLogger;
+
+  constructor(loggerFactory: MomentoLoggerFactory) {
+    this.logger = loggerFactory.getLogger(this);
+    if (!this.isLoggingStarted) {
+      this.isLoggingStarted = true;
+      this.startLogging();
+    }
+  }
+
+  private startLogging(): void {
+    this.eldMonitor = monitorEventLoopDelay({
+      resolution: this.eventLoopDelayInterval,
+    });
+    this.eldMonitor.enable();
+    this.elu = performance.eventLoopUtilization();
+
+    this.intervalId = setInterval(() => {
+      this.elu = performance.eventLoopUtilization(this.elu);
+      const metrics: StateMetrics = {
+        eventLoopUtilization: this.elu.utilization,
+        eventLoopDelayMean: this.eldMonitor.mean,
+        eventLoopDelayMin: this.eldMonitor.min,
+        eventLoopDelayP50: this.eldMonitor.percentile(50),
+        eventLoopDelayP75: this.eldMonitor.percentile(75),
+        eventLoopDelayP90: this.eldMonitor.percentile(90),
+        eventLoopDelayP95: this.eldMonitor.percentile(95),
+        eventLoopDelayP99: this.eldMonitor.percentile(99),
+        eventLoopDelayMax: this.eldMonitor.max,
+        timestamp: Date.now(),
+      };
+      this.logger.info(JSON.stringify(metrics));
+      this.eldMonitor.reset();
+    }, this.metricsLogInterval);
+  }
+
+  onNewRequest(): MiddlewareRequestHandler {
+    return new ExperimentalEventLoopPerformanceMetricsMiddlewareRequestHandler();
+  }
+
+  close() {
+    if (this.intervalId !== null) {
+      this.logger.debug('Stopping event loop metrics logging.');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      this.isLoggingStarted = false;
+      this.logger.debug('Event loop metrics logging stopped.');
+    }
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-metrics-logging-middleware.ts
@@ -5,59 +5,6 @@ import {
   ExperimentalRequestMetrics,
 } from './impl/experimental-metrics-middleware';
 import {MiddlewareRequestHandlerContext} from './middleware';
-import {
-  EventLoopDelayMonitor,
-  EventLoopUtilization,
-  monitorEventLoopDelay,
-  performance,
-} from 'perf_hooks';
-
-interface StateMetrics {
-  /**
-   * The proportion of time the event loop was busy over the last second.
-   */
-  eventLoopUtilization: number;
-
-  /**
-   * The average event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayMean: number;
-
-  /**
-   * The minimum event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayMin: number;
-
-  /**
-   * The 50th percentile event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayP50: number;
-
-  /**
-   * The 75th percentile event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayP75: number;
-
-  /**
-   * The 90th percentile event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayP90: number;
-
-  /**
-   * The 95th percentile event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayP95: number;
-
-  /**
-   * The 99th percentile event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayP99: number;
-
-  /**
-   * The maximum event loop delay over the last second, measured in 20ms increments.
-   */
-  eventLoopDelayMax: number;
-}
 
 class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMetricsMiddlewareRequestHandler {
   constructor(
@@ -99,60 +46,11 @@ class ExperimentalMetricsLoggingMiddlewareRequestHandler extends ExperimentalMet
  * your {Configuration} to enable this middleware.
  */
 export class ExperimentalMetricsLoggingMiddleware extends ExperimentalMetricsMiddleware {
-  private static readonly metricsLogInterval = 1000;
-  private static readonly eventLoopDelayInterval = 20;
-  private static eldMonitor: EventLoopDelayMonitor;
-  private static elu: EventLoopUtilization;
-  private static isLoggingStarted = false;
-  static numActiveRequests = 0;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private static intervalId: any | null = null; // Store the interval ID
-
   constructor(loggerFactory: MomentoLoggerFactory) {
     super(
       loggerFactory,
       (p, l, c) =>
         new ExperimentalMetricsLoggingMiddlewareRequestHandler(p, l, c)
     );
-    if (!ExperimentalMetricsLoggingMiddleware.isLoggingStarted) {
-      ExperimentalMetricsLoggingMiddleware.isLoggingStarted = true;
-      ExperimentalMetricsLoggingMiddleware.startLogging(this.logger);
-    }
-  }
-
-  private static startLogging(logger: MomentoLogger): void {
-    this.eldMonitor = monitorEventLoopDelay({
-      resolution: this.eventLoopDelayInterval,
-    });
-    this.eldMonitor.enable();
-    this.elu = performance.eventLoopUtilization();
-
-    this.intervalId = setInterval(() => {
-      this.elu = performance.eventLoopUtilization(this.elu);
-      const metrics: StateMetrics = {
-        eventLoopUtilization: this.elu.utilization,
-        eventLoopDelayMean: this.eldMonitor.mean,
-        eventLoopDelayMin: this.eldMonitor.min,
-        eventLoopDelayP50: this.eldMonitor.percentile(50),
-        eventLoopDelayP75: this.eldMonitor.percentile(75),
-        eventLoopDelayP90: this.eldMonitor.percentile(90),
-        eventLoopDelayP95: this.eldMonitor.percentile(95),
-        eventLoopDelayP99: this.eldMonitor.percentile(99),
-        eventLoopDelayMax: this.eldMonitor.max,
-      };
-      logger.info(JSON.stringify(metrics));
-      this.eldMonitor.reset();
-    }, this.metricsLogInterval);
-  }
-
-  close() {
-    if (ExperimentalMetricsLoggingMiddleware.intervalId) {
-      this.logger.debug('Stopping Metrics logging.');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      clearInterval(ExperimentalMetricsLoggingMiddleware.intervalId);
-      ExperimentalMetricsLoggingMiddleware.intervalId = null;
-      ExperimentalMetricsLoggingMiddleware.isLoggingStarted = false;
-      this.logger.debug('Metrics logging stopped.');
-    }
   }
 }

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -6,7 +6,7 @@ import {ExperimentalActiveRequestCountLoggingMiddleware} from './experimental-ac
 import {Middleware} from './middleware';
 import {ExperimentalMetricsCsvMiddleware} from './experimental-metrics-csv-middleware';
 
-interface MiddlewareOptions {
+interface ExperimenalMetricsMiddlewareOptions {
   eventLoopMetrics?: boolean;
   perRequestMetrics?: boolean;
   activeRequestCountMetrics?: boolean;
@@ -17,7 +17,7 @@ interface MiddlewareOptions {
 export class MiddlewareFactory {
   public static createMetricsMiddlewares(
     loggerFactory: MomentoLoggerFactory,
-    options: MiddlewareOptions
+    options: ExperimenalMetricsMiddlewareOptions
   ): Middleware[] {
     const middlewares = [];
 

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -19,7 +19,7 @@ export class MiddlewareFactory {
     loggerFactory: MomentoLoggerFactory,
     options: ExperimenalMetricsMiddlewareOptions
   ): Middleware[] {
-    const middlewares = [];
+    const middlewares: Middleware[] = [];
 
     if (options.eventLoopMetrics === true) {
       middlewares.push(

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -7,9 +7,9 @@ import {Middleware} from './middleware';
 import {ExperimentalMetricsCsvMiddleware} from './experimental-metrics-csv-middleware';
 
 interface ExperimenalMetricsMiddlewareOptions {
-  eventLoopMetrics?: boolean;
-  perRequestMetrics?: boolean;
-  activeRequestCountMetrics?: boolean;
+  eventLoopMetricsLog?: boolean;
+  perRequestMetricsLog?: boolean;
+  activeRequestCountMetricsLog?: boolean;
   perRequestMetricsCSVPath?: string;
 }
 
@@ -21,7 +21,7 @@ export class MiddlewareFactory {
   ): Middleware[] {
     const middlewares: Middleware[] = [];
 
-    if (options.eventLoopMetrics === true) {
+    if (options.eventLoopMetricsLog === true) {
       middlewares.push(
         new ExperimentalEventLoopPerformanceMetricsMiddleware(loggerFactory)
       );
@@ -33,11 +33,11 @@ export class MiddlewareFactory {
           loggerFactory
         )
       );
-    } else if (options.perRequestMetrics === true) {
+    } else if (options.perRequestMetricsLog === true) {
       middlewares.push(new ExperimentalMetricsLoggingMiddleware(loggerFactory));
     }
 
-    if (options.activeRequestCountMetrics === true) {
+    if (options.activeRequestCountMetricsLog === true) {
       middlewares.push(
         new ExperimentalActiveRequestCountLoggingMiddleware(loggerFactory)
       );

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -1,0 +1,48 @@
+// The options interface for clarity and type safety
+import {MomentoLoggerFactory} from '@gomomento/sdk-core';
+import {ExperimentalEventLoopPerformanceMetricsMiddleware} from './experimental-event-loop-perf-middleware';
+import {ExperimentalMetricsLoggingMiddleware} from './experimental-metrics-logging-middleware';
+import {ExperimentalActiveRequestCountLoggingMiddleware} from './experimental-active-request-count-middleware';
+import {Middleware} from './middleware';
+import {ExperimentalMetricsCsvMiddleware} from './experimental-metrics-csv-middleware';
+
+interface MiddlewareOptions {
+  eventLoopMetrics?: boolean;
+  perRequestMetrics?: boolean;
+  activeRequestCountMetrics?: boolean;
+  perRequestMetricsCSVPath?: string;
+}
+
+// Static class encapsulating the factory functionality
+export class MiddlewareFactory {
+  public static createMetricsMiddlewares(
+    loggerFactory: MomentoLoggerFactory,
+    options: MiddlewareOptions
+  ): Middleware[] {
+    const middlewares = [];
+
+    if (options.eventLoopMetrics === true) {
+      middlewares.push(
+        new ExperimentalEventLoopPerformanceMetricsMiddleware(loggerFactory)
+      );
+    }
+    if (options.perRequestMetricsCSVPath !== undefined) {
+      middlewares.push(
+        new ExperimentalMetricsCsvMiddleware(
+          options.perRequestMetricsCSVPath,
+          loggerFactory
+        )
+      );
+    } else if (options.perRequestMetrics === true) {
+      middlewares.push(new ExperimentalMetricsLoggingMiddleware(loggerFactory));
+    }
+
+    if (options.activeRequestCountMetrics === true) {
+      middlewares.push(
+        new ExperimentalActiveRequestCountLoggingMiddleware(loggerFactory)
+      );
+    }
+
+    return middlewares;
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/impl/experimental-metrics-middleware.ts
@@ -75,7 +75,7 @@ export interface ExperimentalRequestMetrics {
 export abstract class ExperimentalMetricsMiddlewareRequestHandler
   implements MiddlewareRequestHandler
 {
-  private readonly parent: ExperimentalMetricsMiddleware;
+  protected readonly parent: ExperimentalMetricsMiddleware;
   protected readonly logger: MomentoLogger;
   private readonly connectionID: string;
 
@@ -149,7 +149,7 @@ export abstract class ExperimentalMetricsMiddlewareRequestHandler
     return this.receivedResponseBody && this.receivedResponseStatus;
   }
 
-  private recordMetrics(): void {
+  protected recordMetrics(): void {
     const endTime = new Date().getTime();
     const metrics: ExperimentalRequestMetrics = {
       momento: {

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -226,7 +226,10 @@ export {
 export {ExperimentalRequestLoggingMiddleware} from './config/middleware/experimental-request-logging-middleware';
 export {ExperimentalMetricsCsvMiddleware} from './config/middleware/experimental-metrics-csv-middleware';
 export {ExperimentalMetricsLoggingMiddleware} from './config/middleware/experimental-metrics-logging-middleware';
+export {ExperimentalActiveRequestCountLoggingMiddleware} from './config/middleware/experimental-active-request-count-middleware';
+export {ExperimentalEventLoopPerformanceMetricsMiddleware} from './config/middleware/experimental-event-loop-perf-middleware';
 export {ExampleAsyncMiddleware} from './config/middleware/example-async-middleware';
+export {MiddlewareFactory} from './config/middleware/experimental-middleware-factory';
 
 export {
   ICacheClient,

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -5,7 +5,7 @@ import {
   Configurations,
   DefaultMomentoLoggerFactory,
   DefaultMomentoLoggerLevel,
-  ExperimentalEventLoopPerformanceMetricsMiddleware,
+  MiddlewareFactory,
 } from '../../src';
 
 describe("Test exercises closing a client and jest doesn't hang", () => {
@@ -24,9 +24,12 @@ function integrationTestCacheClientPropsWithExperimentalMetricsMiddleware(): Cac
   return {
     configuration: Configurations.Laptop.latest(loggerFactory)
       .withClientTimeoutMillis(90000)
-      .withMiddlewares([
-        new ExperimentalEventLoopPerformanceMetricsMiddleware(loggerFactory),
-      ]),
+      .withMiddlewares(
+        MiddlewareFactory.createMetricsMiddlewares(loggerFactory, {
+          eventLoopMetricsLog: true,
+          activeRequestCountMetricsLog: true,
+        })
+      ),
     credentialProvider: credsProvider(),
     defaultTtlSeconds: 1111,
   };


### PR DESCRIPTION
This PR extracts the event loop metrics from the metrics logging middleware. The metrics logging middleware is per request and can take a toll on customer's CW bills. We'd want to sometimes measure event loop alone without needing request level metrics so a separate middleware is better for that. A factory method is provided for different options to enable the kind of metrics the user wants, to avoid initializing the middleware for each one.

Usage:

```
const middlewares: Middleware[] = MiddlewareFactory.createMetricsMiddleware(middlewaresExampleloggerFactory, {
    eventLoopMetrics: true,
    activeRequestCountMetrics: true,
    perRequestMetrics: true,
  });
  const middlewaresExampleClient = await CacheClient.create({
    configuration: Configurations.Laptop.v1(middlewaresExampleloggerFactory)
      .withMiddlewares(middlewares),
    credentialProvider: CredentialProvider.fromEnvironmentVariable({
      environmentVariableName: 'MOMENTO_API_KEY',
    }),
    defaultTtlSeconds: 60,
  });
```