### PR TITLE
feat: make max concurrent requests an opt-in config, remove default setting

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -35,7 +35,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
   private readonly logger: MomentoLogger;
   private readonly notYetAbstractedControlClient: CacheControlClient;
   private readonly _configuration: Configuration;
-  private dataRequestConcurrencySemaphore: Semaphore;
+  private dataRequestConcurrencySemaphore: Semaphore | undefined = undefined;
 
   /**
    * Creates an instance of CacheClient.
@@ -50,12 +50,15 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
       configuration: configuration,
     };
 
+    let semaphore: Semaphore | undefined = undefined;
     const numConcurrentRequests = configuration
       .getTransportStrategy()
       .getGrpcConfig()
       .getConcurrentRequestsLimit();
-    validateConcurrentRequestsLimit(numConcurrentRequests);
-    const semaphore = new Semaphore(numConcurrentRequests);
+    if (numConcurrentRequests !== null && numConcurrentRequests !== undefined) {
+      validateConcurrentRequestsLimit(numConcurrentRequests);
+      semaphore = new Semaphore(numConcurrentRequests);
+    }
 
     const controlClient = new CacheControlClient({
       configuration: configuration,
@@ -79,7 +82,9 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
   }
 
   public close() {
-    this.dataRequestConcurrencySemaphore.purge();
+    if (this.dataRequestConcurrencySemaphore !== undefined) {
+      this.dataRequestConcurrencySemaphore.purge();
+    }
     this.controlClient.close();
     this.dataClients.map(dc => dc.close());
     this._configuration.getMiddlewares().map(m => {

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -13,7 +13,7 @@ import {CacheClientProps, EagerCacheClientProps} from './cache-client-props';
 import {
   range,
   Semaphore,
-  validateConcurrentRequestsLimit,
+  validateMaxConcurrentRequests,
   validateTimeout,
   validateTtlSeconds,
 } from '@gomomento/sdk-core/dist/src/internal/utils';
@@ -54,9 +54,9 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     const numConcurrentRequests = configuration
       .getTransportStrategy()
       .getGrpcConfig()
-      .getConcurrentRequestsLimit();
+      .getMaxConcurrentRequests();
     if (numConcurrentRequests !== null && numConcurrentRequests !== undefined) {
-      validateConcurrentRequestsLimit(numConcurrentRequests);
+      validateMaxConcurrentRequests(numConcurrentRequests);
       semaphore = new Semaphore(numConcurrentRequests);
     }
 

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -162,9 +162,9 @@ export interface GrpcConfiguration {
   withNumClients(numClients: number): GrpcConfiguration;
 
   /**
-   * @returns {number} the maximum number of concurrent requests that can be made to the server.
+   * returns the maximum number of concurrent requests that can be made to the server.
    */
-  getConcurrentRequestsLimit(): number;
+  getConcurrentRequestsLimit(): number | undefined;
 
   /**
    * Copy constructor for overriding the maximum number of concurrent requests

--- a/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/grpc-configuration.ts
@@ -22,7 +22,7 @@ export interface GrpcConfigurationProps {
    * number of requests that will be made concurrently across all of the internal clients.
    * If this is not set, it will default to the defaultRequestConcurrencyLimit.
    */
-  concurrentRequestsLimit?: number;
+  maxConcurrentRequests?: number;
 
   /**
    * Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
@@ -164,14 +164,12 @@ export interface GrpcConfiguration {
   /**
    * returns the maximum number of concurrent requests that can be made to the server.
    */
-  getConcurrentRequestsLimit(): number | undefined;
+  getMaxConcurrentRequests(): number | undefined;
 
   /**
    * Copy constructor for overriding the maximum number of concurrent requests
-   * @param {number} concurrentRequestsLimit the maximum number of concurrent requests that can be made to the server
+   * @param {number} maxConcurrentRequests the maximum number of concurrent requests that can be made to the server
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified maximum number of concurrent requests
    */
-  withConcurrentRequestsLimit(
-    concurrentRequestsLimit: number
-  ): GrpcConfiguration;
+  withMaxConcurrentRequests(maxConcurrentRequests: number): GrpcConfiguration;
 }

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -1,7 +1,5 @@
 import {GrpcConfiguration, GrpcConfigurationProps} from './grpc-configuration';
 
