### PR TITLE
fix: instantiate middleware after cred provider

### DIFF
--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -80,7 +80,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento CacheClient');
 
-    this._configuration.getMiddlewares().map(m => {
+    this._configuration.getMiddlewares().forEach(m => {
       if (m.init) {
         m.init();
       }
@@ -93,7 +93,7 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
     }
     this.controlClient.close();
     this.dataClients.map(dc => dc.close());
-    this._configuration.getMiddlewares().map(m => {
+    this._configuration.getMiddlewares().forEach(m => {
       if (m.close) {
         m.close();
       }

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -79,6 +79,12 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
 
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento CacheClient');
+
+    this._configuration.getMiddlewares().map(m => {
+      if (m.init) {
+        m.init();
+      }
+    });
   }
 
   public close() {

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
@@ -49,6 +49,9 @@ export class ExperimentalActiveRequestCountLoggingMiddleware extends Experimenta
           c
         )
     );
+  }
+
+  init() {
     if (!this.isLoggingStarted) {
       this.isLoggingStarted = true;
       this.startLogging();

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-event-loop-perf-middleware.ts
@@ -116,6 +116,9 @@ export class ExperimentalEventLoopPerformanceMetricsMiddleware
 
   constructor(loggerFactory: MomentoLoggerFactory) {
     this.logger = loggerFactory.getLogger(this);
+  }
+
+  init() {
     if (!this.isLoggingStarted) {
       this.isLoggingStarted = true;
       this.startLogging();

--- a/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/middleware.ts
@@ -62,5 +62,6 @@ export interface Middleware {
   onNewRequest(
     context?: MiddlewareRequestHandlerContext
   ): MiddlewareRequestHandler;
+  init?(): void;
   close?(): void;
 }

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -36,6 +36,12 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
     this.logger = configuration.getLoggerFactory().getLogger(this);
     this.logger.debug('Creating Momento LeaderboardClient');
     this.dataClient = new LeaderboardDataClient(propsWithConfig, '0'); // only creating one leaderboard client
+
+    this.configuration.getMiddlewares().forEach(m => {
+      if (m.init) {
+        m.init();
+      }
+    });
   }
 
   public close() {

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -37,6 +37,12 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
     this.logger.debug('Creating Momento LeaderboardClient');
     this.dataClient = new LeaderboardDataClient(propsWithConfig, '0'); // only creating one leaderboard client
 
+    // Initialize middlewares that have init methods. These currently start
+    // background tasks for logging that will execute until they are explicitly
+    // stopped. This is usually handled by the client's close method, but if
+    // there is ever a chance that this client constructor may fail after these
+    // methods are called, it is up to you to catch the exception and call close
+    // on each of these manually.
     this.configuration.getMiddlewares().forEach(m => {
       if (m.init) {
         m.init();

--- a/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache-client-close.test.ts
@@ -25,6 +25,7 @@ function integrationTestCacheClientPropsWithExperimentalMetricsMiddleware(): Cac
   const loggerFactory = new DefaultMomentoLoggerFactory(
     DefaultMomentoLoggerLevel.INFO
   );
+  const credentialProvider = credsProvider();
   return {
     configuration: Configurations.Laptop.latest(loggerFactory)
       .withClientTimeoutMillis(90000)
@@ -35,7 +36,7 @@ function integrationTestCacheClientPropsWithExperimentalMetricsMiddleware(): Cac
           activeRequestCountMetricsLog: true,
         })
       ),
-    credentialProvider: credsProvider(),
+    credentialProvider: credentialProvider,
     defaultTtlSeconds: 1111,
   };
 }


### PR DESCRIPTION
This works around an issue that left background logging tasks from the middleware running, preventing jest from exiting. This is a workaround until a better solution for notifying the middlewares that they should start logging after successful client instantaiation can be implemented.