### PR TITLE
feat: allow setting ttl per item in setBatch

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -4286,7 +4286,7 @@ export class CacheDataClient implements IDataClient {
       return elements.map(element => [
         this.convert(element.key),
         this.convert(element.value),
-        element.ttl,
+        element.ttl ?? ttl,
       ]);
     } else if (elements instanceof Map) {
       return [...elements.entries()].map(([k, v]) => [

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -989,22 +989,19 @@ export class CacheDataClient<
       );
     }
     this.logger.trace(`Issuing 'getBatch' request; keys: ${keys.toString()}`);
-    const result = await this.sendGetBatch(
-      cacheName,
-      keys.map(key => convertToB64String(key))
-    );
+    const result = await this.sendGetBatch(cacheName, keys);
     this.logger.trace(`'getBatch' request result: ${result.toString()}`);
     return result;
   }
 
   private async sendGetBatch(
     cacheName: string,
-    keys: string[]
+    keys: Array<string | Uint8Array>
   ): Promise<CacheGetBatch.Response> {
     const getRequests = [];
     for (const k of keys) {
       const getRequest = new _GetRequest();
-      getRequest.setCacheKey(k);
+      getRequest.setCacheKey(convertToB64String(k));
       getRequests.push(getRequest);
     }
     const request = new _GetBatchRequest();
@@ -2566,7 +2563,7 @@ export class CacheDataClient<
             items.forEach(val => {
               const fvp = new _DictionaryFieldValuePair({
                 field: val.getField_asU8(),
-                value: this.convertToUint8Array(val.getValue()),
+                value: val.getValue_asU8(),
               });
               retDict.push(fvp);
             });

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1087,16 +1087,15 @@ export class CacheDataClient<
 
   private async sendSetBatch(
     cacheName: string,
-    items: SetBatchItem[]
+    items: [string, string, number][]
   ): Promise<CacheSetBatch.Response> {
     const setRequests = [];
     for (const item of items) {
+      const [key, value, ttl] = item;
       const setRequest = new _SetRequest();
-      setRequest.setCacheKey(item.key);
-      setRequest.setCacheBody(item.value);
-      setRequest.setTtlMilliseconds(
-        this.convertSecondsToMilliseconds(item.ttl)
-      );
+      setRequest.setCacheKey(key);
+      setRequest.setCacheBody(value);
+      setRequest.setTtlMilliseconds(this.convertSecondsToMilliseconds(ttl));
       setRequests.push(setRequest);
     }
     const request = new _SetBatchRequest();
@@ -4305,24 +4304,28 @@ export class CacheDataClient<
       | Record<string, string | Uint8Array>
       | Array<SetBatchItem>,
     ttl: number
-  ): SetBatchItem[] {
+  ): [string, string, number][] {
     if (elements instanceof Array) {
-      return elements;
+      return elements.map(element => [
+        convertToB64String(element.key),
+        convertToB64String(element.value),
+        element.ttl ?? ttl,
+      ]);
     } else if (elements instanceof Map) {
       return [...elements.entries()].map(element => {
-        return {
-          key: convertToB64String(element[0]),
-          value: convertToB64String(element[1]),
-          ttl: ttl,
-        };
+        return [
+          convertToB64String(element[0]),
+          convertToB64String(element[1]),
+          ttl,
+        ];
       });
     } else {
       return Object.entries(elements).map(element => {
-        return {
-          key: convertToB64String(element[0]),
-          value: convertToB64String(element[1]),
-          ttl: ttl,
-        };
+        return [
+          convertToB64String(element[0]),
+          convertToB64String(element[1]),
+          ttl,
+        ];
       });
     }
   }

--- a/packages/common-integration-tests/src/batch-get-set.ts
+++ b/packages/common-integration-tests/src/batch-get-set.ts
@@ -131,15 +131,16 @@ export function runBatchGetSetTests(
       // Create list of SetBatchItems and check set batch response
       const items = [
         {key: 'a', value: 'apple', ttl: 3},
-        {key: 'b', value: 'berry', ttl: 3},
-        {key: 'c', value: 'cantaloupe', ttl: 3},
-        {key: '1', value: 'first', ttl: 3},
-        {key: '2', value: 'second', ttl: 3},
+        {key: 'b', value: 'berry', ttl: 1},
+        {key: 'c', value: 'cantaloupe', ttl: 20},
+        {key: '1', value: 'first'},
+        {key: '2', value: 'second', ttl: 2},
         {key: '3', value: 'third', ttl: 3},
       ];
       const response = await cacheClient.setBatch(
         integrationTestCacheName,
-        items
+        items,
+        {ttl: 15}
       );
       expectWithMessage(() => {
         expect(response).toBeInstanceOf(CacheSetBatch.Success);
@@ -175,11 +176,15 @@ export function runBatchGetSetTests(
         expect(getResults.length).toEqual(keys.length);
       }, `expected non-empty results, received ${getResults.toString()}`);
 
-      for (const [index, resp] of getResults.entries()) {
-        expectWithMessage(() => {
-          expect(resp).toBeInstanceOf(CacheGet.Miss);
-        }, `expected MISS for getting key ${keys[index]}, received ${resp.toString()}`);
-      }
+      const getResultsMap = (
+        getResponse as CacheGetBatch.Success
+      ).valuesMapStringString();
+      expect(getResultsMap).toEqual(
+        new Map([
+          ['c', 'cantaloupe'],
+          ['1', 'first'],
+        ])
+      );
     });
 
     it('getBatch happy path with all hits', async () => {

--- a/packages/common-integration-tests/src/dictionary.ts
+++ b/packages/common-integration-tests/src/dictionary.ts
@@ -292,41 +292,6 @@ export function runDictionaryTests(
         expect(hitResponse.valueRecord()).toEqual(expectedStringStringRecord);
       });
 
-      it('should provide value accessors for bytes fields with dictionaryFetch', async () => {
-        const dictionaryName = v4();
-        const field1 = uint8ArrayForTest(v4());
-        const value1 = v4();
-        const field2 = uint8ArrayForTest(v4());
-        const value2 = v4();
-
-        await cacheClient.dictionarySetFields(
-          integrationTestCacheName,
-          dictionaryName,
-          new Map([
-            [field1, value1],
-            [field2, value2],
-          ])
-        );
-
-        const response = await cacheClient.dictionaryFetch(
-          integrationTestCacheName,
-          dictionaryName
-        );
-        expectWithMessage(() => {
-          expect(response).toBeInstanceOf(CacheDictionaryFetch.Hit);
-        }, `expected HIT but got ${response.toString()}`);
-        const hitResponse = response as CacheDictionaryFetch.Hit;
-
-        const expectedBytesBytesMap = new Map<Uint8Array, Uint8Array>([
-          [field1, uint8ArrayForTest(value1)],
-          [field2, uint8ArrayForTest(value2)],
-        ]);
-
-        expect(hitResponse.valueMapUint8ArrayUint8Array()).toEqual(
-          expectedBytesBytesMap
-        );
-      });
-
       it('should do nothing with dictionaryFetch if dictionary does not exist', async () => {
         const dictionaryName = v4();
         let fetchResponse = await cacheClient.dictionaryFetch(
@@ -735,12 +700,6 @@ export function runDictionaryTests(
         const missResponse = hitResponse
           .responses[2] as CacheDictionaryGetField.Miss;
         expect(missResponse.fieldUint8Array()).toEqual(field3);
-
-        const expectedMap = new Map<Uint8Array, Uint8Array>([
-          [field1, value1],
-          [field2, value2],
-        ]);
-        expect(expectedMap).toEqual(hitResponse.valueMapUint8ArrayUint8Array());
       });
 
       it('should support happy path for dictionaryGetFields via curried cache via ICache interface', async () => {

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -68,6 +68,7 @@ import {
   SetCallOptions,
   GetCallOptions,
   SetIfAbsentCallOptions,
+  SetBatchItem,
 } from '../utils';
 import {IControlClient, IPingClient} from '../internal/clients';
 import {IMomentoCache} from './IMomentoCache';
@@ -182,7 +183,8 @@ export interface ICacheClient extends IControlClient, IPingClient {
     cacheName: string,
     items:
       | Record<string, string | Uint8Array>
-      | Map<string | Uint8Array, string | Uint8Array>,
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Array<SetBatchItem>,
     options?: SetBatchOptions
   ): Promise<CacheSetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -65,6 +65,7 @@ import {
   SortedSetFetchByRankCallOptions,
   SortedSetFetchByScoreCallOptions,
   SortedSetLengthByScoreCallOptions,
+  SetBatchItem,
 } from '../utils';
 
 // Type aliases to differentiate the different methods' optional arguments.
@@ -150,7 +151,8 @@ export interface IMomentoCache {
   setBatch(
     items:
       | Record<string, string | Uint8Array>
-      | Map<string | Uint8Array, string | Uint8Array>,
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Array<SetBatchItem>,
     options?: SetBatchOptions
   ): Promise<CacheSetBatch.Response>;
   setFetch(setName: string): Promise<CacheSetFetch.Response>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,7 @@ import {
   WebhookDestination,
   PostUrlWebhookDestination,
   WebhookDestinationType,
+  SetBatchItem,
 } from './utils';
 
 import {
@@ -206,6 +207,7 @@ export {
   CredentialProvider,
   StringMomentoTokenProvider,
   EnvMomentoTokenProvider,
+  SetBatchItem,
 
   // CacheClient Response Types
   CacheGet,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -70,7 +70,11 @@ import {
   CacheSetIfAbsentOrEqual,
   CacheSetSample,
 } from '../../../index';
-import {ListFetchCallOptions, ListRetainCallOptions} from '../../../utils';
+import {
+  ListFetchCallOptions,
+  ListRetainCallOptions,
+  SetBatchItem,
+} from '../../../utils';
 import {
   ICacheClient,
   SetOptions,
@@ -265,7 +269,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * already present it is replaced with the new value.
    *
    * @param {string} cacheName - The cache to store the values in.
-   * @param {Record<string, string | Uint8Array> | Map<string | Uint8Array, string | Uint8Array>} items - The key-value pairs to be stored.
+   * @param {Record<string, string | Uint8Array | SetBatchItem> | Map<string | Uint8Array, string | Uint8Array | SetBatchItem>} items - The key-value pairs to be stored, with the option to set a TTL per item.
    * @param {SetBatchOptions} [options]
    * @param {number} [options.ttl] - The time to live for the items in the cache.
    * Uses the client's default TTL if this is not supplied.
@@ -278,7 +282,8 @@ export abstract class AbstractCacheClient implements ICacheClient {
     cacheName: string,
     items:
       | Record<string, string | Uint8Array>
-      | Map<string | Uint8Array, string | Uint8Array>,
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Array<SetBatchItem>,
     options?: SetBatchOptions
   ): Promise<CacheSetBatch.Response> {
     const client = this.getNextDataClient();

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -59,6 +59,7 @@ import {
   GetBatchCallOptions,
   GetCallOptions,
   SetBatchCallOptions,
+  SetBatchItem,
   SetCallOptions,
   SetIfAbsentCallOptions,
 } from '../../../utils';
@@ -140,7 +141,8 @@ export interface IDataClient {
     cacheName: string,
     items:
       | Record<string, string | Uint8Array>
-      | Map<string | Uint8Array, string | Uint8Array>,
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Array<SetBatchItem>,
     options?: SetBatchCallOptions
   ): Promise<CacheSetBatch.Response>;
   setFetch(cacheName: string, setName: string): Promise<CacheSetFetch.Response>;

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -67,6 +67,7 @@ import {
   SortedSetFetchByRankCallOptions,
   SortedSetFetchByScoreCallOptions,
   SortedSetLengthByScoreCallOptions,
+  SetBatchItem,
 } from '../../../utils';
 import {IMomentoCache} from '../../../clients/IMomentoCache';
 
@@ -208,7 +209,8 @@ export class MomentoCache implements IMomentoCache {
   setBatch(
     items:
       | Record<string, string | Uint8Array>
-      | Map<string | Uint8Array, string | Uint8Array>,
+      | Map<string | Uint8Array, string | Uint8Array>
+      | Array<SetBatchItem>,
     options?: SetBatchOptions
   ): Promise<CacheSetBatch.Response> {
     return this.cacheClient.setBatch(this.cacheName, items, options);

--- a/packages/core/src/messages/responses/cache-batch-get.ts
+++ b/packages/core/src/messages/responses/cache-batch-get.ts
@@ -84,10 +84,8 @@ class _Success extends Response {
    */
   public valuesRecordStringString(): Record<string, string> {
     return this.items.reduce<Record<string, string>>((acc, item, index) => {
-      if (item.value() !== undefined) {
-        acc[TEXT_DECODER.decode(this.keys[index])] = (
-          item as CacheGet.Hit
-        ).valueString();
+      if (item instanceof CacheGet.Hit) {
+        acc[TEXT_DECODER.decode(this.keys[index])] = item.valueString();
       }
       return acc;
     }, {});
@@ -100,10 +98,8 @@ class _Success extends Response {
    */
   public valuesRecordStringUint8Array(): Record<string, Uint8Array> {
     return this.items.reduce<Record<string, Uint8Array>>((acc, item, index) => {
-      if (item.value() !== undefined) {
-        acc[TEXT_DECODER.decode(this.keys[index])] = (
-          item as CacheGet.Hit
-        ).valueUint8Array();
+      if (item instanceof CacheGet.Hit) {
+        acc[TEXT_DECODER.decode(this.keys[index])] = item.valueUint8Array();
       }
       return acc;
     }, {});
@@ -124,11 +120,8 @@ class _Success extends Response {
    */
   public valuesMapStringString(): Map<string, string> {
     return this.items.reduce((acc, item, index) => {
-      if (item.value() !== undefined) {
-        acc.set(
-          TEXT_DECODER.decode(this.keys[index]),
-          (item as CacheGet.Hit).valueString()
-        );
+      if (item instanceof CacheGet.Hit) {
+        acc.set(TEXT_DECODER.decode(this.keys[index]), item.valueString());
       }
       return acc;
     }, new Map<string, string>());
@@ -140,27 +133,11 @@ class _Success extends Response {
    */
   public valuesMapStringUint8Array(): Map<string, Uint8Array> {
     return this.items.reduce((acc, item, index) => {
-      if (item.value() !== undefined) {
-        acc.set(
-          TEXT_DECODER.decode(this.keys[index]),
-          (item as CacheGet.Hit).valueUint8Array()
-        );
+      if (item instanceof CacheGet.Hit) {
+        acc.set(TEXT_DECODER.decode(this.keys[index]), item.valueUint8Array());
       }
       return acc;
     }, new Map<string, Uint8Array>());
-  }
-
-  /**
-   * Returns the data as a Map whose keys and values are byte arrays.
-   * @returns {Map<Uint8Array, Uint8Array>}
-   */
-  public valuesMapUint8ArrayUint8Array(): Map<Uint8Array, Uint8Array> {
-    return this.items.reduce((acc, item, index) => {
-      if (item.value() !== undefined) {
-        acc.set(this.keys[index], (item as CacheGet.Hit).valueUint8Array());
-      }
-      return acc;
-    }, new Map<Uint8Array, Uint8Array>());
   }
 
   public override toString(): string {

--- a/packages/core/src/messages/responses/cache-dictionary-fetch.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-fetch.ts
@@ -57,17 +57,6 @@ class _Hit extends Response {
   }
 
   /**
-   * Returns the data as a Map whose keys and values are byte arrays.
-   * @returns {Map<Uint8Array, Uint8Array>}
-   */
-  public valueMapUint8ArrayUint8Array(): Map<Uint8Array, Uint8Array> {
-    return this.items.reduce((acc, item) => {
-      acc.set(item.field, item.value);
-      return acc;
-    }, new Map<Uint8Array, Uint8Array>());
-  }
-
-  /**
    * Returns the data as a Map whose keys and values are utf-8 strings, decoded from the underlying byte arrays.
    * @returns {Map<string, string>}
    */

--- a/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
@@ -74,19 +74,6 @@ class _Hit extends Response {
   }
 
   /**
-   * Returns the data as a Map whose keys and values are byte arrays.
-   * @returns {Map<Uint8Array, Uint8Array>}
-   */
-  public valueMapUint8ArrayUint8Array(): Map<Uint8Array, Uint8Array> {
-    return this.items.reduce((acc, item, index) => {
-      if (item.result === _ECacheResult.Hit) {
-        acc.set(this.fields[index], item.cacheBody);
-      }
-      return acc;
-    }, new Map<Uint8Array, Uint8Array>());
-  }
-
-  /**
    * Returns the data as a Map whose keys and values are utf-8 strings, decoded from the underlying byte arrays.
    * @returns {Map<string, string>}
    */

--- a/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
@@ -75,19 +75,6 @@ class _Hit extends Response {
   }
 
   /**
-   * Returns the data as a Map whose keys are byte arrays and values numbers.
-   * @returns {Map<Uint8Array, number>}
-   */
-  public valueMapUint8Array(): Map<Uint8Array, number> {
-    return this._responses.reduce((acc, response) => {
-      if (response instanceof CacheSortedSetGetScoreResponse.Hit) {
-        acc.set(response.valueUint8Array(), response.score());
-      }
-      return acc;
-    }, new Map<Uint8Array, number>());
-  }
-
-  /**
    * Returns the data as a Map whose keys are utf-8 strings, decoded from the underlying byte arrays and values are numbers.
    * @returns {Map<string, number>}
    */

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './topic-call-options';
 export * from './expiration';
 export * from './itemType';
 export * from './webhook-destination';
+export * from './set-batch-item';

--- a/packages/core/src/utils/set-batch-item.ts
+++ b/packages/core/src/utils/set-batch-item.ts
@@ -1,0 +1,5 @@
+export type SetBatchItem = {
+  key: string | Uint8Array;
+  value: string | Uint8Array;
+  ttl: number;
+};

--- a/packages/core/src/utils/set-batch-item.ts
+++ b/packages/core/src/utils/set-batch-item.ts
@@ -1,5 +1,5 @@
 export type SetBatchItem = {
   key: string | Uint8Array;
   value: string | Uint8Array;
-  ttl: number;
+  ttl?: number;
 };


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-javascript/issues/1250

Updated by Chris:
In addition to the adding per-item TTL, this PR does the following:
* Adds more test coverage for the different value accessors for the
  GetBatch response, because some of them weren't being tested, and
  there was a bug in the web SDK implementations.
* Fix the web SDK implementations so that the `valueRecord*` and
  `valueMap*` accessors work properly.
* Remove various accessors for GetBatch and Dictionaries that attempted
  to return `Map<Uint8Array, *>`. This was done after spending a lot
  of time trying to write tests to cover these accessors in GetBatch
  and seeing how easy it is to make a very minor mistake that results
  in the inability to access a value in the Map. For example, if you
  try to index into it via a key you construct with `new Uint8Array(...)`,
  as opposed to `TextEncoder.encode(...)`, only one of those will work.
  This complexity seems like a bad UX and I think we should omit it from
  the API until someone needs it.