-const defaultRequestConcurrencyLimit = 100;
-
 export interface TransportStrategy {
   /**
    * Configures the low-level gRPC settings for the Momento client's communication
@@ -55,9 +53,9 @@ export interface TransportStrategy {
   withMaxClientAgeMillis(maxClientAgeMillis: number): TransportStrategy;
 
   /**
-   * @returns {number} the maximum number of concurrent requests that can be made by the client.
+   * returns the maximum number of concurrent requests that can be made by the client.
    */
-  getConcurrentRequestsLimit(): number;
+  getConcurrentRequestsLimit(): number | undefined;
 
   /**
    * Copy constructor to update the maximum number of concurrent requests that can be made by the client.
@@ -95,7 +93,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly deadlineMillis: number;
   private readonly maxSessionMemoryMb: number;
   private readonly numClients: number;
-  private readonly concurrentRequestsLimit: number;
+  private readonly concurrentRequestsLimit?: number;
   private readonly keepAlivePermitWithoutCalls?: number;
   private readonly keepAliveTimeoutMs?: number;
   private readonly keepAliveTimeMs?: number;
@@ -111,14 +109,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
       // This is the previously hardcoded value and a safe default for most environments.
       this.numClients = 6;
     }
-    if (
-      props.concurrentRequestsLimit !== undefined &&
-      props.concurrentRequestsLimit !== null
-    ) {
-      this.concurrentRequestsLimit = props.concurrentRequestsLimit;
-    } else {
-      this.concurrentRequestsLimit = defaultRequestConcurrencyLimit;
-    }
+    this.concurrentRequestsLimit = props.concurrentRequestsLimit;
     this.keepAliveTimeMs = props.keepAliveTimeMs;
     this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;
     this.keepAlivePermitWithoutCalls = props.keepAlivePermitWithoutCalls;
@@ -182,7 +173,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     });
   }
 
-  getConcurrentRequestsLimit(): number {
+  getConcurrentRequestsLimit(): number | undefined {
     return this.concurrentRequestsLimit;
   }
 
@@ -252,7 +243,7 @@ export class StaticTransportStrategy implements TransportStrategy {
     });
   }
 
-  getConcurrentRequestsLimit(): number {
+  getConcurrentRequestsLimit(): number | undefined {
     return this.grpcConfig.getConcurrentRequestsLimit();
   }
 

--- a/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/transport-strategy.ts
@@ -55,16 +55,14 @@ export interface TransportStrategy {
   /**
    * returns the maximum number of concurrent requests that can be made by the client.
    */
-  getConcurrentRequestsLimit(): number | undefined;
+  getMaxConcurrentRequests(): number | undefined;
 
   /**
    * Copy constructor to update the maximum number of concurrent requests that can be made by the client.
-   * @param {number} concurrentRequestsLimit
+   * @param {number} maxConcurrentRequests
    * @returns {TransportStrategy} a new TransportStrategy with the specified concurrent requests limit.
    */
-  withConcurrentRequestsLimit(
-    concurrentRequestsLimit: number
-  ): TransportStrategy;
+  withMaxConcurrentRequests(maxConcurrentRequests: number): TransportStrategy;
 }
 
 export interface TransportStrategyProps {
@@ -93,7 +91,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
   private readonly deadlineMillis: number;
   private readonly maxSessionMemoryMb: number;
   private readonly numClients: number;
-  private readonly concurrentRequestsLimit?: number;
+  private readonly maxConcurrentRequests?: number;
   private readonly keepAlivePermitWithoutCalls?: number;
   private readonly keepAliveTimeoutMs?: number;
   private readonly keepAliveTimeMs?: number;
@@ -109,7 +107,7 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
       // This is the previously hardcoded value and a safe default for most environments.
       this.numClients = 6;
     }
-    this.concurrentRequestsLimit = props.concurrentRequestsLimit;
+    this.maxConcurrentRequests = props.maxConcurrentRequests;
     this.keepAliveTimeMs = props.keepAliveTimeMs;
     this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;
     this.keepAlivePermitWithoutCalls = props.keepAlivePermitWithoutCalls;
