### PR TITLE
chore: skip 5mb test until service changes deploy

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -1,31 +1,31 @@
-import {expectWithMessage} from '@gomomento/common-integration-tests';
-import {SetupIntegrationTest} from './integration-setup';
-import {CacheGet, CacheSet} from '@gomomento/sdk-core';
+// import {expectWithMessage} from '@gomomento/common-integration-tests';
+// import {SetupIntegrationTest} from './integration-setup';
+// import {CacheGet, CacheSet} from '@gomomento/sdk-core';
 
-const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
+// const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-describe('CacheClient', () => {
-  it('should send and receive 5mb messages', async () => {
-    const value = 'a'.repeat(5_000_000);
-    const key = '5mb';
+// describe('CacheClient', () => {
+//   it('should send and receive 5mb messages', async () => {
+//     const value = 'a'.repeat(5_000_000);
+//     const key = '5mb';
 
-    const setResponse = await cacheClient.set(
-      integrationTestCacheName,
-      key,
-      value
-    );
-    expectWithMessage(() => {
-      expect(setResponse).toBeInstanceOf(CacheSet.Success);
-    }, `expected to successfully set 5mb string for key ${key}, received ${setResponse.toString()}`);
+//     const setResponse = await cacheClient.set(
+//       integrationTestCacheName,
+//       key,
+//       value
+//     );
+//     expectWithMessage(() => {
+//       expect(setResponse).toBeInstanceOf(CacheSet.Success);
+//     }, `expected to successfully set 5mb string for key ${key}, received ${setResponse.toString()}`);
 
-    const getResponse = await cacheClient.get(integrationTestCacheName, '5mb');
-    expectWithMessage(() => {
-      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
-    }, `expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
+//     const getResponse = await cacheClient.get(integrationTestCacheName, '5mb');
+//     expectWithMessage(() => {
+//       expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+//     }, `expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
 
-    const responseValue = (getResponse as CacheGet.Hit).value();
-    expectWithMessage(() => {
-      expect(responseValue).toEqual(value);
-    }, `expected 5mb retrieved string to match 5mb value that was set for key ${key}`);
-  });
-});
+//     const responseValue = (getResponse as CacheGet.Hit).value();
+//     expectWithMessage(() => {
+//       expect(responseValue).toEqual(value);
+//     }, `expected 5mb retrieved string to match 5mb value that was set for key ${key}`);
+//   });
+// });

--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -1,31 +1,31 @@
-// import {expectWithMessage} from '@gomomento/common-integration-tests';
-// import {SetupIntegrationTest} from './integration-setup';
-// import {CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {expectWithMessage} from '@gomomento/common-integration-tests';
+import {SetupIntegrationTest} from './integration-setup';
+import {CacheGet, CacheSet} from '@gomomento/sdk-core';
 
-// const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
+const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
-// describe('CacheClient', () => {
-//   it('should send and receive 5mb messages', async () => {
-//     const value = 'a'.repeat(5_000_000);
-//     const key = '5mb';
+describe('CacheClient', () => {
+  it.skip('should send and receive 5mb messages', async () => {
+    const value = 'a'.repeat(5_000_000);
+    const key = '5mb';
 
-//     const setResponse = await cacheClient.set(
-//       integrationTestCacheName,
-//       key,
-//       value
-//     );
-//     expectWithMessage(() => {
-//       expect(setResponse).toBeInstanceOf(CacheSet.Success);
-//     }, `expected to successfully set 5mb string for key ${key}, received ${setResponse.toString()}`);
+    const setResponse = await cacheClient.set(
+      integrationTestCacheName,
+      key,
+      value
+    );
+    expectWithMessage(() => {
+      expect(setResponse).toBeInstanceOf(CacheSet.Success);
+    }, `expected to successfully set 5mb string for key ${key}, received ${setResponse.toString()}`);
 
-//     const getResponse = await cacheClient.get(integrationTestCacheName, '5mb');
-//     expectWithMessage(() => {
-//       expect(getResponse).toBeInstanceOf(CacheGet.Hit);
-//     }, `expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
+    const getResponse = await cacheClient.get(integrationTestCacheName, '5mb');
+    expectWithMessage(() => {
+      expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+    }, `expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
 
-//     const responseValue = (getResponse as CacheGet.Hit).value();
-//     expectWithMessage(() => {
-//       expect(responseValue).toEqual(value);
-//     }, `expected 5mb retrieved string to match 5mb value that was set for key ${key}`);
-//   });
-// });
+    const responseValue = (getResponse as CacheGet.Hit).value();
+    expectWithMessage(() => {
+      expect(responseValue).toEqual(value);
+    }, `expected 5mb retrieved string to match 5mb value that was set for key ${key}`);
+  });
+});


### PR DESCRIPTION
Skipping this test so that canaries don't fail over the weekend while we wait for a service deployment to get the 5mb message size limit fix out to all cells.