### PR TITLE
feat: rename GetBatch and SetBatch response objects to CacheGetBatch and CacheSetBatch

### DIFF
--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -92,14 +92,15 @@ import {
   PutWebhook,
   RotateWebhookSecret,
   GetWebhookSecret,
-  GetBatch,
-  SetBatch,
+  // GetBatch,
+  // SetBatch,
   ReadConcern,
   CacheSetSample,
   CacheKeyExists,
   CacheKeysExist,
 } from '@gomomento/sdk';
 import * as crypto from 'crypto';
+
 
 function retrieveApiKeyFromYourSecretsManager(): string {
   // this is not a valid API key but conforms to the syntax requirements.
@@ -385,37 +386,37 @@ async function example_API_SetIfAbsentOrEqual(cacheClient: CacheClient, cacheNam
   }
 }
 
-async function example_API_SetBatch(cacheClient: CacheClient, cacheName: string) {
-  const values = new Map<string, string>([
-    ['abc', '123'],
-    ['xyz', '321'],
-    ['123', 'xyz'],
-    ['321', 'abc'],
-  ]);
-  const result = await cacheClient.setBatch(cacheName, values);
-  if (result instanceof SetBatch.Success) {
-    console.log('Keys and values stored successfully');
-  } else if (result instanceof SetBatch.Error) {
-    throw new Error(
-      `An error occurred while attempting to batch set in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
-    );
-  }
-}
+// async function example_API_SetBatch(cacheClient: CacheClient, cacheName: string) {
+//   const values = new Map<string, string>([
+//     ['abc', '123'],
+//     ['xyz', '321'],
+//     ['123', 'xyz'],
+//     ['321', 'abc'],
+//   ]);
+//   const result = await cacheClient.setBatch(cacheName, values);
+//   if (result instanceof SetBatch.Success) {
+//     console.log('Keys and values stored successfully');
+//   } else if (result instanceof SetBatch.Error) {
+//     throw new Error(
+//       `An error occurred while attempting to batch set in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
+//     );
+//   }
+// }
 
-async function example_API_GetBatch(cacheClient: CacheClient, cacheName: string) {
-  const keys = ['abc', 'xyz', '123', '321'];
-  const result = await cacheClient.getBatch(cacheName, keys);
-  if (result instanceof GetBatch.Success) {
-    const values = result.values();
-    for (const key of keys) {
-      console.log(`Retrieved value for key '${key}': ${values[key]}`);
-    }
-  } else if (result instanceof GetBatch.Error) {
-    throw new Error(
-      `An error occurred while attempting to batch get in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
-    );
-  }
-}
+// async function example_API_GetBatch(cacheClient: CacheClient, cacheName: string) {
+//   const keys = ['abc', 'xyz', '123', '321'];
+//   const result = await cacheClient.getBatch(cacheName, keys);
+//   if (result instanceof GetBatch.Success) {
+//     const values = result.values();
+//     for (const key of keys) {
+//       console.log(`Retrieved value for key '${key}': ${values[key]}`);
+//     }
+//   } else if (result instanceof GetBatch.Error) {
+//     throw new Error(
+//       `An error occurred while attempting to batch get in cache '${cacheName}': ${result.errorCode()}: ${result.toString()}`
+//     );
+//   }
+// }
 
 async function example_API_ListFetch(cacheClient: CacheClient, cacheName: string) {
   await cacheClient.listConcatenateBack(cacheName, 'test-list', ['a', 'b', 'c']);
@@ -1568,8 +1569,8 @@ async function main() {
     await example_API_SetIfNotEqual(cacheClient, cacheName);
     await example_API_SetIfPresentAndNotEqual(cacheClient, cacheName);
     await example_API_SetIfAbsentOrEqual(cacheClient, cacheName);
-    await example_API_SetBatch(cacheClient, cacheName);
-    await example_API_GetBatch(cacheClient, cacheName);
+    // await example_API_SetBatch(cacheClient, cacheName);
+    // await example_API_GetBatch(cacheClient, cacheName);
 
     await example_API_ListFetch(cacheClient, cacheName);
     await example_API_ListConcatenateBack(cacheClient, cacheName);

--- a/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
+++ b/examples/nodejs/cache/doc-example-files/doc-examples-js-apis.ts
@@ -101,7 +101,6 @@ import {
 } from '@gomomento/sdk';
 import * as crypto from 'crypto';
 
-
 function retrieveApiKeyFromYourSecretsManager(): string {
   // this is not a valid API key but conforms to the syntax requirements.
   const fakeTestV1ApiKey =

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -73,8 +73,8 @@ import * as CacheKeysExist from '@gomomento/sdk-core/dist/src/messages/responses
 import * as CacheUpdateTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-update';
 import * as CacheIncreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-increase';
 import * as CacheDecreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-decrease';
-import * as GetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-get';
-import * as SetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-set';
+import * as CacheGetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-get';
+import * as CacheSetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-set';
 
 // TopicClient Response Types
 import * as TopicPublish from '@gomomento/sdk-core/dist/src/messages/responses/topic-publish';
@@ -353,8 +353,8 @@ export {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
   // TopicClient
   TopicConfigurations,
   TopicConfiguration,

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -67,13 +67,13 @@ import {
   CollectionTtl,
   CompressionLevel,
   CredentialProvider,
-  GetBatch,
+  CacheGetBatch,
   ICompression,
   InvalidArgumentError,
   ItemType,
   MomentoLogger,
   MomentoLoggerFactory,
-  SetBatch,
+  CacheSetBatch,
   SortedSetOrder,
   UnknownError,
 } from '..';
@@ -1515,13 +1515,13 @@ export class CacheDataClient implements IDataClient {
   public async getBatch(
     cacheName: string,
     keys: Array<string | Uint8Array>
-  ): Promise<GetBatch.Response> {
+  ): Promise<CacheGetBatch.Response> {
     try {
       validateCacheName(cacheName);
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err => new GetBatch.Error(err)
+        err => new CacheGetBatch.Error(err)
       );
     }
 
@@ -1542,7 +1542,7 @@ export class CacheDataClient implements IDataClient {
   private async sendGetBatch(
     cacheName: string,
     keys: Uint8Array[]
-  ): Promise<GetBatch.Response> {
+  ): Promise<CacheGetBatch.Response> {
     const getRequests = [];
     for (const k of keys) {
       const getRequest = new grpcCache._GetRequest({
@@ -1578,13 +1578,13 @@ export class CacheDataClient implements IDataClient {
       });
 
       call.on('end', () => {
-        resolve(new GetBatch.Success(results, keys));
+        resolve(new CacheGetBatch.Success(results, keys));
       });
 
       call.on('error', (err: ServiceError | null) => {
         this.cacheServiceErrorMapper.resolveOrRejectError({
           err: err,
-          errorResponseFactoryFn: e => new GetBatch.Error(e),
+          errorResponseFactoryFn: e => new CacheGetBatch.Error(e),
           resolveFn: resolve,
           rejectFn: reject,
         });
@@ -1598,7 +1598,7 @@ export class CacheDataClient implements IDataClient {
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     ttl?: number
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     try {
       validateCacheName(cacheName);
       if (ttl !== undefined) {
@@ -1607,7 +1607,7 @@ export class CacheDataClient implements IDataClient {
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err => new SetBatch.Error(err)
+        err => new CacheSetBatch.Error(err)
       );
     }
 
@@ -1630,7 +1630,7 @@ export class CacheDataClient implements IDataClient {
     cacheName: string,
     items: Record<string, Uint8Array>[],
     ttlSeconds: number
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     const setRequests = [];
     for (const item of items) {
       const setRequest = new grpcCache._SetRequest({
@@ -1666,13 +1666,13 @@ export class CacheDataClient implements IDataClient {
       });
 
       call.on('end', () => {
-        resolve(new SetBatch.Success(results));
+        resolve(new CacheSetBatch.Success(results));
       });
 
       call.on('error', (err: ServiceError | null) => {
         this.cacheServiceErrorMapper.resolveOrRejectError({
           err: err,
-          errorResponseFactoryFn: e => new SetBatch.Error(e),
+          errorResponseFactoryFn: e => new CacheSetBatch.Error(e),
           resolveFn: resolve,
           rejectFn: reject,
         });

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -70,8 +70,8 @@ import * as CacheKeysExist from '@gomomento/sdk-core/dist/src/messages/responses
 import * as CacheUpdateTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-update';
 import * as CacheIncreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-increase';
 import * as CacheDecreaseTtl from '@gomomento/sdk-core/dist/src/messages/responses/cache-ttl-decrease';
-import * as GetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-get';
-import * as SetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-set';
+import * as CacheGetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-get';
+import * as CacheSetBatch from '@gomomento/sdk-core/dist/src/messages/responses/cache-batch-set';
 
 // TopicClient Response Types
 import * as TopicPublish from '@gomomento/sdk-core/dist/src/messages/responses/topic-publish';
@@ -252,8 +252,8 @@ export {
   CacheSetIfNotEqual,
   CacheSetIfPresentAndNotEqual,
   CacheSetIfAbsentOrEqual,
-  SetBatch,
-  GetBatch,
+  CacheSetBatch,
+  CacheGetBatch,
   CacheDelete,
   CacheFlush,
   CreateCache,

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -58,8 +58,8 @@ import {
   SortedSetOrder,
   UnknownError,
   CacheDictionaryLength,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
 } from '..';
 import {Configuration} from '../config/configuration';
 import {Request, RpcError, UnaryResponse} from 'grpc-web';
@@ -977,13 +977,13 @@ export class CacheDataClient<
   public async getBatch(
     cacheName: string,
     keys: Array<string | Uint8Array>
-  ): Promise<GetBatch.Response> {
+  ): Promise<CacheGetBatch.Response> {
     try {
       validateCacheName(cacheName);
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err => new GetBatch.Error(err)
+        err => new CacheGetBatch.Error(err)
       );
     }
     this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
@@ -998,7 +998,7 @@ export class CacheDataClient<
   private async sendGetBatch(
     cacheName: string,
     keys: string[]
-  ): Promise<GetBatch.Response> {
+  ): Promise<CacheGetBatch.Response> {
     const getRequests = [];
     for (const k of keys) {
       const getRequest = new _GetRequest();
@@ -1033,7 +1033,7 @@ export class CacheDataClient<
 
       call.on('end', () => {
         resolve(
-          new GetBatch.Success(
+          new CacheGetBatch.Success(
             results,
             keys.map(key => this.convertToUint8Array(key))
           )
@@ -1043,7 +1043,7 @@ export class CacheDataClient<
       call.on('error', (err: RpcError) => {
         this.cacheServiceErrorMapper.resolveOrRejectError({
           err: err,
-          errorResponseFactoryFn: e => new GetBatch.Error(e),
+          errorResponseFactoryFn: e => new CacheGetBatch.Error(e),
           resolveFn: resolve,
           rejectFn: reject,
         });
@@ -1057,7 +1057,7 @@ export class CacheDataClient<
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     ttl?: number
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     try {
       validateCacheName(cacheName);
       if (ttl !== undefined) {
@@ -1066,7 +1066,7 @@ export class CacheDataClient<
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err => new SetBatch.Error(err)
+        err => new CacheSetBatch.Error(err)
       );
     }
 
@@ -1086,7 +1086,7 @@ export class CacheDataClient<
     cacheName: string,
     items: Record<string, string>[],
     ttlSeconds: number
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     const setRequests = [];
     for (const item of items) {
       const setRequest = new _SetRequest();
@@ -1121,13 +1121,13 @@ export class CacheDataClient<
       });
 
       call.on('end', () => {
-        resolve(new SetBatch.Success(results));
+        resolve(new CacheSetBatch.Success(results));
       });
 
       call.on('error', (err: RpcError) => {
         this.cacheServiceErrorMapper.resolveOrRejectError({
           err: err,
-          errorResponseFactoryFn: e => new SetBatch.Error(e),
+          errorResponseFactoryFn: e => new CacheSetBatch.Error(e),
           resolveFn: resolve,
           rejectFn: reject,
         });

--- a/packages/common-integration-tests/src/batch-get-set.ts
+++ b/packages/common-integration-tests/src/batch-get-set.ts
@@ -1,9 +1,9 @@
 import {
   CacheGet,
   CacheSet,
-  GetBatch,
+  CacheGetBatch,
   ICacheClient,
-  SetBatch,
+  CacheSetBatch,
 } from '@gomomento/sdk-core';
 import {expectWithMessage} from './common-int-test-utils';
 import {delay} from './auth-client';
@@ -23,11 +23,11 @@ export function runBatchGetSetTests(
 
       // Check get batch response
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(GetBatch.Success);
+        expect(response).toBeInstanceOf(CacheGetBatch.Success);
       }, `expected SUCCESS for keys ${keys.toString()}, received ${response.toString()}`);
 
       // Check each response in the batch
-      const getResults = (response as GetBatch.Success).results();
+      const getResults = (response as CacheGetBatch.Success).results();
       expectWithMessage(() => {
         expect(getResults.length).toEqual(keys.length);
       }, `expected non-empty results, received ${getResults.toString()}`);
@@ -54,11 +54,11 @@ export function runBatchGetSetTests(
         items
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(SetBatch.Success);
+        expect(response).toBeInstanceOf(CacheSetBatch.Success);
       }, `expected SUCCESS, received ${response.toString()}`);
 
       // Check each response in the set batch
-      const setResults = (response as SetBatch.Success).results();
+      const setResults = (response as CacheSetBatch.Success).results();
       const keys = [...items.keys()];
       expectWithMessage(() => {
         expect(setResults.length).toEqual(keys.length);
@@ -87,11 +87,11 @@ export function runBatchGetSetTests(
         {ttl: 3}
       );
       expectWithMessage(() => {
-        expect(response).toBeInstanceOf(SetBatch.Success);
+        expect(response).toBeInstanceOf(CacheSetBatch.Success);
       }, `expected SUCCESS, received ${response.toString()}`);
 
       // Check each response in the set batch
-      const setResults = (response as SetBatch.Success).results();
+      const setResults = (response as CacheSetBatch.Success).results();
       const keys = [...items.keys()];
       expectWithMessage(() => {
         expect(setResults.length).toEqual(keys.length);
@@ -111,11 +111,11 @@ export function runBatchGetSetTests(
         keys
       );
       expectWithMessage(() => {
-        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+        expect(getResponse).toBeInstanceOf(CacheGetBatch.Success);
       }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
       // Check each response in the get batch
-      const getResults = (getResponse as GetBatch.Success).results();
+      const getResults = (getResponse as CacheGetBatch.Success).results();
       expectWithMessage(() => {
         expect(getResults.length).toEqual(keys.length);
       }, `expected non-empty results, received ${getResults.toString()}`);
@@ -142,11 +142,11 @@ export function runBatchGetSetTests(
         items
       );
       expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(SetBatch.Success);
+        expect(setResponse).toBeInstanceOf(CacheSetBatch.Success);
       }, `expected SUCCESS, received ${setResponse.toString()}`);
 
       // Check each response in the set batch
-      const setResults = (setResponse as SetBatch.Success).results();
+      const setResults = (setResponse as CacheSetBatch.Success).results();
       const keys = [...items.keys()];
       expectWithMessage(() => {
         expect(setResults.length).toEqual(keys.length);
@@ -164,11 +164,11 @@ export function runBatchGetSetTests(
         keys
       );
       expectWithMessage(() => {
-        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+        expect(getResponse).toBeInstanceOf(CacheGetBatch.Success);
       }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
       // Check each response in the get batch
-      const getResults = (getResponse as GetBatch.Success).results();
+      const getResults = (getResponse as CacheGetBatch.Success).results();
       expectWithMessage(() => {
         expect(getResults.length).toEqual(keys.length);
       }, `expected non-empty results, received ${getResults.toString()}`);
@@ -203,11 +203,11 @@ export function runBatchGetSetTests(
         items
       );
       expectWithMessage(() => {
-        expect(setResponse).toBeInstanceOf(SetBatch.Success);
+        expect(setResponse).toBeInstanceOf(CacheSetBatch.Success);
       }, `expected SUCCESS, received ${setResponse.toString()}`);
 
       // Check each response in the set batch
-      const setResults = (setResponse as SetBatch.Success).results();
+      const setResults = (setResponse as CacheSetBatch.Success).results();
       const setKeys = [...items.keys()];
       expectWithMessage(() => {
         expect(setResults.length).toEqual(setKeys.length);
@@ -226,11 +226,11 @@ export function runBatchGetSetTests(
         keys
       );
       expectWithMessage(() => {
-        expect(getResponse).toBeInstanceOf(GetBatch.Success);
+        expect(getResponse).toBeInstanceOf(CacheGetBatch.Success);
       }, `expected SUCCESS for keys ${keys.toString()}, received ${getResponse.toString()}`);
 
       // Check each response in the get batch
-      const getResults = (getResponse as GetBatch.Success).results();
+      const getResults = (getResponse as CacheGetBatch.Success).results();
       expectWithMessage(() => {
         expect(getResults.length).toEqual(keys.length);
       }, `expected non-empty results, received ${getResults.toString()}`);

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -45,8 +45,8 @@ import {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   CacheDictionaryGetFields,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
   CacheSetIfAbsent,
   CacheSetIfPresent,
   CacheSetIfEqual,
@@ -176,14 +176,14 @@ export interface ICacheClient extends IControlClient, IPingClient {
   getBatch(
     cacheName: string,
     keys: Array<string | Uint8Array>
-  ): Promise<GetBatch.Response>;
+  ): Promise<CacheGetBatch.Response>;
   setBatch(
     cacheName: string,
     items:
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     options?: SetBatchOptions
-  ): Promise<SetBatch.Response>;
+  ): Promise<CacheSetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;
   setAddElement(
     cacheName: string,

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -52,8 +52,8 @@ import {
   CacheDecreaseTtl,
   CacheDictionaryGetFields,
   CacheDictionaryLength,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -146,13 +146,13 @@ export interface IMomentoCache {
     equal: string | Uint8Array,
     options?: SetIfAbsentOrEqualOptions
   ): Promise<CacheSetIfAbsentOrEqual.Response>;
-  getBatch(keys: string[] | Uint8Array[]): Promise<GetBatch.Response>;
+  getBatch(keys: string[] | Uint8Array[]): Promise<CacheGetBatch.Response>;
   setBatch(
     items:
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     options?: SetBatchOptions
-  ): Promise<SetBatch.Response>;
+  ): Promise<CacheSetBatch.Response>;
   setFetch(setName: string): Promise<CacheSetFetch.Response>;
   setAddElement(
     setName: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,8 +60,8 @@ import * as CacheKeysExist from './messages/responses/cache-keys-exist';
 import * as CacheUpdateTtl from './messages/responses/cache-ttl-update';
 import * as CacheIncreaseTtl from './messages/responses/cache-ttl-increase';
 import * as CacheDecreaseTtl from './messages/responses/cache-ttl-decrease';
-import * as SetBatch from './messages/responses/cache-batch-set';
-import * as GetBatch from './messages/responses/cache-batch-get';
+import * as CacheSetBatch from './messages/responses/cache-batch-set';
+import * as CacheGetBatch from './messages/responses/cache-batch-get';
 
 // TopicClient Response Types
 import * as TopicPublish from './messages/responses/topic-publish';
@@ -294,8 +294,8 @@ export {
   CacheIncreaseTtl,
   CacheDecreaseTtl,
   CacheInfo,
-  SetBatch,
-  GetBatch,
+  CacheSetBatch,
+  CacheGetBatch,
   // TopicClient Response Types
   TopicPublish,
   TopicSubscribe,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -59,8 +59,8 @@ import {
   CacheUpdateTtl,
   CacheIncreaseTtl,
   CacheDecreaseTtl,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
   InvalidArgumentError,
   CacheSetIfAbsent,
   CacheSetIfPresent,
@@ -243,14 +243,14 @@ export abstract class AbstractCacheClient implements ICacheClient {
    *
    * @param {string} cacheName - The cache to perform the lookup in.
    * @param {string[] | Uint8Array[]} keys - The list of keys to look up.
-   * @returns {Promise<GetBatch.Response>} -
-   * {@link GetBatch.Success} containing the values if they were found.
-   * {@link GetBatch.Error} on failure.
+   * @returns {Promise<CacheGetBatch.Response>} -
+   * {@link CacheGetBatch.Success} containing the values if they were found.
+   * {@link CacheGetBatch.Error} on failure.
    */
   public async getBatch(
     cacheName: string,
     keys: Array<string | Uint8Array>
-  ): Promise<GetBatch.Response> {
+  ): Promise<CacheGetBatch.Response> {
     return await this.getNextDataClient().getBatch(cacheName, keys);
   }
 
@@ -263,9 +263,9 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {SetOptions} [options]
    * @param {number} [options.ttl] - The time to live for the items in the cache.
    * Uses the client's default TTL if this is not supplied.
-   * @returns {Promise<CacheSet.Response>} -
-   * {@link SetBatch.Success} on success.
-   * {@link SetBatch.Error} on failure.
+   * @returns {Promise<CacheSetBatch.Response>} -
+   * {@link CacheSetBatch.Success} on success.
+   * {@link CacheSetBatch.Error} on failure.
    */
   public async setBatch(
     cacheName: string,
@@ -273,7 +273,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     options?: SetBatchOptions
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     const client = this.getNextDataClient();
     return await client.setBatch(cacheName, items, options?.ttl);
   }

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -45,8 +45,8 @@ import {
   CacheDecreaseTtl,
   CacheDictionaryLength,
   CacheDictionaryGetFields,
-  SetBatch,
-  GetBatch,
+  CacheSetBatch,
+  CacheGetBatch,
   CacheSetIfAbsent,
   CacheSetIfPresent,
   CacheSetIfEqual,
@@ -132,14 +132,14 @@ export interface IDataClient {
   getBatch(
     cacheName: string,
     keys: Array<string | Uint8Array>
-  ): Promise<GetBatch.Response>;
+  ): Promise<CacheGetBatch.Response>;
   setBatch(
     cacheName: string,
     items:
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     ttl?: number
-  ): Promise<SetBatch.Response>;
+  ): Promise<CacheSetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;
   setAddElements(
     cacheName: string,

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -53,8 +53,8 @@ import {
   CacheSortedSetRemoveElements,
   CacheDictionaryGetFields,
   CacheDictionaryLength,
-  GetBatch,
-  SetBatch,
+  CacheGetBatch,
+  CacheSetBatch,
   CacheSetSample,
 } from '../../../index';
 import {
@@ -202,7 +202,7 @@ export class MomentoCache implements IMomentoCache {
       options
     );
   }
-  getBatch(keys: string[] | Uint8Array[]): Promise<GetBatch.Response> {
+  getBatch(keys: string[] | Uint8Array[]): Promise<CacheGetBatch.Response> {
     return this.cacheClient.getBatch(this.cacheName, keys);
   }
   setBatch(
@@ -210,7 +210,7 @@ export class MomentoCache implements IMomentoCache {
       | Record<string, string | Uint8Array>
       | Map<string | Uint8Array, string | Uint8Array>,
     options?: SetBatchOptions
-  ): Promise<SetBatch.Response> {
+  ): Promise<CacheSetBatch.Response> {
     return this.cacheClient.setBatch(this.cacheName, items, options);
   }
   setFetch(setName: string): Promise<CacheSetFetch.Response> {


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/785

Renames objects for better consistency with the other cache response objects.
Will follow-up to update example code after this change is released.