@@ -173,18 +171,16 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     });
   }
 
-  getConcurrentRequestsLimit(): number | undefined {
-    return this.concurrentRequestsLimit;
+  getMaxConcurrentRequests(): number | undefined {
+    return this.maxConcurrentRequests;
   }
 
-  withConcurrentRequestsLimit(
-    concurrentRequestsLimit: number
-  ): GrpcConfiguration {
+  withMaxConcurrentRequests(maxConcurrentRequests: number): GrpcConfiguration {
     return new StaticGrpcConfiguration({
       deadlineMillis: this.deadlineMillis,
       maxSessionMemoryMb: this.maxSessionMemoryMb,
       numClients: this.numClients,
-      concurrentRequestsLimit: concurrentRequestsLimit,
+      maxConcurrentRequests: maxConcurrentRequests,
     });
   }
 }
@@ -243,16 +239,16 @@ export class StaticTransportStrategy implements TransportStrategy {
     });
   }
 
-  getConcurrentRequestsLimit(): number | undefined {
-    return this.grpcConfig.getConcurrentRequestsLimit();
+  getMaxConcurrentRequests(): number | undefined {
+    return this.grpcConfig.getMaxConcurrentRequests();
   }
 
-  withConcurrentRequestsLimit(
-    concurrentRequestsLimit: number
+  withMaxConcurrentRequests(
+    maxConcurrentRequests: number
   ): StaticTransportStrategy {
     return new StaticTransportStrategy({
-      grpcConfiguration: this.grpcConfig.withConcurrentRequestsLimit(
-        concurrentRequestsLimit
+      grpcConfiguration: this.grpcConfig.withMaxConcurrentRequests(
+        maxConcurrentRequests
       ),
       maxIdleMillis: this.maxIdleMillis,
     });

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -387,8 +387,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'set' request; key: ${key.toString()}, value length: ${
           value.length
@@ -397,8 +396,7 @@ export class CacheDataClient implements IDataClient {
       return await this.sendSet(cacheName, encodedKey, encodedValue, ttlToUse);
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -453,13 +451,11 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetFetch(cacheName, this.convert(setName));
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -514,8 +510,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetAddElements(
         cacheName,
         this.convert(setName),
@@ -525,8 +520,7 @@ export class CacheDataClient implements IDataClient {
       );
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -584,8 +578,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetRemoveElements(
         cacheName,
         this.convert(setName),
@@ -593,8 +586,7 @@ export class CacheDataClient implements IDataClient {
       );
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -655,13 +647,11 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetSample(cacheName, this.convert(setName), limit);
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -722,8 +712,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -741,8 +730,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -820,8 +808,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -858,8 +845,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -936,8 +922,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -953,8 +938,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1032,8 +1016,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1050,8 +1033,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1130,8 +1112,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1148,8 +1129,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1228,8 +1208,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresentAndNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1248,8 +1227,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1329,8 +1307,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsentOrEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1349,8 +1326,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1423,14 +1399,12 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'delete' request; key: ${key.toString()}`);
       return await this.sendDelete(cacheName, this.convert(key));
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1481,16 +1455,14 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
       const result = await this.sendGet(cacheName, this.convert(key), options);
       this.logger.trace(`'get' request result: ${result.toString()}`);
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1583,8 +1555,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
       const result = await this.sendGetBatch(
         cacheName,
@@ -1594,8 +1565,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1673,8 +1643,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       const itemsToUse = this.convertSetBatchElements(items);
       const ttlToUse = ttl || this.defaultTtlSeconds;
       this.logger.trace(
@@ -1685,8 +1654,7 @@ export class CacheDataClient implements IDataClient {
       return await this.sendSetBatch(cacheName, itemsToUse, ttlToUse);
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1763,8 +1731,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateBack' request; listName: ${listName}, values length: ${
           values.length
@@ -1787,8 +1754,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1851,8 +1817,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateFront' request; listName: ${listName}, values length: ${
           values.length
@@ -1875,8 +1840,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1939,8 +1903,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listFetch' request; listName: %s, startIndex: %s, endIndex: %s",
         listName,
@@ -1957,8 +1920,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2028,8 +1990,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listRetain' request; listName: %s, startIndex: %s, endIndex: %s, ttl: %s",
         listName,
@@ -2049,8 +2010,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2118,8 +2078,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'listLength' request; listName: ${listName}`);
       const result = await this.sendListLength(
         cacheName,
@@ -2129,8 +2088,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2184,8 +2142,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopBack' request");
       const result = await this.sendListPopBack(
         cacheName,
@@ -2195,8 +2152,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2250,8 +2206,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopFront' request");
       const result = await this.sendListPopFront(
         cacheName,
@@ -2261,8 +2216,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2319,8 +2273,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushBack' request; listName: ${listName}, value length: ${
           value.length
@@ -2341,8 +2294,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2404,8 +2356,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushFront' request; listName: ${listName}, value length: ${
           value.length
@@ -2426,8 +2377,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2487,8 +2437,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listRemoveValue' request; listName: ${listName}, value length: ${value.length}`
       );
@@ -2504,8 +2453,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2558,8 +2506,7 @@ export class CacheDataClient implements IDataClient {
 
     try {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          await this.requestConcurrencySemaphore.acquire();
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryFetch' request; dictionaryName: ${dictionaryName}`
       );
@@ -2573,8 +2520,7 @@ export class CacheDataClient implements IDataClient {
       return result;
     } finally {
       if (this.requestConcurrencySemaphore !== undefined)
-        if (this.requestConcurrencySemaphore !== undefined)
-          this.requestConcurrencySemaphore.release();
+        this.requestConcurrencySemaphore.release();
     }
   }
 

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -147,7 +147,7 @@ export class CacheDataClient implements IDataClient {
   private readonly interceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
   private readonly valueCompressor?: ICompression;
-  private requestConcurrencySemaphore: Semaphore;
+  private requestConcurrencySemaphore: Semaphore | undefined;
 
   /**
    * @param {CacheClientProps} props
@@ -156,7 +156,7 @@ export class CacheDataClient implements IDataClient {
   constructor(
     props: CacheClientPropsWithConfig,
     dataClientID: string,
-    semaphore: Semaphore
+    semaphore: Semaphore | undefined
   ) {
     this.configuration = props.configuration;
     this.credentialProvider = props.credentialProvider;
@@ -386,7 +386,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'set' request; key: ${key.toString()}, value length: ${
           value.length
@@ -394,7 +396,9 @@ export class CacheDataClient implements IDataClient {
       );
       return await this.sendSet(cacheName, encodedKey, encodedValue, ttlToUse);
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -448,10 +452,14 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetFetch(cacheName, this.convert(setName));
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -505,7 +513,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetAddElements(
         cacheName,
         this.convert(setName),
@@ -514,7 +524,9 @@ export class CacheDataClient implements IDataClient {
         ttl.refreshTtl()
       );
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -571,14 +583,18 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetRemoveElements(
         cacheName,
         this.convert(setName),
         this.convertArray(elements)
       );
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -638,10 +654,14 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       return await this.sendSetSample(cacheName, this.convert(setName), limit);
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -701,7 +721,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotExists' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -718,7 +740,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -795,7 +819,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -831,7 +857,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfAbsent' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -907,7 +935,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresent' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -922,7 +952,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfPresent' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -999,7 +1031,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1015,7 +1049,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfEqual' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1093,7 +1129,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1109,7 +1147,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'setIfNotEqual' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1187,7 +1227,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfPresentAndNotEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1205,7 +1247,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1284,7 +1328,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'setIfAbsentOrEqual' request; key: ${key.toString()}, field: ${value.toString()}, ttlSeconds: ${
           ttl?.toString() ?? 'null'
@@ -1302,7 +1348,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1374,11 +1422,15 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'delete' request; key: ${key.toString()}`);
       return await this.sendDelete(cacheName, this.convert(key));
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1428,13 +1480,17 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'get' request; key: ${key.toString()}`);
       const result = await this.sendGet(cacheName, this.convert(key), options);
       this.logger.trace(`'get' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1526,7 +1582,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
       const result = await this.sendGetBatch(
         cacheName,
@@ -1535,7 +1593,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'getBatch' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1612,7 +1672,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       const itemsToUse = this.convertSetBatchElements(items);
       const ttlToUse = ttl || this.defaultTtlSeconds;
       this.logger.trace(
@@ -1622,7 +1684,9 @@ export class CacheDataClient implements IDataClient {
       );
       return await this.sendSetBatch(cacheName, itemsToUse, ttlToUse);
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1698,7 +1762,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateBack' request; listName: ${listName}, values length: ${
           values.length
@@ -1720,7 +1786,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1782,7 +1850,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listConcatenateFront' request; listName: ${listName}, values length: ${
           values.length
@@ -1804,7 +1874,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1866,7 +1938,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listFetch' request; listName: %s, startIndex: %s, endIndex: %s",
         listName,
@@ -1882,7 +1956,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace("'listFetch' request result: %s", result.toString());
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -1951,7 +2027,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'listRetain' request; listName: %s, startIndex: %s, endIndex: %s, ttl: %s",
         listName,
@@ -1970,7 +2048,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace("'listRetain' request result: %s", result.toString());
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2037,7 +2117,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(`Issuing 'listLength' request; listName: ${listName}`);
       const result = await this.sendListLength(
         cacheName,
@@ -2046,7 +2128,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listLength' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2099,7 +2183,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopBack' request");
       const result = await this.sendListPopBack(
         cacheName,
@@ -2108,7 +2194,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPopBack' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2161,7 +2249,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'listPopFront' request");
       const result = await this.sendListPopFront(
         cacheName,
@@ -2170,7 +2260,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPopFront' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2226,7 +2318,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushBack' request; listName: ${listName}, value length: ${
           value.length
@@ -2246,7 +2340,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPushBack' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2307,7 +2403,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listPushFront' request; listName: ${listName}, value length: ${
           value.length
@@ -2327,7 +2425,9 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'listPushFront' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2386,7 +2486,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'listRemoveValue' request; listName: ${listName}, value length: ${value.length}`
       );
@@ -2401,7 +2503,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2453,7 +2557,9 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryFetch' request; dictionaryName: ${dictionaryName}`
       );
@@ -2466,7 +2572,9 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        if (this.requestConcurrencySemaphore !== undefined)
+          this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2521,7 +2629,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionarySetField' request; field: ${field.toString()}, value length: ${
           value.length
@@ -2541,7 +2650,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2603,7 +2713,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionarySetFields' request; elements: ${elements.toString()}, ttl: ${
           ttl.ttlSeconds.toString() ?? 'null'
@@ -2624,7 +2735,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2682,7 +2794,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryGetField' request; field: ${field.toString()}`
       );
@@ -2696,7 +2809,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2773,7 +2887,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryGetFields' request; fields: ${fields.toString()}`
       );
@@ -2787,7 +2902,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2848,7 +2964,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryRemoveField' request; field: ${field.toString()}`
       );
@@ -2862,7 +2979,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2918,7 +3036,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryRemoveFields' request; fields: ${fields.toString()}`
       );
@@ -2932,7 +3051,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -2987,7 +3107,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryLength' request; dictionaryName: ${dictionaryName}`
       );
@@ -3000,7 +3121,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3057,7 +3179,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'increment' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
           ttl?.toString() ?? 'null'
@@ -3073,7 +3196,8 @@ export class CacheDataClient implements IDataClient {
       this.logger.trace(`'increment' request result: ${result.toString()}`);
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3135,7 +3259,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         `Issuing 'dictionaryIncrement' request; field: ${field.toString()}, amount : ${amount}, ttl: ${
           ttl.ttlSeconds.toString() ?? 'null'
@@ -3155,7 +3280,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3221,7 +3347,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetPutElement' request; value: %s, score : %s, ttl: %s",
         truncateString(value.toString()),
@@ -3243,7 +3370,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3306,7 +3434,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetPutElements' request; elements : %s, ttl: %s",
         elements.toString(),
@@ -3329,7 +3458,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3390,7 +3520,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetFetchByRank' request; startRank: %s, endRank : %s, order: %s",
         startRank.toString() ?? 'null',
@@ -3411,7 +3542,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3521,7 +3653,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetFetchByScore' request; minScore: %s, maxScore : %s, order: %s, offset: %s, count: %s",
         minScore?.toString() ?? 'null',
@@ -3547,7 +3680,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3662,7 +3796,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetGetRank' request; value: %s",
         truncateString(value.toString())
@@ -3680,7 +3815,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3767,7 +3903,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetGetScores' request; values: %s",
         truncateString(values.toString())
@@ -3785,7 +3922,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3847,7 +3985,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetIncrementScore' request; value: %s",
         truncateString(value.toString())
@@ -3868,7 +4007,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -3932,7 +4072,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetRemoveElement' request");
 
       const result = await this.sendSortedSetRemoveElement(
@@ -3947,7 +4088,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4004,7 +4146,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetRemoveElements' request");
 
       const result = await this.sendSortedSetRemoveElements(
@@ -4019,7 +4162,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4075,7 +4219,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'sortedSetLength' request");
 
       const result = await this.sendSortedSetLength(
@@ -4089,7 +4234,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4149,7 +4295,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'sortedSetLengthByScore' request; minScore: %s, maxScore: %s",
         minScore?.toString() ?? 'null',
@@ -4169,7 +4316,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4355,10 +4503,12 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendItemGetType(cacheName, this.convert(key));
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4412,10 +4562,12 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       return await this.sendItemGetTtl(cacheName, this.convert(key));
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4466,7 +4618,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'keyExists' request");
 
       const result = await this.sendKeyExists(cacheName, this.convert(key));
@@ -4477,7 +4630,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4528,7 +4682,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'updateTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4546,7 +4701,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4599,7 +4755,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace("Issuing 'keysExist' request");
 
       const result = await this.sendKeysExist(
@@ -4613,7 +4770,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4664,7 +4822,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'increaseTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4682,7 +4841,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 
@@ -4737,7 +4897,8 @@ export class CacheDataClient implements IDataClient {
     }
 
     try {
-      await this.requestConcurrencySemaphore.acquire();
+      if (this.requestConcurrencySemaphore !== undefined)
+        await this.requestConcurrencySemaphore.acquire();
       this.logger.trace(
         "Issuing 'decreaseTtl' request; ttlMilliseconds: %s",
         ttlMilliseconds?.toString() ?? 'null'
@@ -4755,7 +4916,8 @@ export class CacheDataClient implements IDataClient {
       );
       return result;
     } finally {
-      this.requestConcurrencySemaphore.release();
+      if (this.requestConcurrencySemaphore !== undefined)
+        this.requestConcurrencySemaphore.release();
     }
   }
 

--- a/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/cache-client.test.ts
@@ -116,7 +116,7 @@ describe('CacheClient', () => {
   it('cannot create a client with concurrent requests limit below 1', async () => {
     try {
       const negativeLimitConfig = configuration.withTransportStrategy(
-        configuration.getTransportStrategy().withConcurrentRequestsLimit(-1)
+        configuration.getTransportStrategy().withMaxConcurrentRequests(-1)
       );
       await CacheClient.create({
         configuration: negativeLimitConfig,
@@ -132,7 +132,7 @@ describe('CacheClient', () => {
 
     try {
       const zeroLimitConfig = configuration.withTransportStrategy(
-        configuration.getTransportStrategy().withConcurrentRequestsLimit(0)
+        configuration.getTransportStrategy().withMaxConcurrentRequests(0)
       );
       await CacheClient.create({
         configuration: zeroLimitConfig,

--- a/packages/core/src/internal/utils/validators.ts
+++ b/packages/core/src/internal/utils/validators.ts
@@ -220,7 +220,7 @@ export function validateLeaderboardNumberOfElements(numElements: number) {
   }
 }
 
-export function validateConcurrentRequestsLimit(limit: number) {
+export function validateMaxConcurrentRequests(limit: number) {
   if (limit < 1) {
     throw new InvalidArgumentError(
       'concurrent requests limit must be strictly positive (> 0)'


### PR DESCRIPTION
Users should opt-in to setting the max concurrent requests limit. The default behavior of the SDK should remain the same if the limit is not set (locally confirmed this). 

Renamed from ConcurrentRequestsLimit to MaxConcurrentRequests.
Created a higher order function to apply the semaphore (if max concurrent request limit is set).