### PR TITLE
feat: add max concurrent request limit config option

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -34,7 +34,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
   private readonly logger: MomentoLogger;
   private readonly notYetAbstractedControlClient: CacheControlClient;
   private readonly _configuration: Configuration;
-  private semaphore: Semaphore;
+  private dataRequestConcurrencySemaphore: Semaphore;
 
   /**
    * Creates an instance of CacheClient.
@@ -70,14 +70,14 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     super(controlClient, dataClients);
     this._configuration = configuration;
     this.notYetAbstractedControlClient = controlClient;
-    this.semaphore = semaphore;
+    this.dataRequestConcurrencySemaphore = semaphore;
 
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento CacheClient');
   }
 
   public close() {
-    this.semaphore.purge();
+    this.dataRequestConcurrencySemaphore.purge();
     this.controlClient.close();
     this.dataClients.map(dc => dc.close());
     this._configuration.getMiddlewares().map(m => {

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -18,8 +18,8 @@ export interface GrpcConfigurationProps {
 
   /**
    * The maximum number of concurrent requests that can be made to the server.
-   * This limit is independent of the number of clients, meaning this limit is the maximum number of
-   * requests that will be made concurrently across all of the internal clients.
+   * This limit is independent of the number of internal clients, meaning this limit is the maximum
+   * number of requests that will be made concurrently across all of the internal clients.
    */
   concurrentRequestsLimit?: number;
 

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -20,6 +20,7 @@ export interface GrpcConfigurationProps {
    * The maximum number of concurrent requests that can be made to the server.
    * This limit is independent of the number of internal clients, meaning this limit is the maximum
    * number of requests that will be made concurrently across all of the internal clients.
+   * If this is not set, it will default to the defaultRequestConcurrencyLimit.
    */
   concurrentRequestsLimit?: number;
 

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -17,6 +17,13 @@ export interface GrpcConfigurationProps {
   numClients?: number;
 
   /**
+   * The maximum number of concurrent requests that can be made to the server.
+   * This limit is independent of the number of clients, meaning this limit is the maximum number of
+   * requests that will be made concurrently across all of the internal clients.
+   */
+  concurrentRequestsLimit?: number;
+
+  /**
    * Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
    *
    * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
@@ -152,4 +159,18 @@ export interface GrpcConfiguration {
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified number of clients
    */
   withNumClients(numClients: number): GrpcConfiguration;
+
+  /**
+   * @returns {number} the maximum number of concurrent requests that can be made to the server.
+   */
+  getConcurrentRequestsLimit(): number;
+
+  /**
+   * Copy constructor for overriding the maximum number of concurrent requests
+   * @param {number} concurrentRequestsLimit the maximum number of concurrent requests that can be made to the server
+   * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified maximum number of concurrent requests
+   */
+  withConcurrentRequestsLimit(
+    concurrentRequestsLimit: number
+  ): GrpcConfiguration;
 }

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -79,6 +79,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly deadlineMillis: number;
   private readonly maxSessionMemoryMb: number;
   private readonly numClients: number;
+  private readonly concurrentRequestsLimit: number;
   private readonly keepAlivePermitWithoutCalls?: number;
   private readonly keepAliveTimeoutMs?: number;
   private readonly keepAliveTimeMs?: number;
@@ -93,6 +94,15 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     } else {
       // This is the previously hardcoded value and a safe default for most environments.
       this.numClients = 6;
+    }
+    if (
+      props.concurrentRequestsLimit !== undefined &&
+      props.concurrentRequestsLimit !== null
+    ) {
+      this.concurrentRequestsLimit = props.concurrentRequestsLimit;
+    } else {
+      // This is a hardcoded limit that can be tuned, but it likely a safe default for most environments.
+      this.concurrentRequestsLimit = 100;
     }
     this.keepAliveTimeMs = props.keepAliveTimeMs;
     this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;
@@ -154,6 +164,21 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
       deadlineMillis: this.deadlineMillis,
       maxSessionMemoryMb: this.maxSessionMemoryMb,
       numClients: numClients,
