### PR TITLE
fix: expose WithConcurrentRequestsLimit on TransportStrategy interface, add validator and test

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -13,6 +13,7 @@ import {CacheClientProps, EagerCacheClientProps} from './cache-client-props';
 import {
   range,
   Semaphore,
+  validateConcurrentRequestsLimit,
   validateTimeout,
   validateTtlSeconds,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
@@ -53,6 +54,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       .getTransportStrategy()
       .getGrpcConfig()
       .getConcurrentRequestsLimit();
+    validateConcurrentRequestsLimit(numConcurrentRequests);
     const semaphore = new Semaphore(numConcurrentRequests);
 
     const controlClient = new CacheControlClient({

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -53,6 +53,20 @@ export interface TransportStrategy {
    * @returns {TransportStrategy} a new TransportStrategy with the specified max client age.
    */
   withMaxClientAgeMillis(maxClientAgeMillis: number): TransportStrategy;
+
+  /**
+   * @returns {number} the maximum number of concurrent requests that can be made by the client.
+   */
+  getConcurrentRequestsLimit(): number;
+
+  /**
+   * Copy constructor to update the maximum number of concurrent requests that can be made by the client.
+   * @param {number} concurrentRequestsLimit
+   * @returns {TransportStrategy} a new TransportStrategy with the specified concurrent requests limit.
+   */
+  withConcurrentRequestsLimit(
+    concurrentRequestsLimit: number
+  ): TransportStrategy;
 }
 
 export interface TransportStrategyProps {
@@ -234,6 +248,21 @@ export class StaticTransportStrategy implements TransportStrategy {
   withClientTimeoutMillis(clientTimeout: number): StaticTransportStrategy {
     return new StaticTransportStrategy({
       grpcConfiguration: this.grpcConfig.withDeadlineMillis(clientTimeout),
+      maxIdleMillis: this.maxIdleMillis,
+    });
+  }
+
+  getConcurrentRequestsLimit(): number {
+    return this.grpcConfig.getConcurrentRequestsLimit();
+  }
+
+  withConcurrentRequestsLimit(
+    concurrentRequestsLimit: number
+  ): StaticTransportStrategy {
+    return new StaticTransportStrategy({
+      grpcConfiguration: this.grpcConfig.withConcurrentRequestsLimit(
+        concurrentRequestsLimit
+      ),
       maxIdleMillis: this.maxIdleMillis,
     });
   }

--- a/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
@@ -113,4 +113,37 @@ describe('CacheClient', () => {
       }
     }
   });
+  it('cannot create a client with concurrent requests limit below 1', async () => {
+    try {
+      const negativeLimitConfig = configuration.withTransportStrategy(
+        configuration.getTransportStrategy().withConcurrentRequestsLimit(-1)
+      );
+      await CacheClient.create({
+        configuration: negativeLimitConfig,
+        credentialProvider: credentialProvider,
+        defaultTtlSeconds: 100,
+      });
+      fail(new Error('Expected InvalidArgumentError to be thrown!'));
+    } catch (e) {
+      if (!(e instanceof InvalidArgumentError)) {
+        fail(new Error('Expected InvalidArgumentError to be thrown!'));
+      }
+    }
+
+    try {
+      const zeroLimitConfig = configuration.withTransportStrategy(
+        configuration.getTransportStrategy().withConcurrentRequestsLimit(0)
+      );
+      await CacheClient.create({
+        configuration: zeroLimitConfig,
+        credentialProvider: credentialProvider,
+        defaultTtlSeconds: 100,
+      });
+      fail(new Error('Expected InvalidArgumentError to be thrown!'));
+    } catch (e) {
+      if (!(e instanceof InvalidArgumentError)) {
+        fail(new Error('Expected InvalidArgumentError to be thrown!'));
+      }
+    }
+  });
 });

--- a/packages/core/src/internal/utils/validators.ts
+++ b/packages/core/src/internal/utils/validators.ts
@@ -219,3 +219,11 @@ export function validateLeaderboardNumberOfElements(numElements: number) {
     throw new InvalidArgumentError('must provide at least one element');
   }
 }
+
+export function validateConcurrentRequestsLimit(limit: number) {
+  if (limit < 1) {
+    throw new InvalidArgumentError(
+      'concurrent requests limit must be strictly positive (> 0)'
+    );
+  }
+}


### PR DESCRIPTION
Follow up to #1209, addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/739

Realized WithConcurrentRequestsLimit was missing from the TransportStrategy interface. Should now be publicly accessible and usable.

Added validator to ensure limit is strictly positive. Added unit tests to confirm.