### PR TITLE
feat: add compression for dictionaries

### DIFF
--- a/packages/client-sdk-nodejs-compression/test/integration/compression.test.ts
+++ b/packages/client-sdk-nodejs-compression/test/integration/compression.test.ts
@@ -3,7 +3,12 @@ import {
   CacheClient,
   CacheGet,
   CacheSet,
+  CacheDictionarySetField,
+  CacheDictionarySetFields,
+  CacheDictionaryGetField,
+  CacheDictionaryFetch,
   CompressionLevel,
+  CacheDictionaryGetFields,
 } from '@gomomento/sdk';
 import {CompressorFactory} from '../../src';
 import {v4} from 'uuid';
@@ -31,9 +36,29 @@ function randomString() {
 }
 
 const testValue = 'my-value';
-const testValueCompressed = [
+const testValueCompressed = Uint8Array.from([
   40, 181, 47, 253, 0, 96, 65, 0, 0, 109, 121, 45, 118, 97, 108, 117, 101,
-];
+]);
+const testValue2 = 'my-value2';
+const testValue2Compressed = Uint8Array.from([
+  40, 181, 47, 253, 0, 96, 73, 0, 0, 109, 121, 45, 118, 97, 108, 117, 101, 50,
+]);
+
+const bytesEncoderForTests = new TextEncoder();
+function uint8ArrayForTest(value: string): Uint8Array {
+  return Uint8Array.from(bytesEncoderForTests.encode(value));
+}
+
+function compareMapStringUint8Array(
+  actual: Map<string, Uint8Array>,
+  expected: Map<string, Uint8Array>
+) {
+  expect(actual.size).toEqual(expected.size);
+  for (const [key, value] of expected) {
+    expect(actual.has(key)).toBeTruthy();
+    expect(actual.get(key)).toEqual(value);
+  }
+}
 
 describe('CompressorFactory', () => {
   describe('CacheClient.set', () => {
@@ -67,9 +92,9 @@ describe('CompressorFactory', () => {
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `Expected CacheClient.get to be a hit after CacheClient.set with compression specified, got: '${getResponse.toString()}'`);
-      expect(
-        Array.from((getResponse as CacheGet.Hit).valueUint8Array())
-      ).toEqual(testValueCompressed);
+      expect((getResponse as CacheGet.Hit).valueUint8Array()).toEqual(
+        testValueCompressed
+      );
     });
     it('should not compress the value if compress is not specified', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
@@ -88,6 +113,36 @@ describe('CompressorFactory', () => {
     });
   });
   describe('CacheClient.get', () => {
+    it('should not return an error if decompress is true and compression is not enabled and it is a miss', async () => {
+      const getResponse = await cacheClientWithoutCompressorFactory.get(
+        cacheName,
+        randomString(),
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Miss);
+      }, `Expected CacheClient.get to be a miss with decompression specified and no compression enabled, got: '${getResponse.toString()}'`);
+    });
+    it('should return an error if decompress is true and compression is not enabled and it is a hit', async () => {
+      const cacheClient = cacheClientWithoutCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue);
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `Expected CacheClient.set to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.get(cacheName, key, {
+        decompress: true,
+      });
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Error);
+        expect((getResponse as CacheGet.Error).toString()).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.get` was called with the `decompress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.get to return an error if decompression is specified without compressor set, but got: ${getResponse.toString()}`);
+    });
     it('should decompress the value if decompress is true', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
       const key = randomString();
@@ -124,9 +179,9 @@ describe('CompressorFactory', () => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `Expected CacheClient.get to be a hit after CacheClient.set with compression specified, got: '${getResponse.toString()}'`);
 
-      expect(
-        Array.from((getResponse as CacheGet.Hit).valueUint8Array())
-      ).toEqual(testValueCompressed);
+      expect((getResponse as CacheGet.Hit).valueUint8Array()).toEqual(
+        testValueCompressed
+      );
     });
     it('should return the value if it is not compressed and decompress is true', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
@@ -146,7 +201,7 @@ describe('CompressorFactory', () => {
       expect((getResponse as CacheGet.Hit).valueString()).toEqual(testValue);
     });
   });
