### PR TITLE
chore: add node 20 to examples, and re-add node 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
   test-examples:
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [16, 18, 20]
       fail-fast: true
     name: Test examples on node ${{ matrix.node }}
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
   test-examples:
     strategy:
       matrix:
-        node: [16, 18]
+        node: [14, 16, 18, 20]
       fail-fast: true
     name: Test examples on node ${{ matrix.node }}
     runs-on: macos-latest


### PR DESCRIPTION
Ended up not re-adding 14 because it no longer works on github. We should add 20 though.