+    });
+  }
+
+  getConcurrentRequestsLimit(): number {
+    return this.concurrentRequestsLimit;
+  }
+
+  withConcurrentRequestsLimit(
+    concurrentRequestsLimit: number
+  ): GrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      deadlineMillis: this.deadlineMillis,
+      maxSessionMemoryMb: this.maxSessionMemoryMb,
+      numClients: this.numClients,
+      concurrentRequestsLimit: concurrentRequestsLimit,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -1,5 +1,7 @@
 import {GrpcConfiguration, GrpcConfigurationProps} from './grpc-configuration';
 
+const defaultRequestConcurrencyLimit = 100;
+
 export interface TransportStrategy {
   /**
    * Configures the low-level gRPC settings for the Momento client's communication
@@ -101,8 +103,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     ) {
       this.concurrentRequestsLimit = props.concurrentRequestsLimit;
     } else {
-      // This is a hardcoded limit that can be tuned, but it likely a safe default for most environments.
-      this.concurrentRequestsLimit = 100;
+      this.concurrentRequestsLimit = defaultRequestConcurrencyLimit;
     }
     this.keepAliveTimeMs = props.keepAliveTimeMs;
     this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -1408,7 +1408,7 @@ export class CacheDataClient implements IDataClient {
     try {
       await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
-      const result = await this.sendGet(cacheName, this.convert(key));
+      const result = await this.sendGet(cacheName, this.convert(key), options);
       this.logger.trace(`'get' request result: ${result.toString()}`);
       return result;
     } finally {

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -145,7 +145,7 @@ export class CacheDataClient implements IDataClient {
   private readonly interceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
   private readonly valueCompressor?: ICompression;
-  private semaphore: Semaphore;
+  private requestConcurrencySemaphore: Semaphore;
 
   /**
    * @param {CacheClientProps} props
@@ -168,7 +168,7 @@ export class CacheDataClient implements IDataClient {
     } else {
       this.valueCompressor = undefined;
     }
-    this.semaphore = semaphore;
+    this.requestConcurrencySemaphore = semaphore;
 
     const grpcConfig = this.configuration
       .getTransportStrategy()
@@ -386,7 +386,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'set' request; key: ${key.toString()}, value length: ${
           value.length
@@ -394,7 +394,7 @@ export class CacheDataClient implements IDataClient {
       );
       return await this.sendSet(cacheName, encodedKey, encodedValue, ttlToUse);
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -448,10 +448,10 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetFetch(cacheName, this.convert(setName));
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -505,7 +505,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetAddElements(
         cacheName,
         this.convert(setName),
@@ -514,7 +514,7 @@ export class CacheDataClient implements IDataClient {
         ttl.refreshTtl()
       );
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -571,14 +571,14 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetRemoveElements(
         cacheName,
         this.convert(setName),
         this.convertArray(elements)
       );
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -638,10 +638,10 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetSample(cacheName, this.convert(setName), limit);
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -701,7 +701,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -718,7 +718,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -794,7 +794,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -809,7 +809,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfAbsent' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -885,7 +885,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -900,7 +900,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfPresent' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -977,7 +977,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -993,7 +993,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfEqual' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1071,7 +1071,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1087,7 +1087,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfNotEqual' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1165,7 +1165,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresentAndNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1183,7 +1183,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1262,7 +1262,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsentOrEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1280,7 +1280,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1352,11 +1352,11 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'delete' request; key: ${key.toString()}`);
       return await this.sendDelete(cacheName, this.convert(key));
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1406,13 +1406,13 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
       const result = await this.sendGet(cacheName, this.convert(key));
       this.logger.trace(`'get' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1506,7 +1506,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
       const result = await this.sendGetBatch(
         cacheName,
@@ -1515,7 +1515,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'getBatch' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1592,7 +1592,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       const itemsToUse = this.convertSetBatchElements(items);
       const ttlToUse = ttl || this.defaultTtlSeconds;
       this.logger.trace(
@@ -1602,7 +1602,7 @@ export class CacheDataClient implements IDataClient {
       );
       return await this.sendSetBatch(cacheName, itemsToUse, ttlToUse);
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1678,7 +1678,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateBack' request; listName: ${listName}, values length: ${
           values.length
@@ -1700,7 +1700,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1762,7 +1762,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateFront' request; listName: ${listName}, values length: ${
           values.length
@@ -1784,7 +1784,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1846,7 +1846,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listFetch' request; listName: %s, startIndex: %s, endIndex: %s",
         listName,
@@ -1862,7 +1862,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace("'listFetch' request result: %s", result.toString());
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1931,7 +1931,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listRetain' request; listName: %s, startIndex: %s, endIndex: %s, ttl: %s",
         listName,
@@ -1950,7 +1950,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace("'listRetain' request result: %s", result.toString());
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2017,7 +2017,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'listLength' request; listName: ${listName}`);
       const result = await this.sendListLength(
         cacheName,
@@ -2026,7 +2026,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listLength' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2079,7 +2079,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopBack' request");
       const result = await this.sendListPopBack(
         cacheName,
@@ -2088,7 +2088,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPopBack' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2141,7 +2141,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopFront' request");
       const result = await this.sendListPopFront(
         cacheName,
@@ -2150,7 +2150,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPopFront' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2206,7 +2206,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushBack' request; listName: ${listName}, value length: ${
           value.length
@@ -2226,7 +2226,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPushBack' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2287,7 +2287,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushFront' request; listName: ${listName}, value length: ${
           value.length
@@ -2307,7 +2307,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPushFront' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2366,7 +2366,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listRemoveValue' request; listName: ${listName}, value length: ${value.length}`
       );
@@ -2381,7 +2381,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2433,7 +2433,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryFetch' request; dictionaryName: ${dictionaryName}`
       );
@@ -2446,7 +2446,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2501,7 +2501,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
           value.length
@@ -2521,7 +2521,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2583,7 +2583,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionarySetFields' request; elements: ${elements.toString()}, ttl: ${
           ttl.ttlSeconds.toString() ?? 'null'
@@ -2604,7 +2604,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2662,7 +2662,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryGetField' request; field: ${field.toString()}`
       );
@@ -2676,7 +2676,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2753,7 +2753,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryGetFields' request; fields: ${fields.toString()}`
       );
@@ -2767,7 +2767,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2828,7 +2828,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryRemoveField' request; field: ${field.toString()}`
       );
@@ -2842,7 +2842,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2898,7 +2898,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryRemoveFields' request; fields: ${fields.toString()}`
       );
@@ -2912,7 +2912,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2967,7 +2967,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryLength' request; dictionaryName: ${dictionaryName}`
       );
@@ -2980,7 +2980,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3037,7 +3037,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'increment' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
           ttl?.toString() ?? 'null'
@@ -3053,7 +3053,7 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'increment' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3115,7 +3115,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryIncrement' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
           ttl.ttlSeconds.toString() ?? 'null'
@@ -3135,7 +3135,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3201,7 +3201,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetPutElement' request; value: %s, score : %s, ttl: %s",
         truncateString(value.toString()),
@@ -3223,7 +3223,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3286,7 +3286,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetPutElements' request; elements : %s, ttl: %s",
         elements.toString(),
@@ -3309,7 +3309,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3370,7 +3370,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetFetchByRank' request; startRank: %s, endRank : %s, order: %s",
         startRank.toString() ?? 'null',
@@ -3391,7 +3391,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3501,7 +3501,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetFetchByScore' request; minScore: %s, maxScore : %s, order: %s, offset: %s, count: %s",
         minScore?.toString() ?? 'null',
@@ -3527,7 +3527,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3642,7 +3642,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetGetRank' request; value: %s",
         truncateString(value.toString())
@@ -3660,7 +3660,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3747,7 +3747,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetGetScores' request; values: %s",
         truncateString(values.toString())
@@ -3765,7 +3765,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3827,7 +3827,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetIncrementScore' request; value: %s",
         truncateString(value.toString())
@@ -3848,7 +3848,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3912,7 +3912,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetRemoveElement' request");
 
       const result = await this.sendSortedSetRemoveElement(
@@ -3927,7 +3927,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3984,7 +3984,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetRemoveElements' request");
 
       const result = await this.sendSortedSetRemoveElements(
@@ -3999,7 +3999,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4055,7 +4055,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetLength' request");
 
       const result = await this.sendSortedSetLength(
@@ -4069,7 +4069,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4129,7 +4129,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetLengthByScore' request; minScore: %s, maxScore: %s",
         minScore?.toString() ?? 'null',
@@ -4149,7 +4149,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4335,10 +4335,10 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendItemGetType(cacheName, this.convert(key));
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4392,10 +4392,10 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       return await this.sendItemGetTtl(cacheName, this.convert(key));
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4446,7 +4446,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'keyExists' request");
 
       const result = await this.sendKeyExists(cacheName, this.convert(key));
@@ -4457,7 +4457,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4508,7 +4508,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'updateTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4526,7 +4526,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4579,7 +4579,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'keysExist' request");
 
       const result = await this.sendKeysExist(
@@ -4593,7 +4593,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4644,7 +4644,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'increaseTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4662,7 +4662,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4717,7 +4717,7 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.semaphore.acquire();
+      await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'decreaseTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4735,7 +4735,7 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.semaphore.release();
+      this.requestConcurrencySemaphore.release();
     }
   }
 

--- a/packages/core/src/internal/utils/index.ts
+++ b/packages/core/src/internal/utils/index.ts
@@ -5,3 +5,4 @@ export * from './object';
 export * from './sleep';
 export * from './string';
 export * from './validators';
+export * from './semaphore';

--- a/packages/core/src/internal/utils/semaphore.ts
+++ b/packages/core/src/internal/utils/semaphore.ts
@@ -1,0 +1,54 @@
+// Source: https://gist.github.com/gregkorossy/e33be1f201cf242197d9c4d0a1fa7335
+
+export class Semaphore {
+  private counter = 0;
+  private waiting: {
+    resolve: (value: unknown) => void;
+    err: (reason?: any) => void;
+  }[] = [];
+  private max: number;
+
+  constructor(max: number) {
+    this.max = max;
+  }
+
+  public take(): void {
+    if (this.waiting.length > 0 && this.counter < this.max) {
+      this.counter += 1;
+      const promise = this.waiting.shift();
+      if (promise) {
+        promise.resolve(undefined);
+      }
+    }
+  }
+
+  public acquire(): Promise<unknown> {
+    if (this.counter < this.max) {
+      this.counter += 1;
+      return new Promise(resolve => {
+        resolve(undefined);
+      });
+    }
+    return new Promise((resolve, err) => {
+      this.waiting.push({resolve, err});
+    });
+  }
+
+  public release(): void {
+    this.counter -= 1;
+    this.take();
+  }
+
+  public purge(): number {
+    const unresolved = this.waiting.length;
+
+    for (let i = 0; i < unresolved; i += 1) {
+      this.waiting[i].err('Task has been purged.');
+    }
+
+    this.counter = 0;
+    this.waiting = [];
+
+    return unresolved;
+  }
+}

--- a/packages/core/test/unit/utils/semaphore.test.ts
+++ b/packages/core/test/unit/utils/semaphore.test.ts
@@ -1,21 +1,21 @@
 // Unit test the semaphore class
 
-import { Semaphore } from "../../../src/internal/utils";
+import {Semaphore} from '../../../src/internal/utils';
 
 describe('Semaphore', () => {
-  let asyncTaskWithoutSemaphore = async () => {
-    return new Promise<void>((resolve) => {
+  const asyncTaskWithoutSemaphore = () => {
+    return new Promise<void>(resolve => {
       setTimeout(() => {
         resolve();
       }, 1000);
     });
-  }
+  };
 
-  let asyncTaskWithSemaphore = async (semaphore: Semaphore) => {
+  const asyncTaskWithSemaphore = async (semaphore: Semaphore) => {
     await semaphore.acquire();
     await asyncTaskWithoutSemaphore();
     semaphore.release();
-  }
+  };
 
   it('Tasks without semaphore should complete concurrently', async () => {
     const startTime = Date.now();

--- a/packages/core/test/unit/utils/semaphore.test.ts
+++ b/packages/core/test/unit/utils/semaphore.test.ts
@@ -1,0 +1,66 @@
+// Unit test the semaphore class
+
+import { Semaphore } from "../../../src/internal/utils";
+
+describe('Semaphore', () => {
+  let asyncTaskWithoutSemaphore = async () => {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 1000);
+    });
+  }
+
+  let asyncTaskWithSemaphore = async (semaphore: Semaphore) => {
+    await semaphore.acquire();
+    await asyncTaskWithoutSemaphore();
+    semaphore.release();
+  }
+
+  it('Tasks without semaphore should complete concurrently', async () => {
+    const startTime = Date.now();
+    const promises = [];
+    for (let i = 0; i < 6; i++) {
+      promises.push(asyncTaskWithoutSemaphore());
+    }
+    await Promise.all(promises);
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeLessThan(1100);
+  });
+
+  it('Tasks with semaphore with limit set to 1 should complete serially', async () => {
+    const startTime = Date.now();
+    const semaphore = new Semaphore(1);
+    const promises = [];
+    for (let i = 0; i < 6; i++) {
+      promises.push(asyncTaskWithSemaphore(semaphore));
+    }
+    await Promise.all(promises);
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeLessThan(6100);
+  });
+
+  it('Tasks with semaphore with limit set to 3 should complete with twice the concurrent time', async () => {
+    const startTime = Date.now();
+    const semaphore = new Semaphore(3);
+    const promises = [];
+    for (let i = 0; i < 6; i++) {
+      promises.push(asyncTaskWithSemaphore(semaphore));
+    }
+    await Promise.all(promises);
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeLessThan(2100);
+  });
+
+  it('Tasks with semaphore with limit set to 6 should complete concurrently', async () => {
+    const startTime = Date.now();
+    const semaphore = new Semaphore(6);
+    const promises = [];
+    for (let i = 0; i < 6; i++) {
+      promises.push(asyncTaskWithSemaphore(semaphore));
+    }
+    await Promise.all(promises);
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeLessThan(1100);
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/739

* Adds semaphore class in `core` package and exposes `concurrentRequestsLimit` as a grpc config option in the Node.js sdk. (Can implement in web sdk too if useful)
* Creates a semaphore in the CacheClient that caps the number of concurrent requests across all of the data clients. Had to wrap each API `send*` request in a `try-finally` block to acquire and release the semaphore.
* Adds unit tests for the semaphore class in the `core` package

Locally verified that given a `Promise.all` with 100 get requests with concurrency limit set to 10, there are only a max of 10 active requests at once. Logs snippet:
```
[2024-04-03T20:41:49.386Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): {"momento":{"numActiveRequestsAtStart":6,"numActiveRequestsAtFinish":10,"requestType":"_GetRequest","status":0,"startTime":1712176909321,"requestBodyTime":1712176909322,"endTime":1712176909386,"duration":65,"requestSize":5,"responseSize":2,"connectionID":"5"}}
[2024-04-03T20:41:49.387Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): {"momento":{"numActiveRequestsAtStart":7,"numActiveRequestsAtFinish":10,"requestType":"_GetRequest","status":0,"startTime":1712176909321,"requestBodyTime":1712176909322,"endTime":1712176909387,"duration":66,"requestSize":5,"responseSize":2,"connectionID":"0"}}
[2024-04-03T20:41:49.389Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): {"momento":{"numActiveRequestsAtStart":1,"numActiveRequestsAtFinish":10,"requestType":"_GetRequest","status":0,"startTime":1712176909320,"requestBodyTime":1712176909322,"endTime":1712176909389,"duration":69,"requestSize":5,"responseSize":2,"connectionID":"0"}}
[2024-04-03T20:41:49.390Z] INFO (Momento: ExperimentalMetricsLoggingMiddleware): {"momento":{"numActiveRequestsAtStart":9,"numActiveRequestsAtFinish":10,"requestType":"_GetRequest","status":0,"startTime":1712176909321,"requestBodyTime":1712176909322,"endTime":1712176909390,"duration":69,"requestSize":5,"responseSize":2,"connectionID":"2"}}
```

Was unable to get the semaphore working at the middleware level, or at least couldn't prove it was working correctly because active request middleware would show number of concurrent requests > limit.