### PR TITLE
chore: dont eagerly connect to clients in unit tests

### DIFF
--- a/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
@@ -5,7 +5,6 @@ import {
   SimpleCacheClient,
   CreateCache,
   StringMomentoTokenProvider,
-  CredentialProvider,
   MomentoErrorCode,
 } from '../../src';
 import {SimpleCacheClientProps} from '../../src/cache-client-props';
@@ -32,11 +31,9 @@ describe('CacheClient', () => {
 
   it('cannot create/get cache with invalid name', async () => {
     const invalidCacheNames = ['', '    '];
-    const momento = await CacheClient.create({
+    const momento = new CacheClient({
       configuration: configuration,
-      credentialProvider: CredentialProvider.fromEnvironmentVariable({
-        environmentVariableName: 'TEST_AUTH_TOKEN',
-      }),
+      credentialProvider: credentialProvider,
       defaultTtlSeconds: 100,
     });
     for (const name of invalidCacheNames) {
@@ -54,7 +51,7 @@ describe('CacheClient', () => {
       const invalidTimeoutConfig = configuration.withTransportStrategy(
         configuration.getTransportStrategy().withClientTimeoutMillis(-1)
       );
-      await CacheClient.create({
+      new CacheClient({
         configuration: invalidTimeoutConfig,
         credentialProvider: credentialProvider,
         defaultTtlSeconds: 100,
@@ -68,7 +65,7 @@ describe('CacheClient', () => {
   });
   it('createWithEagerConnection throws if it cannot connect', async () => {
     try {
-      await CacheClient.create({
+      new CacheClient({
         configuration: configuration,
         credentialProvider: credentialProvider,
         defaultTtlSeconds: 100,
@@ -88,7 +85,7 @@ describe('CacheClient', () => {
   });
   it('cannot create a client with an invalid default TTL', async () => {
     try {
-      await CacheClient.create({
+      new CacheClient({
         configuration: configuration,
         credentialProvider: credentialProvider,
         defaultTtlSeconds: -100,
@@ -101,7 +98,7 @@ describe('CacheClient', () => {
     }
 
     try {
-      await CacheClient.create({
+      new CacheClient({
         configuration: configuration,
         credentialProvider: credentialProvider,
         defaultTtlSeconds: 10.5,


### PR DESCRIPTION
We shouldn't eagerly connect to clients from unit tests as its not intended to make network requests and is validating other static code paths using the client.
