### PR TITLE
feat: add middleware for emitting GC events

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
@@ -97,6 +97,8 @@ class ExperimentalEventLoopPerformanceMetricsMiddlewareRequestHandler
  * This middleware enables event-loop performance metrics.It runs a periodic task specified by metricsLogInterval
  * to gather various event-loop metrics that can be correlated with the overall application's performance. This is
  * particularly helpful to analyze and correlate resource contention with higher network latencies.
+ *
+ * See {@link StateMetrics} for each heuristic/metric and their description.
  */
 export class ExperimentalEventLoopPerformanceMetricsMiddleware
   implements Middleware

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
@@ -6,11 +6,9 @@ import {
   MiddlewareStatus,
 } from './middleware';
 import {
-  constants,
   EventLoopDelayMonitor,
   EventLoopUtilization,
   monitorEventLoopDelay,
-  PerformanceEntry,
   performance,
 } from 'perf_hooks';
 import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
@@ -120,21 +118,6 @@ export class ExperimentalEventLoopPerformanceMetricsMiddleware
       this.isLoggingStarted = true;
       this.startLogging();
     }
-
-    const obs = new PerformanceObserver(items => {
-      items
-        .getEntries()
-        .filter(
-          item =>
-            (item as PerformanceEntry).kind ===
-            constants.NODE_PERFORMANCE_GC_MAJOR
-        )
-        .forEach(item => {
-          console.log(`Major GC event`);
-          console.log(JSON.stringify(item));
-        });
-    });
-    obs.observe({entryTypes: ['gc']});
   }
 
   private startLogging(): void {

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
@@ -6,9 +6,11 @@ import {
   MiddlewareStatus,
 } from './middleware';
 import {
+  constants,
   EventLoopDelayMonitor,
   EventLoopUtilization,
   monitorEventLoopDelay,
+  PerformanceEntry,
   performance,
 } from 'perf_hooks';
 import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
@@ -118,6 +120,21 @@ export class ExperimentalEventLoopPerformanceMetricsMiddleware
       this.isLoggingStarted = true;
       this.startLogging();
     }
