### PR TITLE
chore: fix readme to point to correct examples dir

### DIFF
--- a/packages/client-sdk-nodejs/README.md
+++ b/packages/client-sdk-nodejs/README.md
@@ -61,7 +61,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available in the [examples](../../examples/nodejs) subdirectory.
+Working example projects, with all required build configuration files, are available in the [examples](https://github.com/momentohq/client-sdk-javascript/tree/main/examples/nodejs) subdirectory.
 
 ## Developing
 

--- a/packages/client-sdk-nodejs/README.template.md
+++ b/packages/client-sdk-nodejs/README.template.md
@@ -20,7 +20,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available in the [examples](../../examples/nodejs) subdirectory.
+Working example projects, with all required build configuration files, are available in the [examples'](https://github.com/momentohq/client-sdk-javascript/tree/main/examples/nodejs) subdirectory.
 
 ## Developing
 

--- a/packages/client-sdk-web/README.md
+++ b/packages/client-sdk-web/README.md
@@ -63,7 +63,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available in the [examples](../../examples/web) subdirectory.
+Working example projects, with all required build configuration files, are available in the [examples](https://github.com/momentohq/client-sdk-javascript/tree/main/examples/web) subdirectory.
 
 ## Developing
 

--- a/packages/client-sdk-web/README.template.md
+++ b/packages/client-sdk-web/README.template.md
@@ -19,7 +19,7 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available in the [examples](../../examples/web) subdirectory.
+Working example projects, with all required build configuration files, are available in the [examples](https://github.com/momentohq/client-sdk-javascript/tree/main/examples/web) subdirectory.
 
 ## Developing
 


### PR DESCRIPTION
Due to the nature of mono repos, relative path pointing to examples will break in README. Updated to absolute paths instead for examples on README.