### PR TITLE
chore: add incremental gc metrics to middleware

### DIFF
--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-garbage-collection-middleware.ts
@@ -67,7 +67,11 @@ export class ExperimentalGarbageCollectionPerformanceMetricsMiddleware
           // NODE_PERFORMANCE_GC_MAJOR indicates a major GC event such as STW (stop-the-world) pauses
           // and other long delays. This filter is to control the volume of GC logs if we were to enable
           // this on a customer's client.
-          item => item.kind === constants.NODE_PERFORMANCE_GC_MAJOR
+          // NODE_PERFORMANCE_GC_INCREMENTAL prints incremental GC stream of logs when the process is approaching
+          // max memory.
+          item =>
+            item.kind === constants.NODE_PERFORMANCE_GC_MAJOR ||
+            item.kind === constants.NODE_PERFORMANCE_GC_INCREMENTAL
         )
         .forEach(item => {
           const gcEventObject = {


### PR DESCRIPTION
Adding another flag to GC metrics as on raider logs we didn't see any GC log during the 30-60 second prior to OOMs. The v8 engine automatically dumps a couple before going OOM but that doesn't help much as its only the last bit of GC events. Adding another flag to give a shot as this flag aims to incrementally log GC events as the process is approaching close to max memory but don't have a lot of hope.

```
2024-03-15T16:42:33.194Z [2024-03-15T16:42:33.194Z] INFO (Momento: ExperimentalEventLoopPerformanceMetricsMiddleware): {"eventLoopUtilization":0.11524289698329374,"eventLoopDelayMean":20044800,"eventLoopDelayMin":19070976,"eventLoopDelayP50":20070399,"eventLoopDelayP75":20070399,"eventLoopDelayP90":20316159,"eventLoopDelayP95":20660223,"eventLoopDelayP99":20742143,"eventLoopDelayMax":20742143,"timestamp":1710520953194}
2024-03-15T16:43:07.208Z ----- Native stack trace -----
2024-03-15T16:43:07.208Z <--- JS stacktrace --->
2024-03-15T16:43:07.208Z <--- Last few GCs --->
2024-03-15T16:43:07.208Z FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
2024-03-15T16:43:07.208Z [1:0x674f2a0]  8634777 ms: Mark-Compact (reduce) 993.7 (1013.8) -> 993.0 (1014.1) MB, 3120.46 / 0.00 ms  (average mu = 0.241, current mu = 0.003) allocation failure; scavenge might not succeed
2024-03-15T16:43:07.208Z [1:0x674f2a0]  8637894 ms: Mark-Compact (reduce) 994.0 (1014.1) -> 993.7 (1014.8) MB, 3114.59 / 0.00 ms  (average mu = 0.128, current mu = 0.001) allocation failure; scavenge might not succeed
2024-03-15T16:43:07.209Z  1: 0xca5580 node::Abort() [node]
2024-03-15T16:43:07.210Z  2: 0xb781f9  [node]
2024-03-15T16:43:07.210Z  3: 0xeca4d0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
2024-03-15T16:43:07.211Z  4: 0xeca7b7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
2024-03-15T16:43:07.212Z  5: 0x10dc505  [node]
2024-03-15T16:43:07.257Z  6: 0x10f4388 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
2024-03-15T16:43:07.258Z  7: 0x10ca4a1 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
2024-03-15T16:43:07.259Z  8: 0x10cb635 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
2024-03-15T16:43:07.260Z  9: 0x10a8c86 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
2024-03-15T16:43:07.261Z 10: 0x1503a16 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
2024-03-15T16:43:07.262Z 11: 0x193cef6  [node]
```