-  /*describe('CacheClient.dictionarySetField', () => {
+  describe('CacheClient.dictionarySetField', () => {
     it('should return an error if compress is true but compression is not enabled', async () => {
       const setResponse =
         await cacheClientWithoutCompressorFactory.dictionarySetField(
@@ -158,9 +213,12 @@ describe('CompressorFactory', () => {
             compress: true,
           }
         );
+      console.log(setResponse.toString());
       expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(CacheSet.Error);
-        expect((setResponse as CacheSet.Error).toString()).toEqual(
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Error);
+        expect(
+          (setResponse as CacheDictionarySetField.Error).toString()
+        ).toEqual(
           'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionarySetField` was called with the `compress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
         );
       }, `Expected CacheClient.dictionarySetField to return an error if compression is specified without compressor set, but got: ${setResponse.toString()}`);
@@ -178,7 +236,7 @@ describe('CompressorFactory', () => {
         }
       );
       expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
       }, `Expected CacheClient.dictionarySetField to be a success with compression specified, got: '${setResponse.toString()}'`);
 
       const getResponse = await cacheClient.dictionaryGetField(
@@ -187,12 +245,12 @@ describe('CompressorFactory', () => {
         'my-field'
       );
       expectWithMessage(() => {
-        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
       }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with compression specified, got: '${getResponse.toString()}'`);
 
-      expect((getResponse as CacheGet.Hit).valueString()).toEqual(
-        testValueCompressed
-      );
+      expect(
+        (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
+      ).toEqual(testValueCompressed);
     });
     it('should not compress the value if compress is not specified', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
@@ -204,7 +262,7 @@ describe('CompressorFactory', () => {
         testValue
       );
       expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
       }, `Expected CacheClient.dictionarySetField to be a success with no compression specified, got: '${setResponse.toString()}'`);
 
       const getResponse = await cacheClient.dictionaryGetField(
@@ -213,10 +271,539 @@ describe('CompressorFactory', () => {
         'my-field'
       );
       expectWithMessage(() => {
-        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
       }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with no compression specified, got: '${getResponse.toString()}'`);
 
-      expect((getResponse as CacheGet.Hit).valueString()).toEqual(testValue);
+      expect(
+        (getResponse as CacheDictionaryGetField.Hit).valueString()
+      ).toEqual(testValue);
     });
-  });*/
+  });
+  describe('CacheClient.dictionaryGetField', () => {
+    it('should not return an error if decompress is true and compression is not enabled and it is a miss', async () => {
+      const getResponse =
+        await cacheClientWithoutCompressorFactory.dictionaryGetField(
+          cacheName,
+          randomString(),
+          'my-field',
+          {
+            decompress: true,
+          }
+        );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Miss);
+      }, `Expected CacheClient.dictionaryGetField to be a miss with decompression specified and no compression enabled, got: '${getResponse.toString()}'`);
+    });
+    it('should return an error if decompress is true and compression is not enabled and it is a hit', async () => {
+      const cacheClient = cacheClientWithoutCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field',
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Error);
+        expect(
+          (getResponse as CacheDictionaryGetField.Error).toString()
+        ).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionaryGetField` was called with the `decompress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.dictionaryGetField to return an error if decompression is specified without compressor set, but got: ${getResponse.toString()}`);
+    });
+    it('should decompress the value if decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue,
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field',
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expect(
+          (getResponse as CacheDictionaryGetField.Hit).valueString()
+        ).toEqual(testValue);
+      }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with compression specified, got: '${getResponse.toString()}'`);
+    });
+    it('should not decompress the value if decompress is false', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue,
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field',
+        {
+          decompress: false,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expect(
+          (getResponse as CacheDictionaryGetField.Hit).valueUint8Array()
+        ).toEqual(testValueCompressed);
+      }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with compression specified, got: '${getResponse.toString()}'`);
+    });
+    it('should return the value if it is not compressed and decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field',
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetField.Hit);
+        expect(
+          (getResponse as CacheDictionaryGetField.Hit).valueString()
+        ).toEqual(testValue);
+      }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with compression specified, got: '${getResponse.toString()}'`);
+    });
+  });
+  describe('CacheClient.dictionarySetFields', () => {
+    it('should return an error if compress is true but compression is not enabled', async () => {
+      const setResponse =
+        await cacheClientWithoutCompressorFactory.dictionarySetFields(
+          cacheName,
+          randomString(),
+          {
+            'my-field': testValue,
+          },
+          {
+            compress: true,
+          }
+        );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Error);
+        expect(
+          (setResponse as CacheDictionarySetFields.Error).toString()
+        ).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionarySetFields` was called with the `compress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.dictionarySetFields to return an error if compression is specified without compressor set, but got: ${setResponse.toString()}`);
+    });
+    it('should compress the value if compress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        },
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      // Test heterogeneous case
+      const setResponse2 = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field3',
+        testValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse2).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with no compression specified, got: '${setResponse2.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        const actual = (
+          fetchResponse as CacheDictionaryFetch.Hit
+        ).valueMapStringUint8Array();
+        compareMapStringUint8Array(
+          actual,
+          new Map<string, Uint8Array>([
+            ['my-field', Uint8Array.from(testValueCompressed)],
+            ['my-field2', Uint8Array.from(testValue2Compressed)],
+            ['my-field3', Uint8Array.from(uint8ArrayForTest(testValue))],
+          ])
+        );
+      }, `Expected CacheClient.dictionaryGetFields to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${fetchResponse.toString()}'`);
+    });
+    it('should not compress the value if compress is not specified', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key);
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expect((fetchResponse as CacheDictionaryFetch.Hit).value()).toEqual({
+          'my-field': testValue,
+          'my-field2': testValue2,
+        });
+      }, `Expected CacheClient.dictionaryGetFields to be a hit after CacheClient.dictionarySetFields with no compression specified, got: '${fetchResponse.toString()}'`);
+    });
+  });
+  describe('CacheClient.dictionaryGetFields', () => {
+    it('should not return an error if decompress is true and compression is not enabled and it is a miss', async () => {
+      const getResponse =
+        await cacheClientWithoutCompressorFactory.dictionaryGetFields(
+          cacheName,
+          randomString(),
+          ['my-field', 'my-field2'],
+          {
+            decompress: true,
+          }
+        );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Miss);
+      }, `Expected CacheClient.dictionaryGetFields to be a miss with decompression specified and no compression enabled, got: '${getResponse.toString()}'`);
+    });
+    it('should return an error if decompress is true and compression is not enabled and it is a hit', async () => {
+      const cacheClient = cacheClientWithoutCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetFields(
+        cacheName,
+        key,
+        ['my-field', 'my-field2'],
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Error);
+        expect(
+          (getResponse as CacheDictionaryGetFields.Error).toString()
+        ).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionaryGetFields` was called with the `decompress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.dictionaryGetFields to return an error if decompression is specified without compressor set, but got: ${getResponse.toString()}`);
+    });
+    it('should decompress the value if decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        },
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetFields(
+        cacheName,
+        key,
+        ['my-field', 'my-field2'],
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        expect((getResponse as CacheDictionaryGetFields.Hit).value()).toEqual({
+          'my-field': testValue,
+          'my-field2': testValue2,
+        });
+      }, `Expected CacheClient.dictionaryGetFields to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${getResponse.toString()}'`);
+    });
+    it('should not decompress the value if decompress is false', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        },
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetFields(
+        cacheName,
+        key,
+        ['my-field', 'my-field2'],
+        {
+          decompress: false,
+        }
+      );
+
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        const actual = (
+          getResponse as CacheDictionaryGetFields.Hit
+        ).valueMapStringUint8Array();
+        compareMapStringUint8Array(
+          actual,
+          new Map<string, Uint8Array>([
+            ['my-field', Uint8Array.from(testValueCompressed)],
+            ['my-field2', Uint8Array.from(testValue2Compressed)],
+          ])
+        );
+      }, `Expected CacheClient.dictionaryGetFields to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${getResponse.toString()}'`);
+    });
+    it('should return the value if it is not compressed and decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetFields(
+        cacheName,
+        key,
+        ['my-field', 'my-field2'],
+        {
+          decompress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheDictionaryGetFields.Hit);
+        expect((getResponse as CacheDictionaryGetFields.Hit).value()).toEqual({
+          'my-field': testValue,
+          'my-field2': testValue2,
+        });
+      }, `Expected CacheClient.dictionaryGetFields to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${getResponse.toString()}'`);
+    });
+  });
+  describe('CacheClient.dictionaryFetch', () => {
+    it('should not return an error if decompress is true and compression is not enabled and it is a miss', async () => {
+      const fetchResponse =
+        await cacheClientWithoutCompressorFactory.dictionaryFetch(
+          cacheName,
+          randomString(),
+          {
+            decompress: true,
+          }
+        );
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Miss);
+      }, `Expected CacheClient.dictionaryFetch to be a miss with decompression specified and no compression enabled, got: '${fetchResponse.toString()}'`);
+    });
+    it('should return an error if decompress is true and compression is not enabled and it is a hit', async () => {
+      const cacheClient = cacheClientWithoutCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key, {
+        decompress: true,
+      });
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Error);
+        expect(
+          (fetchResponse as CacheDictionaryFetch.Error).toString()
+        ).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionaryFetch` was called with the `decompress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.dictionaryFetch to return an error if decompression is specified without compressor set, but got: ${fetchResponse.toString()}`);
+    });
+    it('should decompress the value if decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        },
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      // Test the heterogeneous case
+      const setResponse2 = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field3',
+        testValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse2).toBeInstanceOf(CacheDictionarySetField.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with no compression specified, got: '${setResponse2.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key, {
+        decompress: true,
+      });
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        const actual = (fetchResponse as CacheDictionaryFetch.Hit).value();
+        expect(actual).toEqual({
+          'my-field': testValue,
+          'my-field2': testValue2,
+          'my-field3': testValue,
+        });
+      }, `Expected CacheClient.dictionaryFetch to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${fetchResponse.toString()}'`);
+    });
+    it('should not decompress the value if decompress is false', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        },
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key, {
+        decompress: false,
+      });
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        const actual = (
+          fetchResponse as CacheDictionaryFetch.Hit
+        ).valueMapStringUint8Array();
+        compareMapStringUint8Array(
+          actual,
+          new Map<string, Uint8Array>([
+            ['my-field', Uint8Array.from(testValueCompressed)],
+            ['my-field2', Uint8Array.from(testValue2Compressed)],
+          ])
+        );
+      }, `Expected CacheClient.dictionaryFetch to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${fetchResponse.toString()}'`);
+    });
+    it('should return the value if it is not compressed and decompress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetFields(
+        cacheName,
+        key,
+        {
+          'my-field': testValue,
+          'my-field2': testValue2,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheDictionarySetFields.Success);
+      }, `Expected CacheClient.dictionarySetFields to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const fetchResponse = await cacheClient.dictionaryFetch(cacheName, key, {
+        decompress: true,
+      });
+      expectWithMessage(() => {
+        expect(fetchResponse).toBeInstanceOf(CacheDictionaryFetch.Hit);
+        expect((fetchResponse as CacheDictionaryFetch.Hit).value()).toEqual({
+          'my-field': testValue,
+          'my-field2': testValue2,
+        });
+      }, `Expected CacheClient.dictionaryFetch to be a hit after CacheClient.dictionarySetFields with compression specified, got: '${fetchResponse.toString()}'`);
+    });
+  });
 });

--- a/packages/client-sdk-nodejs-compression/test/integration/compression.test.ts
+++ b/packages/client-sdk-nodejs-compression/test/integration/compression.test.ts
@@ -6,6 +6,7 @@ import {
   CompressionLevel,
 } from '@gomomento/sdk';
 import {CompressorFactory} from '../../src';
+import {v4} from 'uuid';
 
 const {cacheClientPropsWithConfig, cacheName} = setupIntegrationTest();
 
@@ -25,6 +26,10 @@ const cacheClientWithoutCompressorFactory = new CacheClient({
   defaultTtlSeconds: cacheClientPropsWithConfig.defaultTtlSeconds,
 });
 
+function randomString() {
+  return v4();
+}
+
 const testValue = 'my-value';
 const testValueCompressed = [
   40, 181, 47, 253, 0, 96, 65, 0, 0, 109, 121, 45, 118, 97, 108, 117, 101,
@@ -35,7 +40,7 @@ describe('CompressorFactory', () => {
     it('should return an error if compress is true but compression is not enabled', async () => {
       const setResponse = await cacheClientWithoutCompressorFactory.set(
         cacheName,
-        'my-key',
+        randomString(),
         testValue,
         {
           compress: true,
@@ -50,84 +55,50 @@ describe('CompressorFactory', () => {
     });
     it('should compress the value if compress is true', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
-      const setResponse = await cacheClient.set(
-        cacheName,
-        'my-key',
-        testValue,
-        {
-          compress: true,
-        }
-      );
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue, {
+        compress: true,
+      });
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `Expected CacheClient.set to be a success with compression specified, got: '${setResponse.toString()}'`);
 
-      const getResponse = await cacheClient.get(cacheName, 'my-key');
+      const getResponse = await cacheClient.get(cacheName, key);
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `Expected CacheClient.get to be a hit after CacheClient.set with compression specified, got: '${getResponse.toString()}'`);
-
-      console.log(
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        `THE COMPRESSED BYTES: ${(
-          getResponse as CacheGet.Hit
-        ).valueUint8Array()}`
-      );
       expect(
         Array.from((getResponse as CacheGet.Hit).valueUint8Array())
       ).toEqual(testValueCompressed);
     });
     it('should not compress the value if compress is not specified', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
-      console.log('TEST CALLING SET');
-      const setResponse = await cacheClient.set(cacheName, 'my-key', testValue);
-      console.log('TEST BACK FROM SET');
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue);
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `Expected CacheClient.set to be a success with no compression specified, got: '${setResponse.toString()}'`);
 
-      console.log('TEST CALLING GET');
-      const getResponse = await cacheClient.get(cacheName, 'my-key');
-      console.log('TEST BACK FROM GET');
+      const getResponse = await cacheClient.get(cacheName, key);
       expectWithMessage(() => {
         expect(getResponse).toBeInstanceOf(CacheGet.Hit);
       }, `Expected CacheClient.get to be a hit after CacheClient.set with no compression specified, got: '${getResponse.toString()}'`);
 
       expect((getResponse as CacheGet.Hit).valueString()).toEqual(testValue);
     });
-    it('should return an error if compress is true but compression is not enabled', async () => {
-      const setResponse = await cacheClientWithoutCompressorFactory.set(
-        cacheName,
-        'my-key',
-        testValue,
-        {
-          compress: true,
-        }
-      );
-      expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(CacheSet.Error);
-        expect((setResponse as CacheSet.Error).toString()).toEqual(
-          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.set` was called with the `compress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
-        );
-      }, `Expected CacheClient.set to be an Error with compression disabled and compression specified, got: '${setResponse.toString()}'`);
-    });
   });
   describe('CacheClient.get', () => {
     it('should decompress the value if decompress is true', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
-      const setResponse = await cacheClient.set(
-        cacheName,
-        'my-key',
-        testValue,
-        {
-          compress: true,
-        }
-      );
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue, {
+        compress: true,
+      });
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `Expected CacheClient.set to be a success with compression specified, got: '${setResponse.toString()}'`);
 
-      const getResponse = await cacheClient.get(cacheName, 'my-key', {
+      const getResponse = await cacheClient.get(cacheName, key, {
         decompress: true,
       });
       expectWithMessage(() => {
@@ -138,19 +109,15 @@ describe('CompressorFactory', () => {
     });
     it('should not decompress the value if decompress is false', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
-      const setResponse = await cacheClient.set(
-        cacheName,
-        'my-key',
-        testValue,
-        {
-          compress: true,
-        }
-      );
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue, {
+        compress: true,
+      });
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `Expected CacheClient.set to be a success with compression specified, got: '${setResponse.toString()}'`);
 
-      const getResponse = await cacheClient.get(cacheName, 'my-key', {
+      const getResponse = await cacheClient.get(cacheName, key, {
         decompress: false,
       });
       expectWithMessage(() => {
@@ -163,12 +130,13 @@ describe('CompressorFactory', () => {
     });
     it('should return the value if it is not compressed and decompress is true', async () => {
       const cacheClient = cacheClientWithDefaultCompressorFactory;
-      const setResponse = await cacheClient.set(cacheName, 'my-key', testValue);
+      const key = randomString();
+      const setResponse = await cacheClient.set(cacheName, key, testValue);
       expectWithMessage(() => {
         expect(setResponse).toBeInstanceOf(CacheSet.Success);
       }, `Expected CacheClient.set to be a success with compression specified, got: '${setResponse.toString()}'`);
 
-      const getResponse = await cacheClient.get(cacheName, 'my-key', {
+      const getResponse = await cacheClient.get(cacheName, key, {
         decompress: true,
       });
       expectWithMessage(() => {
@@ -178,4 +146,77 @@ describe('CompressorFactory', () => {
       expect((getResponse as CacheGet.Hit).valueString()).toEqual(testValue);
     });
   });
+  /*describe('CacheClient.dictionarySetField', () => {
+    it('should return an error if compress is true but compression is not enabled', async () => {
+      const setResponse =
+        await cacheClientWithoutCompressorFactory.dictionarySetField(
+          cacheName,
+          randomString(),
+          'my-field',
+          testValue,
+          {
+            compress: true,
+          }
+        );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Error);
+        expect((setResponse as CacheSet.Error).toString()).toEqual(
+          'Invalid argument passed to Momento client: Compressor is not set, but `CacheClient.dictionarySetField` was called with the `compress` option; please install @gomomento/sdk-nodejs-compression and call `Configuration.withCompressionStrategy` to enable compression.'
+        );
+      }, `Expected CacheClient.dictionarySetField to return an error if compression is specified without compressor set, but got: ${setResponse.toString()}`);
+    });
+    it('should compress the value if compress is true', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue,
+        {
+          compress: true,
+        }
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field'
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with compression specified, got: '${getResponse.toString()}'`);
+
+      expect((getResponse as CacheGet.Hit).valueString()).toEqual(
+        testValueCompressed
+      );
+    });
+    it('should not compress the value if compress is not specified', async () => {
+      const cacheClient = cacheClientWithDefaultCompressorFactory;
+      const key = randomString();
+      const setResponse = await cacheClient.dictionarySetField(
+        cacheName,
+        key,
+        'my-field',
+        testValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `Expected CacheClient.dictionarySetField to be a success with no compression specified, got: '${setResponse.toString()}'`);
+
+      const getResponse = await cacheClient.dictionaryGetField(
+        cacheName,
+        key,
+        'my-field'
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `Expected CacheClient.dictionaryGetField to be a hit after CacheClient.dictionarySetField with no compression specified, got: '${getResponse.toString()}'`);
+
+      expect((getResponse as CacheGet.Hit).valueString()).toEqual(testValue);
+    });
+  });*/
 });

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -2576,7 +2576,7 @@ export class CacheDataClient implements IDataClient {
       await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
-          value.length
+          encodedValue.length
         }, ttl: ${ttl.ttlSeconds.toString() ?? 'null'}`
       );
 

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -116,8 +116,11 @@ import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 import {ConnectionError} from '@gomomento/sdk-core/dist/src/errors';
 import {common} from '@gomomento/generated-types/dist/common';
 import {
+  DictionarySetFieldCallOptions,
+  DictionarySetFieldsCallOptions,
   GetCallOptions,
   SetCallOptions,
+  ttlOrFromCacheTtl,
 } from '@gomomento/sdk-core/dist/src/utils';
 import grpcCache = cache.cache_client;
 import ECacheResult = cache_client.ECacheResult;
@@ -2488,7 +2491,7 @@ export class CacheDataClient implements IDataClient {
     dictionaryName: string,
     field: string | Uint8Array,
     value: string | Uint8Array,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    options?: DictionarySetFieldCallOptions
   ): Promise<CacheDictionarySetField.Response> {
     try {
       validateCacheName(cacheName);
@@ -2499,6 +2502,8 @@ export class CacheDataClient implements IDataClient {
         err => new CacheDictionarySetField.Error(err)
       );
     }
+
+    const ttl = ttlOrFromCacheTtl(options);
 
     try {
       await this.requestConcurrencySemaphore.acquire();
@@ -2570,7 +2575,7 @@ export class CacheDataClient implements IDataClient {
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>
       | Array<[string, string | Uint8Array]>,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    options?: DictionarySetFieldsCallOptions
   ): Promise<CacheDictionarySetFields.Response> {
     try {
       validateCacheName(cacheName);
@@ -2581,6 +2586,8 @@ export class CacheDataClient implements IDataClient {
         err => new CacheDictionarySetFields.Error(err)
       );
     }
+
+    const ttl = ttlOrFromCacheTtl(options);
 
     try {
       await this.requestConcurrencySemaphore.acquire();

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -153,7 +153,12 @@ import {
   Equal,
   NotEqual,
 } from '@gomomento/generated-types-webtext/dist/common_pb';
-import {SetCallOptions} from '@gomomento/sdk-core/dist/src/utils';
+import {
+  SetCallOptions,
+  DictionarySetFieldCallOptions,
+  DictionarySetFieldsCallOptions,
+  ttlOrFromCacheTtl,
+} from '@gomomento/sdk-core/dist/src/utils';
 
 export interface DataClientProps {
   configuration: Configuration;
@@ -2195,7 +2200,7 @@ export class CacheDataClient<
     dictionaryName: string,
     field: string | Uint8Array,
     value: string | Uint8Array,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    options?: DictionarySetFieldCallOptions
   ): Promise<CacheDictionarySetField.Response> {
     try {
       validateCacheName(cacheName);
@@ -2206,6 +2211,9 @@ export class CacheDataClient<
         err => new CacheDictionarySetField.Error(err)
       );
     }
+
+    const ttl = ttlOrFromCacheTtl(options);
+
     this.logger.trace(
       `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
         value.length
