### PR TITLE
chore: add record accessor for keys exist response

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -4582,7 +4582,7 @@ export class CacheDataClient implements IDataClient {
         },
         (err, resp) => {
           if (resp) {
-            resolve(new CacheKeysExist.Success(resp.exists));
+            resolve(new CacheKeysExist.Success(keys, resp.exists));
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -4015,7 +4015,12 @@ export class CacheDataClient<
         },
         (err, resp) => {
           if (resp) {
-            resolve(new CacheKeysExist.Success(resp.getExistsList()));
+            resolve(
+              new CacheKeysExist.Success(
+                this.convertArrayToUint8(keys),
+                resp.getExistsList()
+              )
+            );
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -3987,10 +3987,7 @@ export class CacheDataClient<
 
     this.logger.trace("Issuing 'keysExist' request");
 
-    const result = await this.sendKeysExist(
-      cacheName,
-      this.convertArrayToB64Strings(keys)
-    );
+    const result = await this.sendKeysExist(cacheName, keys);
 
     this.logger.trace(
       "'keysExist' request result: %s",
@@ -4001,10 +3998,10 @@ export class CacheDataClient<
 
   private async sendKeysExist(
     cacheName: string,
-    keys: string[]
+    keys: string[] | Uint8Array[]
   ): Promise<CacheKeysExist.Response> {
     const request = new _KeysExistRequest();
-    request.setCacheKeysList(keys);
+    request.setCacheKeysList(this.convertArrayToB64Strings(keys));
 
     return await new Promise((resolve, reject) => {
       this.clientWrapper.keysExist(

--- a/packages/common-integration-tests/src/keys-exist.ts
+++ b/packages/common-integration-tests/src/keys-exist.ts
@@ -119,9 +119,9 @@ export function runKeysExistTest(
       const successOrdering1 = responseOrdering1 as CacheKeysExist.Success;
       expect(successOrdering1.exists()).toEqual([true, false, true]);
       expect(successOrdering1.valueRecord()).toEqual({
-        [key1]: true,
-        [key2]: false,
-        [key3]: true,
+        key1: true,
+        key2: false,
+        key3: true,
       });
 
       const responseOrdering2 = await cacheClient.keysExist(
@@ -136,9 +136,9 @@ export function runKeysExistTest(
       const successOrdering2 = responseOrdering2 as CacheKeysExist.Success;
       expect(successOrdering2.exists()).toEqual([false, true, true]);
       expect(successOrdering2.valueRecord()).toEqual({
-        [key2]: false,
-        [key3]: true,
-        [key1]: true,
+        key2: false,
+        key3: true,
+        key1: true,
       });
 
       const responseOrdering3 = await cacheClient.keysExist(
@@ -153,8 +153,8 @@ export function runKeysExistTest(
       const successOrdering3 = responseOrdering3 as CacheKeysExist.Success;
       expect(successOrdering3.exists()).toEqual([false, false]);
       expect(successOrdering3.valueRecord()).toEqual({
-        [key2]: false,
-        [key4]: false,
+        key2: false,
+        key4: false,
       });
     });
 

--- a/packages/common-integration-tests/src/keys-exist.ts
+++ b/packages/common-integration-tests/src/keys-exist.ts
@@ -119,9 +119,9 @@ export function runKeysExistTest(
       const successOrdering1 = responseOrdering1 as CacheKeysExist.Success;
       expect(successOrdering1.exists()).toEqual([true, false, true]);
       expect(successOrdering1.valueRecord()).toEqual({
-        key1: true,
-        key2: false,
-        key3: true,
+        [key1]: true,
+        [key2]: false,
+        [key3]: true,
       });
 
       const responseOrdering2 = await cacheClient.keysExist(
@@ -136,9 +136,9 @@ export function runKeysExistTest(
       const successOrdering2 = responseOrdering2 as CacheKeysExist.Success;
       expect(successOrdering2.exists()).toEqual([false, true, true]);
       expect(successOrdering2.valueRecord()).toEqual({
-        key2: false,
-        key3: true,
-        key1: true,
+        [key1]: true,
+        [key2]: false,
+        [key3]: true,
       });
 
       const responseOrdering3 = await cacheClient.keysExist(
@@ -153,8 +153,8 @@ export function runKeysExistTest(
       const successOrdering3 = responseOrdering3 as CacheKeysExist.Success;
       expect(successOrdering3.exists()).toEqual([false, false]);
       expect(successOrdering3.valueRecord()).toEqual({
-        key2: false,
-        key4: false,
+        [key2]: false,
+        [key4]: false,
       });
     });
 

--- a/packages/common-integration-tests/src/keys-exist.ts
+++ b/packages/common-integration-tests/src/keys-exist.ts
@@ -116,8 +116,13 @@ export function runKeysExistTest(
         expect(responseOrdering1).toBeInstanceOf(CacheKeysExist.Success);
       }, `expected SUCCESS but got ${responseOrdering1.toString()}`);
 
-      const successOrdering1 = responseOrdering1 as CacheKeyExists.Success;
+      const successOrdering1 = responseOrdering1 as CacheKeysExist.Success;
       expect(successOrdering1.exists()).toEqual([true, false, true]);
+      expect(successOrdering1.valueRecord()).toEqual({
+        [key1]: true,
+        [key2]: false,
+        [key3]: true,
+      });
 
       const responseOrdering2 = await cacheClient.keysExist(
         integrationTestCacheName,
@@ -128,8 +133,13 @@ export function runKeysExistTest(
         expect(responseOrdering2).toBeInstanceOf(CacheKeysExist.Success);
       }, `expected SUCCESS but got ${responseOrdering2.toString()}`);
 
-      const successOrdering2 = responseOrdering2 as CacheKeyExists.Success;
+      const successOrdering2 = responseOrdering2 as CacheKeysExist.Success;
       expect(successOrdering2.exists()).toEqual([false, true, true]);
+      expect(successOrdering2.valueRecord()).toEqual({
+        [key2]: false,
+        [key3]: true,
+        [key1]: true,
+      });
 
       const responseOrdering3 = await cacheClient.keysExist(
         integrationTestCacheName,
@@ -140,8 +150,12 @@ export function runKeysExistTest(
         expect(responseOrdering3).toBeInstanceOf(CacheKeysExist.Success);
       }, `expected SUCCESS but got ${responseOrdering3.toString()}`);
 
-      const successOrdering3 = responseOrdering3 as CacheKeyExists.Success;
+      const successOrdering3 = responseOrdering3 as CacheKeysExist.Success;
       expect(successOrdering3.exists()).toEqual([false, false]);
+      expect(successOrdering3.valueRecord()).toEqual({
+        [key2]: false,
+        [key4]: false,
+      });
     });
 
     it('should support happy path for keysExist via curried cache via ICache interface', async () => {

--- a/packages/core/src/messages/responses/cache-keys-exist.ts
+++ b/packages/core/src/messages/responses/cache-keys-exist.ts
@@ -25,12 +25,12 @@ const TEXT_DECODER = new TextDecoder();
 export abstract class Response extends ResponseBase {}
 
 class _Success extends Response {
-  private readonly _fields: Uint8Array[];
+  private readonly _keys: Uint8Array[];
   private readonly _exists: boolean[];
 
-  constructor(fields: Uint8Array[], exists: boolean[]) {
+  constructor(keys: Uint8Array[], exists: boolean[]) {
     super();
-    this._fields = fields;
+    this._keys = keys;
     this._exists = exists;
   }
 
@@ -47,7 +47,7 @@ class _Success extends Response {
    * @returns {Record<string, boolean>}
    */
   public valueRecord(): Record<string, boolean> {
-    return this._fields.reduce<Record<string, boolean>>((acc, field, index) => {
+    return this._keys.reduce<Record<string, boolean>>((acc, field, index) => {
       acc[TEXT_DECODER.decode(field)] = this._exists[index];
       return acc;
     }, {});

--- a/packages/core/src/messages/responses/cache-keys-exist.ts
+++ b/packages/core/src/messages/responses/cache-keys-exist.ts
@@ -47,11 +47,10 @@ class _Success extends Response {
    * @returns {Record<string, boolean>}
    */
   public valueRecord(): Record<string, boolean> {
-    const record: Record<string, boolean> = {};
-    this._fields.forEach((field, index) => {
-      record[TEXT_DECODER.decode(field)] = this._exists[index];
-    });
-    return record;
+    return this._fields.reduce<Record<string, boolean>>((acc, field, index) => {
+      acc[TEXT_DECODER.decode(field)] = this._exists[index];
+      return acc;
+    }, {});
   }
 
   public override toString(): string {


### PR DESCRIPTION
We add a record accessor for keys exist to be in line with the .NET
and Rust SDKs.

The record maps from the key to a boolean indicating whether the key
exists in the cache or not.
