### PR TITLE
chore: expand eager connection failure log

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -229,7 +229,11 @@ export class CacheDataClient implements IDataClient {
         .watchConnectivityState(currentState, deadline, (error?: Error) => {
           if (error) {
             this.logger.error(
-              `Unable to eagerly connect to Momento. Please contact Momento if this persists. currentState: ${currentState}, ${error.name} : ${error.message}, stack: ${error.stack ? error.stack : 'Stack trace undefined'}`
+              `Unable to eagerly connect to Momento. Please contact Momento if this persists. currentState: ${currentState}, errorName: ${
+                error.name
+              } : errorMessage: ${error.message}, errorStack: ${
+                error.stack ? error.stack : 'Stack trace undefined'
+              }`
             );
             resolve();
             return;

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -229,7 +229,7 @@ export class CacheDataClient implements IDataClient {
         .watchConnectivityState(currentState, deadline, (error?: Error) => {
           if (error) {
             this.logger.error(
-              `Unable to eagerly connect to Momento. Please contact Momento if this persists. currentState: ${currentState}, ${error.name} : ${error.message} `
+              `Unable to eagerly connect to Momento. Please contact Momento if this persists. currentState: ${currentState}, ${error.name} : ${error.message}, stack: ${error.stack ? error.stack : 'Stack trace undefined'}`
             );
             resolve();
             return;

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -229,8 +229,7 @@ export class CacheDataClient implements IDataClient {
         .watchConnectivityState(currentState, deadline, (error?: Error) => {
           if (error) {
             this.logger.error(
-              `Unable to connect to Momento: ${error.name}. currentState: ${currentState} :
-              Please contact Momento if this persists. `
+              `Unable to eagerly connect to Momento. Please contact Momento if this persists. currentState: ${currentState}, ${error.name} : ${error.message} `
             );
             resolve();
             return;


### PR DESCRIPTION
Clearvector log had an eager connection failure that truncated the stack trace :( 
CurrentState 1 indicates `CONNECTING` and it took 40 seconds for successful requests to show up.

```
| 1709840715443 | 2024-03-07T19:45:15.443Z e614536c-623d-5393-be95-0d087951900d ERROR [2024-03-07T19:45:15.442Z] ERROR (Momento: _CacheDataClient): Unable to connect to Momento: Error. currentState: 1 :               Please contact Momento if this persists.
```