### PR TITLE
chore: add configuration getters to cache clients

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -32,7 +32,7 @@ const EAGER_CONNECTION_DEFAULT_TIMEOUT_SECONDS = 30;
 export class CacheClient extends AbstractCacheClient implements ICacheClient {
   private readonly logger: MomentoLogger;
   private readonly notYetAbstractedControlClient: CacheControlClient;
-  private readonly configuration: Configuration;
+  private readonly _configuration: Configuration;
 
   /**
    * Creates an instance of CacheClient.
@@ -60,7 +60,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       (_, id) => new CacheDataClient(propsWithConfig, String(id))
     );
     super(controlClient, dataClients);
-    this.configuration = configuration;
+    this._configuration = configuration;
     this.notYetAbstractedControlClient = controlClient;
 
     this.logger = configuration.getLoggerFactory().getLogger(this);
@@ -70,7 +70,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
   public close() {
     this.controlClient.close();
     this.dataClients.map(dc => dc.close());
-    this.configuration.getMiddlewares().map(m => {
+    this._configuration.getMiddlewares().map(m => {
       if (m.close) {
         m.close();
       }
@@ -98,6 +98,17 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       );
     }
     return client;
+  }
+
+  /**
+   * Returns the configuration used to create the CacheClient.
+   *
+   * @readonly
+   * @type {Configuration} - The configuration used to create the CacheClient.
+   * @memberof CacheClient
+   */
+  public get configuration(): Configuration {
+    return this._configuration;
   }
 
   /**

--- a/packages/client-sdk-nodejs/src/config/configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/configuration.ts
@@ -137,6 +137,11 @@ export interface Configuration {
    * @returns {Configuration} a new Configuration object with the specified compression settings
    */
   withCompressionStrategy(compression: CompressionStrategy): Configuration;
+
+  /**
+   * @returns {boolean} whether the client has a compression strategy configured.
+   */
+  hasCompressionStrategy(): boolean;
 }
 
 export class CacheConfiguration implements Configuration {
@@ -283,5 +288,9 @@ export class CacheConfiguration implements Configuration {
       readConcern: this.readConcern,
       compression: compressionStrategy,
     });
+  }
+
+  hasCompressionStrategy(): boolean {
+    return this.compression !== undefined;
   }
 }

--- a/packages/client-sdk-web/src/cache-client.ts
+++ b/packages/client-sdk-web/src/cache-client.ts
@@ -18,6 +18,8 @@ interface CacheClientPropsWithConfiguration extends CacheClientProps {
 }
 
 export class CacheClient extends AbstractCacheClient implements ICacheClient {
+  private readonly _configuration: Configuration;
+
   constructor(props: CacheClientProps) {
     validateTtlSeconds(props.defaultTtlSeconds);
     const configuration =
@@ -37,6 +39,17 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
   public close() {
     this.controlClient.close();
     this.dataClients.map(dc => dc.close());
+  }
+
+  /**
+   * The configuration used by this client.
+   *
+   * @readonly
+   * @type {Configuration} the configuration used by this client
+   * @memberof CacheClient
+   */
+  public get configuration(): Configuration {
+    return this._configuration;
   }
 }
 


### PR DESCRIPTION
In order to read the configuration from an already instantiated cache
client externally, we add configuration getters to the cache clients.
