### PR TITLE
chore: unskip 5mb test

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -5,7 +5,7 @@ import {CacheGet, CacheSet} from '@gomomento/sdk-core';
 const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
 describe('CacheClient', () => {
-  it.skip('should send and receive 5mb messages', async () => {
+  it('should send and receive 5mb messages', async () => {
     const value = 'a'.repeat(5_000_000);
     const key = '5mb';
 


### PR DESCRIPTION
Unskipping this test now that canary cells have the 5mb fix