### PR TITLE
fix: cleanups to topic subscription example code

### DIFF
--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -1062,20 +1062,19 @@ async function example_API_TopicSubscribe(topicClient: TopicClient) {
       return;
     },
     onItem: (item: TopicItem) => {
-      console.log(`Publishing values to the topic 'test-topic': ${item.value().toString()}`);
+      console.log(`Received an item on subscription for 'test-topic': ${item.value().toString()}`);
       return;
     },
   });
   if (result instanceof TopicSubscribe.Subscription) {
     console.log("Successfully subscribed to topic 'test-topic'");
 
+    console.log("Publishing a value to the topic 'test-topic'");
     // Publish a value
     await topicClient.publish('test-cache', 'test-topic', 'test-value');
 
-    // Wait for published values to be received.
-    setTimeout(() => {
-      console.log('Waiting for the published values');
-    }, 2000);
+    console.log('Waiting for the published value to be received.');
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     // Need to close the stream before the example ends or else the example will hang.
     result.unsubscribe();


### PR DESCRIPTION
This commit just makes some minor cleanups to the logic in the
example code for topic subscriptions. In particular:

* Change the wording of the messages a bit so that it's clear that
  the `OnItem` represents when a message was received rather than
  published.
* Change the `setTimeout` call so that we are awaiting it to ensure
  that the published message has time to get recieved on the
  subscription. Previously this call to setTimeout was not being
  awaited, so we just moved on to the subscription cancellation
  immediately and then logged the waiting message 2 seconds later :)