+
+    const obs = new PerformanceObserver(items => {
+      items
+        .getEntries()
+        .filter(
+          item =>
+            (item as PerformanceEntry).kind ===
+            constants.NODE_PERFORMANCE_GC_MAJOR
+        )
+        .forEach(item => {
+          console.log(`Major GC event`);
+          console.log(JSON.stringify(item));
+        });
+    });
+    obs.observe({entryTypes: ['gc']});
   }
 
   private startLogging(): void {

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
@@ -5,12 +5,8 @@ import {
   MiddlewareRequestHandler,
   MiddlewareStatus,
 } from './middleware';
-import {constants, PerformanceEntry, PerformanceObserver} from 'perf_hooks';
+import {constants, PerformanceObserver} from 'perf_hooks';
 import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
-
-interface GCEvent extends PerformanceEntry {
-  timestamp: number;
-}
 
 class ExperimentalGarbageCollectionPerformanceMetricsMiddlewareRequestHandler
   implements MiddlewareRequestHandler
@@ -63,11 +59,15 @@ export class ExperimentalGarbageCollectionPerformanceMetricsMiddleware
           item => item.kind === constants.NODE_PERFORMANCE_GC_MAJOR
         )
         .forEach(item => {
-          const gcEvent: GCEvent = {
-            ...item,
+          const gcEventObject = {
+            entryType: item.entryType,
+            startTime: item.startTime,
+            duration: item.duration,
+            kind: item.kind,
+            flags: item.flags,
             timestamp: Date.now(),
           };
-          this.logger.info(JSON.stringify(gcEvent));
+          this.logger.info(JSON.stringify(gcEventObject));
         });
     });
     this.gcObserver.observe({entryTypes: ['gc']});

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
@@ -1,0 +1,87 @@
+import {
+  Middleware,
+  MiddlewareMessage,
+  MiddlewareMetadata,
+  MiddlewareRequestHandler,
+  MiddlewareStatus,
+} from './middleware';
+import {constants, PerformanceEntry} from 'perf_hooks';
+import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
+
+interface GCEvent extends PerformanceEntry {
+  timestamp: number;
+}
+
+class ExperimentalGarbageCollectionPerformanceMetricsMiddlewareRequestHandler
+  implements MiddlewareRequestHandler
+{
+  onRequestBody(request: MiddlewareMessage): Promise<MiddlewareMessage> {
+    return Promise.resolve(request);
+  }
+
+  onRequestMetadata(metadata: MiddlewareMetadata): Promise<MiddlewareMetadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseMetadata(
+    metadata: MiddlewareMetadata
+  ): Promise<MiddlewareMetadata> {
+    return Promise.resolve(metadata);
+  }
+
+  onResponseBody(
+    response: MiddlewareMessage | null
+  ): Promise<MiddlewareMessage | null> {
+    return Promise.resolve(response);
+  }
+
+  onResponseStatus(status: MiddlewareStatus): Promise<MiddlewareStatus> {
+    return Promise.resolve(status);
+  }
+}
+
+/**
+ * This middleware enables garbage collection metrics. It subscribers to a GC performance observer provided by
+ * node's built-in performance hooks, and logs key GC events.
+ */
+export class ExperimentalGarbageCollectionPerformanceMetricsMiddleware
+  implements Middleware
+{
+  private readonly logger: MomentoLogger;
+  private readonly gcObserver: PerformanceObserver;
+
+  constructor(loggerFactory: MomentoLoggerFactory) {
+    this.logger = loggerFactory.getLogger(this);
+
+    this.gcObserver = new PerformanceObserver(items => {
+      items
+        .getEntries()
+        .filter(
+          // NODE_PERFORMANCE_GC_MAJOR indicates a major GC event such as STW (stop-the-world) pauses
+          // and other long delays. This filter is to control the volume of GC logs if we were to enable
+          // this on a customer's client.
+          item =>
+            (item as PerformanceEntry).kind ===
+            constants.NODE_PERFORMANCE_GC_MAJOR
+        )
+        .forEach(item => {
+          const performanceEntry: PerformanceEntry =
+            item.toJSON() as PerformanceEntry;
+          const gcEvent: GCEvent = {
+            ...performanceEntry,
+            timestamp: Date.now(),
+          };
+          this.logger.info(JSON.stringify(gcEvent));
+        });
+    });
+    this.gcObserver.observe({entryTypes: ['gc']});
+  }
+
+  onNewRequest(): MiddlewareRequestHandler {
+    return new ExperimentalGarbageCollectionPerformanceMetricsMiddlewareRequestHandler();
+  }
+
+  close() {
+    this.gcObserver.disconnect();
+  }
+}

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
@@ -38,7 +38,18 @@ class ExperimentalGarbageCollectionPerformanceMetricsMiddlewareRequestHandler
 
 /**
  * This middleware enables garbage collection metrics. It subscribers to a GC performance observer provided by
- * node's built-in performance hooks, and logs key GC events.
+ * node's built-in performance hooks, and logs key GC events. A sample log looks like:
+ *
+ * {
+ *     "entryType": "gc",
+ *     "startTime": 8221.879917,
+ *     "duration": 2.8905000016093254,  <-- most important field to analyze for stop the world events, measured in milliseconds.
+ *     "detail": {
+ *         "kind": 4,  <-- constant for NODE_PERFORMANCE_GC_MAJOR. `MAJOR` events might point to GC events causing long delays.
+ *         "flags": 32
+ *     },
+ *     "timestamp": 1710300309368
+ * }
  */
 export class ExperimentalGarbageCollectionPerformanceMetricsMiddleware
   implements Middleware

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
@@ -5,7 +5,7 @@ import {
   MiddlewareRequestHandler,
   MiddlewareStatus,
 } from './middleware';
