### PR TITLE
chore: add missing KeyExists and KeysExist docs snippets and correct docstrings

### DIFF
--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -96,6 +96,8 @@ import {
   SetBatch,
   ReadConcern,
   CacheSetSample,
+  CacheKeyExists,
+  CacheKeysExist,
 } from '@gomomento/sdk';
 import * as crypto from 'crypto';
 
@@ -940,6 +942,28 @@ async function example_API_SortedSetRemoveElements(cacheClient: CacheClient, cac
   }
 }
 
+async function example_API_KeyExists(cacheClient: CacheClient, cacheName: string) {
+  const result = await cacheClient.keyExists(cacheName, 'test-key');
+  if (result instanceof CacheKeyExists.Success) {
+    console.log("Does 'test-key' exists in the cache?", result.exists());
+  } else if (result instanceof CacheKeyExists.Error) {
+    throw new Error(
+      `An error occurred while attempting to call keyExists on key 'test-key' in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
+async function example_API_KeysExist(cacheClient: CacheClient, cacheName: string) {
+  const result = await cacheClient.keysExist(cacheName, ['test-key1', 'test-key2']);
+  if (result instanceof CacheKeysExist.Success) {
+    console.log("Do 'test-key1' and 'test-key2' exist in the cache?", result.exists());
+  } else if (result instanceof CacheKeysExist.Error) {
+    throw new Error(
+      `An error occurred while attempting to call keysExist on keys 'test-key1' and 'test-key2' in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
+    );
+  }
+}
+
 function example_API_InstantiateAuthClient() {
   new AuthClient({
     credentialProvider: CredentialProvider.fromEnvironmentVariable({
@@ -1584,6 +1608,9 @@ async function main() {
     await example_API_SortedSetIncrementScore(cacheClient, cacheName);
     await example_API_SortedSetRemoveElement(cacheClient, cacheName);
     await example_API_SortedSetRemoveElements(cacheClient, cacheName);
+
+    await example_API_KeyExists(cacheClient, cacheName);
+    await example_API_KeysExist(cacheClient, cacheName);
 
     example_API_InstantiateAuthClient();
     const authClient = new AuthClient({

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -1531,7 +1531,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache to look in.
    * @param {string | Uint8Array} key - The key to look up.
    * @returns {Promise<CacheKeyExists.Response>}
-   * {@link CacheKeyExists.Success} if key is found? or if key is checked?
+   * {@link CacheKeyExists.Success} returns boolean indicating whether the key was found.
    * {@link CacheKeyExists.Error} on failure.
    */
   public async keyExists(
@@ -1547,7 +1547,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache to look in.
    * @param {string[] | Uint8Array[]} keys - The keys to look up.
    * @returns {Promise<CacheKeysExist.Response>}
-   * {@link CacheKeysExist.Success} if at least one key is found? if all keys checked?
+   * {@link CacheKeysExist.Success} returns list of booleans indicating whether each key was found.
    * {@link CacheKeysExist.Error} on failure.
    */
   public async keysExist(


### PR DESCRIPTION
Rishti had pointed out the incorrect docstrings a little while ago, and I noticed the missing dev docs snippets for KeyExists and KeysExist while implementing them in the Rust SDK.