### PR TITLE
fix: Updated the sleep time for auth token expiry

### DIFF
--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -173,7 +173,7 @@ export function runAuthClientTests(
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
       // Wait 1sec for the token to expire
-      await delay(1000);
+      await delay(62000);
 
       const authTokenAuthClient = authTokenAuthClientFactory(
         generateSuccessRst.apiKey
@@ -186,11 +186,11 @@ export function runAuthClientTests(
         expect(refreshResponse).toBeInstanceOf(RefreshApiKey.Error);
       }, `Unexpected response: ${refreshResponse.toString()}`);
       const errorResponse = refreshResponse as RefreshApiKey.Error;
+      const matchesErrorCode =
+        errorResponse.errorCode() === MomentoErrorCode.AUTHENTICATION_ERROR ||
+        errorResponse.errorCode() === MomentoErrorCode.INVALID_ARGUMENT_ERROR;
       expectWithMessage(
-        () =>
-          expect(errorResponse.errorCode()).toEqual(
-            MomentoErrorCode.AUTHENTICATION_ERROR
-          ),
+        () => expect(matchesErrorCode).toEqual(true),
         `Unexpected error code: ${errorResponse.errorCode()}`
       );
     });
@@ -253,7 +253,7 @@ export function runAuthClientTests(
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
       // Wait 1sec for the token to expire
-      await delay(1000);
+      await delay(62000);
 
       const cacheClient = cacheClientFactory(generateSuccessRst.apiKey);
 

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -172,7 +172,7 @@ export function runAuthClientTests(
       }, `Unexpected response: ${generateResponse.toString()}`);
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
-      // Wait 1sec for the token to expire
+      // Wait 62 sec for the token to expire (mr2rs has a 60 sec leeway)
       await delay(62000);
 
       const authTokenAuthClient = authTokenAuthClientFactory(
@@ -252,7 +252,7 @@ export function runAuthClientTests(
       }, `Unexpected response: ${generateResponse.toString()}`);
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
-      // Wait 1sec for the token to expire
+      // Wait 62 sec for the token to expire (mr2rs has a 60 sec leeway)
       await delay(62000);
 
       const cacheClient = cacheClientFactory(generateSuccessRst.apiKey);

--- a/packages/common-integration-tests/src/auth-client.ts
+++ b/packages/common-integration-tests/src/auth-client.ts
@@ -172,8 +172,8 @@ export function runAuthClientTests(
       }, `Unexpected response: ${generateResponse.toString()}`);
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
-      // Wait 62 sec for the token to expire (mr2rs has a 60 sec leeway)
-      await delay(62000);
+      // Wait 1.5 sec for the token to expire
+      await delay(1500);
 
       const authTokenAuthClient = authTokenAuthClientFactory(
         generateSuccessRst.apiKey
@@ -252,8 +252,8 @@ export function runAuthClientTests(
       }, `Unexpected response: ${generateResponse.toString()}`);
       const generateSuccessRst = generateResponse as GenerateApiKey.Success;
 
-      // Wait 62 sec for the token to expire (mr2rs has a 60 sec leeway)
-      await delay(62000);
+      // Wait 1.5 sec for the token to expire
+      await delay(1500);
 
       const cacheClient = cacheClientFactory(generateSuccessRst.apiKey);
 


### PR DESCRIPTION
Updated the sleep to 1.5 sec instead of 1 sec to give little extra buffer.

We have also updated the error code refresh token api with expired token, to make sure the changes flow through smoothly, checking for error code to be one of the old or new one.

Verified that the tests are passing with this change:
<img width="1102" alt="Screenshot 2024-03-18 at 4 48 16 PM" src="https://github.com/momentohq/client-sdk-javascript/assets/21008442/5dc5b137-0bee-4d15-8658-4045ec5316eb">