@@ -2272,7 +2280,7 @@ export class CacheDataClient<
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>
       | Array<[string, string | Uint8Array]>,
-    ttl: CollectionTtl = CollectionTtl.fromCacheTtl()
+    options?: DictionarySetFieldsCallOptions
   ): Promise<CacheDictionarySetFields.Response> {
     try {
       validateCacheName(cacheName);
@@ -2283,6 +2291,9 @@ export class CacheDataClient<
         err => new CacheDictionarySetFields.Error(err)
       );
     }
+
+    const ttl = ttlOrFromCacheTtl(options);
+
     this.logger.trace(
       `Issuing 'dictionarySetFields' request; elements: ${elements.toString()}, ttl: ${
         ttl.ttlSeconds.toString() ?? 'null'

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -67,6 +67,11 @@ import {
   SortedSetLengthByScoreCallOptions,
   SetCallOptions,
   GetCallOptions,
+  DictionaryGetFieldCallOptions,
+  DictionaryGetFieldsCallOptions,
+  DictionaryFetchCallOptions,
+  DictionarySetFieldCallOptions,
+  DictionarySetFieldsCallOptions,
 } from '../utils';
 import {IControlClient, IPingClient} from '../internal/clients';
 import {IMomentoCache} from './IMomentoCache';
@@ -88,8 +93,11 @@ export type ListPushBackOptions = FrontTruncatableCallOptions;
 export type ListPushFrontOptions = BackTruncatableCallOptions;
 export type SetAddElementOptions = CollectionCallOptions;
 export type SetAddElementsOptions = CollectionCallOptions;
-export type DictionarySetFieldOptions = CollectionCallOptions;
-export type DictionarySetFieldsOptions = CollectionCallOptions;
+export type DictionaryGetFieldOptions = DictionaryGetFieldCallOptions;
+export type DictionaryGetFieldsOptions = DictionaryGetFieldsCallOptions;
+export type DictionaryFetchOptions = DictionaryFetchCallOptions;
+export type DictionarySetFieldOptions = DictionarySetFieldCallOptions;
+export type DictionarySetFieldsOptions = DictionarySetFieldsCallOptions;
 export type DictionaryIncrementOptions = CollectionCallOptions;
 export type IncrementOptions = ScalarCallOptions;
 export type SortedSetPutElementOptions = CollectionCallOptions;
@@ -281,7 +289,8 @@ export interface ICacheClient extends IControlClient, IPingClient {
   dictionaryGetField(
     cacheName: string,
     dictionaryName: string,
-    field: string | Uint8Array
+    field: string | Uint8Array,
+    options?: DictionaryGetFieldOptions
   ): Promise<CacheDictionaryGetField.Response>;
   dictionaryGetFields(
     cacheName: string,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -80,7 +80,11 @@ import {
   ListPushBackOptions,
   ListConcatenateBackOptions,
   ListConcatenateFrontOptions,
+  DictionaryGetFieldOptions,
+  DictionaryGetFieldsOptions,
+  DictionaryFetchOptions,
   DictionarySetFieldOptions,
+  DictionarySetFieldsOptions,
   DictionaryIncrementOptions,
   SortedSetFetchByRankOptions,
   SortedSetPutElementOptions,
@@ -174,7 +178,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache to perform the lookup in.
    * @param {string | Uint8Array} key - The key to look up.
    * @param {GetOptions} [options]
-   * @param {decompress} [options.decompress] - Whether to decompress the value. Defaults to false.
+   * @param {decompress} [options.decompress=false] - Whether to decompress the value. Defaults to false.
    * @returns {Promise<CacheGet.Response>} -
    * {@link CacheGet.Hit} containing the value if one is found.
    * {@link CacheGet.Miss} if the key does not exist.
@@ -197,8 +201,8 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string | Uint8Array} value - The value to be stored.
    * @param {SetOptions} [options]
    * @param {number} [options.ttl] - The time to live for the item in the cache.
-   * @param {compress} [options.compress] - Whether to compress the value. Defaults to false.
    * Uses the client's default TTL if this is not supplied.
+   * @param {boolean} [options.compress=false] - Whether to compress the value. Defaults to false.
    * @returns {Promise<CacheSet.Response>} -
    * {@link CacheSet.Success} on success.
    * {@link CacheSet.Error} on failure.
@@ -914,6 +918,8 @@ export abstract class AbstractCacheClient implements ICacheClient {
    *
    * @param {string} cacheName - The cache to perform the lookup in.
    * @param {string} dictionaryName - The dictionary to fetch.
+   * @param {DictionaryFetchOptions} [options]
+   * @param {boolean} [options.decompress=false] - Whether to decompress the values. Defaults to false.
    * @returns {Promise<CacheDictionaryFetch.Response>} -
    * {@link CacheDictionaryFetch.Hit} containing the dictionary elements if the
    * dictionary exists.
@@ -922,10 +928,11 @@ export abstract class AbstractCacheClient implements ICacheClient {
    */
   public async dictionaryFetch(
     cacheName: string,
-    dictionaryName: string
+    dictionaryName: string,
+    options?: DictionaryFetchOptions
   ): Promise<CacheDictionaryFetch.Response> {
     const client = this.getNextDataClient();
-    return await client.dictionaryFetch(cacheName, dictionaryName);
+    return await client.dictionaryFetch(cacheName, dictionaryName, options);
   }
 
   /**
@@ -965,10 +972,10 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} dictionaryName - The dictionary to add to.
    * @param {string | Uint8Array} field - The field to set.
    * @param {string | Uint8Array} value - The value to store.
-   * @param {DictionarySetFieldOptions} options
+   * @param {DictionarySetFieldOptions} [options]
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
-   * Refreshes the dictionary's TTL using the client's default if this is not
-   * supplied.
+   *  Refreshes the dictionary's TTL using the client's default if this is not supplied.
+   * @param {boolean} [options.compress=false] - Whether to compress the value. Defaults to false.
    * @returns {Promise<CacheDictionarySetField.Response>} -
    * {@link CacheDictionarySetField.Success} on success.
    * {@link CacheDictionarySetField.Error} on failure.
@@ -986,7 +993,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
       dictionaryName,
       field,
       value,
-      options?.ttl
+      options
     );
   }
 
@@ -1002,6 +1009,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
    * Refreshes the dictionary's TTL using the client's default if this is not
    * supplied.
+   * @param {boolean} [options.compress=false] - Whether to compress the values. Defaults to false.
    * @returns {Promise<CacheDictionarySetFields.Response>} -
    * {@link CacheDictionarySetFields.Success} on success.
    * {@link CacheDictionarySetFields.Error} on failure.
@@ -1013,14 +1021,14 @@ export abstract class AbstractCacheClient implements ICacheClient {
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>
       | Array<[string, string | Uint8Array]>,
-    options?: DictionarySetFieldOptions
+    options?: DictionarySetFieldsOptions
   ): Promise<CacheDictionarySetFields.Response> {
     const client = this.getNextDataClient();
     return await client.dictionarySetFields(
       cacheName,
       dictionaryName,
       elements,
-      options?.ttl
+      options
     );
   }
 
@@ -1030,6 +1038,8 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache containing the dictionary.
    * @param {string} dictionaryName - The dictionary to look up.
    * @param {string | Uint8Array} field - The field to look up.
+   * @param {DictionaryGetFieldOptions} options
+   * @param {boolean} [options.decompress=false] - Whether to decompress the value. Defaults to false.
    * @returns {Promise<CacheDictionaryGetField.Response>} -
    * {@link CacheDictionaryGetField.Hit} containing the dictionary element if
    * one is found.
@@ -1039,10 +1049,16 @@ export abstract class AbstractCacheClient implements ICacheClient {
   public async dictionaryGetField(
     cacheName: string,
     dictionaryName: string,
-    field: string | Uint8Array
+    field: string | Uint8Array,
+    options?: DictionaryGetFieldOptions
   ): Promise<CacheDictionaryGetField.Response> {
     const client = this.getNextDataClient();
-    return await client.dictionaryGetField(cacheName, dictionaryName, field);
+    return await client.dictionaryGetField(
+      cacheName,
+      dictionaryName,
+      field,
+      options
+    );
   }
 
   /**
@@ -1051,6 +1067,8 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache containing the dictionary.
    * @param {string} dictionaryName - The dictionary to look up.
    * @param {string[] | Uint8Array[]} fields - The fields to look up.
+   * @param {DictionaryGetFieldsOptions} options
+   * @param {boolean} [options.decompress=false] - Whether to decompress the values. Defaults to false.
    * @returns {Promise<CacheDictionaryGetFields.Response>} -
    * {@link CacheDictionaryGetFields.Hit} containing the dictionary elements if
    * the dictionary exists.
@@ -1060,10 +1078,16 @@ export abstract class AbstractCacheClient implements ICacheClient {
   public async dictionaryGetFields(
     cacheName: string,
     dictionaryName: string,
-    fields: string[] | Uint8Array[]
+    fields: string[] | Uint8Array[],
+    options?: DictionaryGetFieldsOptions
   ): Promise<CacheDictionaryGetFields.Response> {
     const client = this.getNextDataClient();
-    return await client.dictionaryGetFields(cacheName, dictionaryName, fields);
+    return await client.dictionaryGetFields(
+      cacheName,
+      dictionaryName,
+      fields,
+      options
+    );
   }
 
   /**

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -1005,7 +1005,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} dictionaryName - The dictionary to add to.
    * @param {Map<string | Uint8Array, string | Uint8Array>} elements - The
    * elements to set.
-   * @param {DictionarySetFieldsOptions} options
+   * @param {DictionarySetFieldsOptions} [options]
    * @param {CollectionTtl} [options.ttl] - How the TTL should be managed.
    * Refreshes the dictionary's TTL using the client's default if this is not
    * supplied.
@@ -1038,7 +1038,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache containing the dictionary.
    * @param {string} dictionaryName - The dictionary to look up.
    * @param {string | Uint8Array} field - The field to look up.
-   * @param {DictionaryGetFieldOptions} options
+   * @param {DictionaryGetFieldOptions} [options]
    * @param {boolean} [options.decompress=false] - Whether to decompress the value. Defaults to false.
    * @returns {Promise<CacheDictionaryGetField.Response>} -
    * {@link CacheDictionaryGetField.Hit} containing the dictionary element if
@@ -1067,7 +1067,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache containing the dictionary.
    * @param {string} dictionaryName - The dictionary to look up.
    * @param {string[] | Uint8Array[]} fields - The fields to look up.
-   * @param {DictionaryGetFieldsOptions} options
+   * @param {DictionaryGetFieldsOptions} [options]
    * @param {boolean} [options.decompress=false] - Whether to decompress the values. Defaults to false.
    * @returns {Promise<CacheDictionaryGetFields.Response>} -
    * {@link CacheDictionaryGetFields.Hit} containing the dictionary elements if

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -55,7 +55,15 @@ import {
   CacheSetIfAbsentOrEqual,
   CacheSetSample,
 } from '../../../index';
-import {GetCallOptions, SetCallOptions} from '../../../utils';
+import {
+  GetCallOptions,
+  SetCallOptions,
+  DictionaryFetchCallOptions,
+  DictionaryGetFieldCallOptions,
+  DictionaryGetFieldsCallOptions,
+  DictionarySetFieldCallOptions,
+  DictionarySetFieldsCallOptions,
+} from '../../../utils';
 
 export interface IDataClient {
   get(
@@ -216,7 +224,7 @@ export interface IDataClient {
     dictionaryName: string,
     field: string | Uint8Array,
     value: string | Uint8Array,
-    ttl?: CollectionTtl
+    options?: DictionarySetFieldCallOptions
   ): Promise<CacheDictionarySetField.Response>;
   dictionarySetFields(
     cacheName: string,
@@ -225,21 +233,24 @@ export interface IDataClient {
       | Map<string | Uint8Array, string | Uint8Array>
       | Record<string, string | Uint8Array>
       | Array<[string, string | Uint8Array]>,
-    ttl?: CollectionTtl
+    options?: DictionarySetFieldsCallOptions
   ): Promise<CacheDictionarySetFields.Response>;
   dictionaryGetField(
     cacheName: string,
     dictionaryName: string,
-    field: string | Uint8Array
+    field: string | Uint8Array,
+    options?: DictionaryGetFieldCallOptions
   ): Promise<CacheDictionaryGetField.Response>;
   dictionaryGetFields(
     cacheName: string,
     dictionaryName: string,
-    fields: string[] | Uint8Array[]
+    fields: string[] | Uint8Array[],
+    options?: DictionaryGetFieldsCallOptions
   ): Promise<CacheDictionaryGetFields.Response>;
   dictionaryFetch(
     cacheName: string,
-    dictionaryName: string
+    dictionaryName: string,
+    options?: DictionaryFetchCallOptions
   ): Promise<CacheDictionaryFetch.Response>;
   dictionaryIncrement(
     cacheName: string,

--- a/packages/core/src/utils/cache-call-options.ts
+++ b/packages/core/src/utils/cache-call-options.ts
@@ -7,13 +7,26 @@ export interface ScalarCallOptions {
   ttl?: number;
 }
 
-export interface SetCallOptions extends ScalarCallOptions {
+export interface CompressableCallOptions {
+  /**
+   * Whether to compress the data.
+   */
   compress?: boolean;
 }
 
-export interface GetCallOptions {
+export interface DecompressableCallOptions {
+  /**
+   * Whether to decompress the data.
+   */
   decompress?: boolean;
 }
+
+export interface SetCallOptions
+  extends ScalarCallOptions,
+    CompressableCallOptions {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface GetCallOptions extends DecompressableCallOptions {}
 
 export interface CollectionCallOptions {
   /**
@@ -21,6 +34,37 @@ export interface CollectionCallOptions {
    */
   ttl?: CollectionTtl;
 }
+
+/**
+ * Returns the TTL from the options or refresh with the cache TTL.
+ *
+ * @param options The options to get the TTL from.
+ * @returns The TTL from the options or a default value.
+ */
+export function ttlOrFromCacheTtl(
+  options?: CollectionCallOptions
+): CollectionTtl {
+  return options?.ttl ?? CollectionTtl.fromCacheTtl();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DictionaryGetFieldCallOptions
+  extends DecompressableCallOptions {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DictionaryGetFieldsCallOptions
+  extends DecompressableCallOptions {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DictionaryFetchCallOptions extends DecompressableCallOptions {}
+
+export interface DictionarySetFieldCallOptions
+  extends CollectionCallOptions,
+    CompressableCallOptions {}
+
+export interface DictionarySetFieldsCallOptions
+  extends CollectionCallOptions,
+    CompressableCallOptions {}
 
 export interface FrontTruncatableCallOptions extends CollectionCallOptions {
   /**


### PR DESCRIPTION
Adds compression support for dictionaries, specifically on `dictionarySetField`, `dictionarySetFields`, `dictionaryGetField`, `dictionaryGetFields`, and `dictionaryFetch`. We add integration tests on the compression library and refactor the library as well to handle comparing `Uint8Array`s better.

In a future PR we ought to refactor the backend to reduce code duplication. With the integration tests in place now, that should be less risky.