-import {constants, PerformanceEntry} from 'perf_hooks';
+import {constants, PerformanceEntry, PerformanceObserver} from 'perf_hooks';
 import {MomentoLogger, MomentoLoggerFactory} from '@gomomento/sdk-core';
 
 interface GCEvent extends PerformanceEntry {
@@ -60,15 +60,11 @@ export class ExperimentalGarbageCollectionPerformanceMetricsMiddleware
           // NODE_PERFORMANCE_GC_MAJOR indicates a major GC event such as STW (stop-the-world) pauses
           // and other long delays. This filter is to control the volume of GC logs if we were to enable
           // this on a customer's client.
-          item =>
-            (item as PerformanceEntry).kind ===
-            constants.NODE_PERFORMANCE_GC_MAJOR
+          item => item.kind === constants.NODE_PERFORMANCE_GC_MAJOR
         )
         .forEach(item => {
-          const performanceEntry: PerformanceEntry =
-            item.toJSON() as PerformanceEntry;
           const gcEvent: GCEvent = {
-            ...performanceEntry,
+            ...item,
             timestamp: Date.now(),
           };
           this.logger.info(JSON.stringify(gcEvent));

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -5,9 +5,11 @@ import {ExperimentalMetricsLoggingMiddleware} from './experimental-metrics-loggi
 import {ExperimentalActiveRequestCountLoggingMiddleware} from './experimental-active-request-count-middleware';
 import {Middleware} from './middleware';
 import {ExperimentalMetricsCsvMiddleware} from './experimental-metrics-csv-middleware';
+import {ExperimentalGarbageCollectionPerformanceMetricsMiddleware} from './experimental-garbage-collection-middleware';
 
 interface ExperimenalMetricsMiddlewareOptions {
   eventLoopMetricsLog?: boolean;
+  garbageCollectionMetricsLog?: boolean;
   perRequestMetricsLog?: boolean;
   activeRequestCountMetricsLog?: boolean;
   perRequestMetricsCSVPath?: string;
@@ -40,6 +42,14 @@ export class MiddlewareFactory {
     if (options.activeRequestCountMetricsLog === true) {
       middlewares.push(
         new ExperimentalActiveRequestCountLoggingMiddleware(loggerFactory)
+      );
+    }
+
+    if (options.garbageCollectionMetricsLog === true) {
+      middlewares.push(
+        new ExperimentalGarbageCollectionPerformanceMetricsMiddleware(
+          loggerFactory
+        )
       );
     }
 

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-middleware-factory.ts
@@ -7,11 +7,30 @@ import {Middleware} from './middleware';
 import {ExperimentalMetricsCsvMiddleware} from './experimental-metrics-csv-middleware';
 import {ExperimentalGarbageCollectionPerformanceMetricsMiddleware} from './experimental-garbage-collection-middleware';
 
-interface ExperimenalMetricsMiddlewareOptions {
+interface ExperimentalMetricsMiddlewareOptions {
+  /**
+   * Setting this to true will emit a periodic JSON log for the event loop profile of the nodeJS process.
+   */
   eventLoopMetricsLog?: boolean;
+  /**
+   * Setting this to true will emit a JSON log during major GC events, as observed by node's perf_hooks.
+   */
   garbageCollectionMetricsLog?: boolean;
+  /**
+   * Setting this to true will emit a JSON log for each Momento request, that includes the client-side latency
+   * among other request profile statistics.
+   */
   perRequestMetricsLog?: boolean;
+  /**
+   * Setting this to true will emit a periodic JSON log for active Momento request count on the nodeJS process
+   * as observed when the periodic task wakes up. This can be handy with eventLoopMetricsLog to observe the event loop
+   * delay against the maximum number of concurrent connections the application is observing.
+   */
   activeRequestCountMetricsLog?: boolean;
+  /**
+   * Setting this to true will write a CSV recrd for each Momento request, that includes the client-side latency
+   * among other request profile statistics. The path is the file path on your disk where the CSV file is stored.
+   */
   perRequestMetricsCSVPath?: string;
 }
 
@@ -19,7 +38,7 @@ interface ExperimenalMetricsMiddlewareOptions {
 export class MiddlewareFactory {
   public static createMetricsMiddlewares(
     loggerFactory: MomentoLoggerFactory,
-    options: ExperimenalMetricsMiddlewareOptions
+    options: ExperimentalMetricsMiddlewareOptions
   ): Middleware[] {
     const middlewares: Middleware[] = [];
 

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -228,6 +228,7 @@ export {ExperimentalMetricsCsvMiddleware} from './config/middleware/experimental
 export {ExperimentalMetricsLoggingMiddleware} from './config/middleware/experimental-metrics-logging-middleware';
 export {ExperimentalActiveRequestCountLoggingMiddleware} from './config/middleware/experimental-active-request-count-middleware';
 export {ExperimentalEventLoopPerformanceMetricsMiddleware} from './config/middleware/experimental-event-loop-perf-middleware';
+export {ExperimentalGarbageCollectionPerformanceMetricsMiddleware} from './config/middleware/experimental-garbage-collection-middleware';
 export {ExampleAsyncMiddleware} from './config/middleware/example-async-middleware';
 export {MiddlewareFactory} from './config/middleware/experimental-middleware-factory';
 

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -15,7 +15,6 @@ describe("Test exercises closing a client and jest doesn't hang", () => {
       client = await CacheClient.create(
         integrationTestCacheClientPropsWithExperimentalMetricsMiddleware()
       );
-      client.close();
     } finally {
       if (client) client.close();
     }

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -9,11 +9,16 @@ import {
 } from '../../src';
 
 describe("Test exercises closing a client and jest doesn't hang", () => {
-  it('constructs a client with background task and closes it', () => {
-    const client = new CacheClient(
-      integrationTestCacheClientPropsWithExperimentalMetricsMiddleware()
-    );
-    client.close();
+  it('constructs a client with background task and closes it', async () => {
+    let client;
+    try {
+      client = await CacheClient.create(
+        integrationTestCacheClientPropsWithExperimentalMetricsMiddleware()
+      );
+      client.close();
+    } finally {
+      if (client) client.close();
+    }
   });
 });
 

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -27,6 +27,7 @@ function integrationTestCacheClientPropsWithExperimentalMetricsMiddleware(): Cac
       .withMiddlewares(
         MiddlewareFactory.createMetricsMiddlewares(loggerFactory, {
           eventLoopMetricsLog: true,
+          garbageCollectionMetricsLog: true,
           activeRequestCountMetricsLog: true,
         })
       ),


### PR DESCRIPTION
This PR adds a middleware to emit GC events. It subscriber's to node's built-in performance hook for garbage collection. The data emitted here is [similar](https://nodejs.org/en/learn/diagnostics/memory/using-gc-traces) to what we'd get through `--trace-gc` on a nodejs process with more control. The cadence is dictated by the the hook's observer, so we filter out major GC events  to log through filter `NODE_PERFORMANCE_GC_MAJOR`. This [SO post](https://stackoverflow.com/questions/74165486/gc-operation-types-in-nodejs) is the closest to documentation provided for these flags unfortunately, and the [official docs](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#performanceentryflags) don't describe it properly. These logs however were printed 5-6 times in a 1 minute run of the load-generator, so aren't very verbose. I see much more logs/noise if I enable everything, so I'd like to start with this flag on a customer's account as major events seem like what we are more interested in.

A sample log:

```
[2024-03-13T03:25:09.368Z] INFO (Momento: ExperimentalGarbageCollectionPerformanceMetricsMiddleware):
{
    "entryType": "gc",
    "startTime": 8221.879917,
    "duration": 2.8905000016093254,
    "detail": {
        "kind": 4,
        "flags": 32
    },
    "timestamp": 1710300309368
}
```

The `kind` 4 indicates `NODE_PERFORMANCE_GC_MAJOR`. I'll read up more on `flags`. `duration` is the one we are most interested in. `timestamp` is something I added for plotting, and `startTime` is kinda bleh as it measures from start of nodeJS process. Might be good to plot GC duration over time though so let it stay as is.