### PR TITLE
fix: use specific semaphore resolve/err types

### DIFF
--- a/packages/core/src/internal/utils/semaphore.ts
+++ b/packages/core/src/internal/utils/semaphore.ts
@@ -3,8 +3,8 @@
 export class Semaphore {
   private counter = 0;
   private waiting: {
-    resolve: (value: unknown) => void;
-    err: (reason?: any) => void;
+    resolve: (value?: unknown) => void;
+    err: (reason?: string) => void;
   }[] = [];
   private max: number;
 
@@ -17,7 +17,7 @@ export class Semaphore {
       this.counter += 1;
       const promise = this.waiting.shift();
       if (promise) {
-        promise.resolve(undefined);
+        promise.resolve();
       }
     }
   }


### PR DESCRIPTION
Previously we used unknown and any types for the sempahore internal
promise resolve/error types. We can use more specific ones to avoid
warnings on GH.
