### PR TITLE
chore: add vscode workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .idea
 .node-version
 *.tgz
+!.vscode/*code-workspace

--- a/.vscode/client-sdk-javascript.code-workspace
+++ b/.vscode/client-sdk-javascript.code-workspace
@@ -1,0 +1,24 @@
+{
+  "folders": [
+    {
+      "path": "..",
+      "name": "<root>",
+    },
+    {
+      "path": "../packages/core",
+      "name": "packages/core",
+    },
+    {
+      "path": "../packages/client-sdk-nodejs",
+      "name": "packages/client-sdk-nodejs",
+    },
+    {
+      "path": "../packages/client-sdk-web",
+      "name": "packages/client-sdk-web",
+    },
+    {
+      "path": "../packages/common-integration-tests",
+      "name": "packages/common-integration-tests",
+    },
+  ]
+}


### PR DESCRIPTION
Adds a recommended workspace file for vs code users. This allows
developers to view all the main projects in the repo in one view, with
the node modules resolution working as if each folder were opened
independently. See
https://code.visualstudio.com/docs/editor/multi-root-workspaces
