### PR TITLE
fix: require explicit override keyword for overriding abstract method properties/functions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node: [18]
     name: Test Cache on Node ${{ matrix.node }}
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}

--- a/examples/cloudflare-workers/http-api/tsconfig.json
+++ b/examples/cloudflare-workers/http-api/tsconfig.json
@@ -96,6 +96,8 @@
 
 		/* Completeness */
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+		"skipLibCheck": true, /* Skip type checking all .d.ts files. */
+		// requires the `override` keyword to override a method/property from a parent class
+		"noImplicitOverride": true
 	}
 }

--- a/examples/cloudflare-workers/http-api/tsconfig.json
+++ b/examples/cloudflare-workers/http-api/tsconfig.json
@@ -87,7 +87,7 @@
 		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
 		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
 		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+		 "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
 		// "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
 		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
 		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */

--- a/examples/cloudflare-workers/web-sdk/tsconfig.json
+++ b/examples/cloudflare-workers/web-sdk/tsconfig.json
@@ -96,6 +96,8 @@
 
 		/* Completeness */
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+		"skipLibCheck": true, /* Skip type checking all .d.ts files. */
+		// requires the `override` keyword to override a method/property from a parent class
+		"noImplicitOverride": true
 	}
 }

--- a/examples/cloudflare-workers/web-sdk/tsconfig.json
+++ b/examples/cloudflare-workers/web-sdk/tsconfig.json
@@ -87,7 +87,7 @@
 		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
 		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
 		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+		 "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
 		// "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
 		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
 		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */

--- a/examples/fastly-compute/.eslintrc.json
+++ b/examples/fastly-compute/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/fastly-compute/tsconfig.json
+++ b/examples/fastly-compute/tsconfig.json
@@ -16,7 +16,8 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     // requires the `override` keyword to override a method/property from a parent class
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "./src/**/*.js",

--- a/examples/fastly-compute/tsconfig.json
+++ b/examples/fastly-compute/tsconfig.json
@@ -14,7 +14,9 @@
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "include": [
     "./src/**/*.js",

--- a/examples/nodejs/access-control/.eslintrc.json
+++ b/examples/nodejs/access-control/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/access-control/tsconfig.json
+++ b/examples/nodejs/access-control/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/access-control/tsconfig.json
+++ b/examples/nodejs/access-control/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/lambda-examples/advanced-compression/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/tsconfig.json
@@ -100,7 +100,8 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
     // requires the `override` keyword to override a method/property from a parent class
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "src/**/*.ts",

--- a/examples/nodejs/aws/lambda-examples/advanced-compression/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/tsconfig.json
@@ -98,7 +98,9 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "include": [
     "src/**/*.ts",

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/.eslintrc.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/.eslintrc.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/infrastructure/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/.eslintrc.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/.eslintrc.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/infrastructure/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/.eslintrc.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/tsconfig.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/aws/secrets-manager/.eslintrc.json
+++ b/examples/nodejs/aws/secrets-manager/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/aws/secrets-manager/tsconfig.json
+++ b/examples/nodejs/aws/secrets-manager/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/aws/secrets-manager/tsconfig.json
+++ b/examples/nodejs/aws/secrets-manager/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/cache/tsconfig.json
+++ b/examples/nodejs/cache/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/cache/tsconfig.json
+++ b/examples/nodejs/cache/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/compression-zstd/.eslintrc.json
+++ b/examples/nodejs/compression-zstd/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/compression-zstd/tsconfig.json
+++ b/examples/nodejs/compression-zstd/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/compression-zstd/tsconfig.json
+++ b/examples/nodejs/compression-zstd/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/compression/.eslintrc.json
+++ b/examples/nodejs/compression/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/compression/tsconfig.json
+++ b/examples/nodejs/compression/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/compression/tsconfig.json
+++ b/examples/nodejs/compression/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/get-set-batch-perf-test/.eslintrc.json
+++ b/examples/nodejs/get-set-batch-perf-test/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/get-set-batch-perf-test/tsconfig.json
+++ b/examples/nodejs/get-set-batch-perf-test/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/get-set-batch-perf-test/tsconfig.json
+++ b/examples/nodejs/get-set-batch-perf-test/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/load-gen/.eslintrc.json
+++ b/examples/nodejs/load-gen/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/load-gen/tsconfig.json
+++ b/examples/nodejs/load-gen/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/load-gen/tsconfig.json
+++ b/examples/nodejs/load-gen/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/mongodb-examples/simple-read-aside/.eslintrc.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/mongodb-examples/simple-read-aside/tsconfig.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/mongodb-examples/simple-read-aside/tsconfig.json
+++ b/examples/nodejs/mongodb-examples/simple-read-aside/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/observability/.eslintrc.json
+++ b/examples/nodejs/observability/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/observability/tsconfig.json
+++ b/examples/nodejs/observability/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/observability/tsconfig.json
+++ b/examples/nodejs/observability/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/rate-limiter/.eslintrc.json
+++ b/examples/nodejs/rate-limiter/.eslintrc.json
@@ -47,7 +47,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/rate-limiter/tsconfig.json
+++ b/examples/nodejs/rate-limiter/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/rate-limiter/tsconfig.json
+++ b/examples/nodejs/rate-limiter/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/token-vending-machine/infrastructure/.eslintrc.json
+++ b/examples/nodejs/token-vending-machine/infrastructure/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/token-vending-machine/infrastructure/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/infrastructure/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/token-vending-machine/infrastructure/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/infrastructure/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/tsconfig.json
@@ -95,7 +95,7 @@
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+     "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/tsconfig.json
@@ -105,6 +105,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-    "outDir": "./dist"
+    "outDir": "./dist",
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   }
 }

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/.eslintrc.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/tsconfig.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/nodejs/topics/.eslintrc.json
+++ b/examples/nodejs/topics/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/nodejs/topics/tsconfig.json
+++ b/examples/nodejs/topics/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/nodejs/topics/tsconfig.json
+++ b/examples/nodejs/topics/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/web/cache/.eslintrc.json
+++ b/examples/web/cache/.eslintrc.json
@@ -50,7 +50,8 @@
     // async without await is often an error and in other uses it obfuscates
     // the intent of the developer. Functions are async when they want to await.
     "require-await": "error",
-    "import/no-duplicates": "error"
+    "import/no-duplicates": "error",
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
   },
   "settings": {
     "import/resolver": {

--- a/examples/web/cache/tsconfig.json
+++ b/examples/web/cache/tsconfig.json
@@ -19,6 +19,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "typeRoots": [
       "./node_modules/@types"
     ],

--- a/examples/web/cache/tsconfig.json
+++ b/examples/web/cache/tsconfig.json
@@ -14,7 +14,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/examples/web/nextjs-chat/tsconfig.json
+++ b/examples/web/nextjs-chat/tsconfig.json
@@ -16,6 +16,7 @@
     "incremental": true,
     // requires the `override` keyword to override a method/property from a parent class
     "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
     "plugins": [
       {
         "name": "next"

--- a/examples/web/nextjs-chat/tsconfig.json
+++ b/examples/web/nextjs-chat/tsconfig.json
@@ -14,6 +14,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true,
     "plugins": [
       {
         "name": "next"

--- a/examples/web/vite-chat-app/.eslintrc.cjs
+++ b/examples/web/vite-chat-app/.eslintrc.cjs
@@ -23,5 +23,6 @@ module.exports = {
       { allowConstantExport: true },
     ],
     '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error'
   },
 }

--- a/examples/web/vite-chat-app/tsconfig.json
+++ b/examples/web/vite-chat-app/tsconfig.json
@@ -18,7 +18,9 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/examples/web/vite-chat-app/tsconfig.node.json
+++ b/examples/web/vite-chat-app/tsconfig.node.json
@@ -4,7 +4,9 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "include": ["vite.config.ts"]
 }

--- a/examples/web/vite-chat-app/tsconfig.node.json
+++ b/examples/web/vite-chat-app/tsconfig.node.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     // requires the `override` keyword to override a method/property from a parent class
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]
 }

--- a/examples/web/vite-chat-app/tsconfig.node.json
+++ b/examples/web/vite-chat-app/tsconfig.node.json
@@ -5,7 +5,6 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    // requires the `override` keyword to override a method/property from a parent class
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/packages/client-sdk-nodejs-compression-zstd/.eslintrc.json
+++ b/packages/client-sdk-nodejs-compression-zstd/.eslintrc.json
@@ -1,68 +1,69 @@
 {
-    "root": true,
-    "env": {
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:import/recommended",
-        "plugin:prettier/recommended",
-        "plugin:node/recommended"
+  "root": true,
+  "env": {
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:prettier/recommended",
+    "plugin:node/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "semi": ["error", "always"],
+    "import/no-extraneous-dependencies": ["error", {}],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": ["error", {
+      "tryExtensions": [".js", ".ts", ".json", ".node"]
+    }],
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "project": "./tsconfig.json"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "semi": ["error", "always"],
-        "import/no-extraneous-dependencies": ["error", {}],
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": ["error", {
-            "tryExtensions": [".js", ".ts", ".json", ".node"]
-        }],
-        "prettier/prettier": "error",
-        "block-scoped-var": "error",
-        "eqeqeq": "error",
-        "no-var": "error",
-        "prefer-const": "error",
-        "eol-last": "error",
-        "prefer-arrow-callback": "error",
-        "no-trailing-spaces": "error",
-        "quotes": ["warn", "single", { "avoidEscape": true }],
-        "no-restricted-properties": [
-            "error",
-            {
-                "object": "describe",
-                "property": "only"
-            },
-            {
-                "object": "it",
-                "property": "only"
-            }
-        ],
-        // async without await is often an error and in other uses it obfuscates
-        // the intent of the developer. Functions are async when they want to await.
-        "require-await": "error",
-        "import/no-duplicates": "error",
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-          "warn",
-          { 
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "node": {
-                "extensions": [".js", ".jsx", ".ts", ".tsx"]
-            }
-        }
+    // async without await is often an error and in other uses it obfuscates
+    // the intent of the developer. Functions are async when they want to await.
+    "require-await": "error",
+    "import/no-duplicates": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
+  }
 }

--- a/packages/client-sdk-nodejs-compression-zstd/tsconfig.json
+++ b/packages/client-sdk-nodejs-compression-zstd/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],

--- a/packages/client-sdk-nodejs-compression-zstd/tsconfig.json
+++ b/packages/client-sdk-nodejs-compression-zstd/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/packages/client-sdk-nodejs-compression/.eslintrc.json
+++ b/packages/client-sdk-nodejs-compression/.eslintrc.json
@@ -1,68 +1,69 @@
 {
-    "root": true,
-    "env": {
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:import/recommended",
-        "plugin:prettier/recommended",
-        "plugin:node/recommended"
+  "root": true,
+  "env": {
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:prettier/recommended",
+    "plugin:node/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "semi": ["error", "always"],
+    "import/no-extraneous-dependencies": ["error", {}],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": ["error", {
+      "tryExtensions": [".js", ".ts", ".json", ".node"]
+    }],
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "project": "./tsconfig.json"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "semi": ["error", "always"],
-        "import/no-extraneous-dependencies": ["error", {}],
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": ["error", {
-            "tryExtensions": [".js", ".ts", ".json", ".node"]
-        }],
-        "prettier/prettier": "error",
-        "block-scoped-var": "error",
-        "eqeqeq": "error",
-        "no-var": "error",
-        "prefer-const": "error",
-        "eol-last": "error",
-        "prefer-arrow-callback": "error",
-        "no-trailing-spaces": "error",
-        "quotes": ["warn", "single", { "avoidEscape": true }],
-        "no-restricted-properties": [
-            "error",
-            {
-                "object": "describe",
-                "property": "only"
-            },
-            {
-                "object": "it",
-                "property": "only"
-            }
-        ],
-        // async without await is often an error and in other uses it obfuscates
-        // the intent of the developer. Functions are async when they want to await.
-        "require-await": "error",
-        "import/no-duplicates": "error",
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-          "warn",
-          { 
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "node": {
-                "extensions": [".js", ".jsx", ".ts", ".tsx"]
-            }
-        }
+    // async without await is often an error and in other uses it obfuscates
+    // the intent of the developer. Functions are async when they want to await.
+    "require-await": "error",
+    "import/no-duplicates": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
+  }
 }

--- a/packages/client-sdk-nodejs-compression/tsconfig.json
+++ b/packages/client-sdk-nodejs-compression/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],

--- a/packages/client-sdk-nodejs-compression/tsconfig.json
+++ b/packages/client-sdk-nodejs-compression/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/packages/client-sdk-nodejs/.eslintrc.json
+++ b/packages/client-sdk-nodejs/.eslintrc.json
@@ -51,12 +51,13 @@
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": [
           "warn",
-          { 
+          {
             "argsIgnorePattern": "^_",
             "varsIgnorePattern": "^_",
             "caughtErrorsIgnorePattern": "^_"
           }
-        ]
+        ],
+      "@typescript-eslint/switch-exhaustiveness-check": "error"
     },
     "settings": {
         "import/resolver": {

--- a/packages/client-sdk-nodejs/src/cache-client.ts
+++ b/packages/client-sdk-nodejs/src/cache-client.ts
@@ -145,7 +145,9 @@ export class CacheClient extends AbstractCacheClient implements ICacheClient {
    * {@link CacheFlush.Success} on success.
    * {@link CacheFlush.Error} on failure.
    */
-  public async flushCache(cacheName: string): Promise<CacheFlush.Response> {
+  public override async flushCache(
+    cacheName: string
+  ): Promise<CacheFlush.Response> {
     return await this.notYetAbstractedControlClient.flushCache(cacheName);
   }
 }

--- a/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/experimental-active-request-count-middleware.ts
@@ -15,7 +15,7 @@ class ExperimentalActiveRequestCountLoggingMiddlewareRequestHandler extends Expe
     super(parent, logger, context);
   }
 
-  protected recordMetrics(): void {
+  protected override recordMetrics(): void {
     this.parent.decrementActiveRequestCount();
   }
 

--- a/packages/client-sdk-nodejs/src/errors/compression-error.ts
+++ b/packages/client-sdk-nodejs/src/errors/compression-error.ts
@@ -1,7 +1,7 @@
 import {SdkError} from '@gomomento/sdk-core';
 
 export class CompressionError extends SdkError {
-  _messageWrapper = 'Compression Error';
+  override _messageWrapper = 'Compression Error';
   constructor(action: string, option: string) {
     super(
       `Compressor is not set, but \`${action}\` was called with the \`${option}\` option; please install @gomomento/sdk-nodejs-compression and call \`Configuration.withCompressionStrategy\` to enable compression.`

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -30,12 +30,12 @@ import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 export class PubsubClient extends AbstractPubsubClient<ServiceError> {
   private readonly client: grpcPubsub.PubsubClient;
   private readonly configuration: TopicConfiguration;
-  protected readonly credentialProvider: CredentialProvider;
+  protected override readonly credentialProvider: CredentialProvider;
   private readonly unaryRequestTimeoutMs: number;
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
   private static readonly DEFAULT_MAX_SESSION_MEMORY_MB: number = 256;
-  protected readonly logger: MomentoLogger;
-  protected readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
+  protected override readonly logger: MomentoLogger;
+  protected override readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly unaryInterceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
 
@@ -86,7 +86,7 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
       PubsubClient.initializeStreamingInterceptors(headers);
   }
 
-  public getEndpoint(): string {
+  public override getEndpoint(): string {
     const endpoint = this.credentialProvider.getCacheEndpoint();
     this.logger.debug(`Using cache endpoint: ${endpoint}`);
     return endpoint;

--- a/packages/client-sdk-nodejs/tsconfig.json
+++ b/packages/client-sdk-nodejs/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],

--- a/packages/client-sdk-nodejs/tsconfig.json
+++ b/packages/client-sdk-nodejs/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/packages/client-sdk-web/.eslintrc.json
+++ b/packages/client-sdk-web/.eslintrc.json
@@ -1,68 +1,69 @@
 {
-    "root": true,
-    "env": {
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:import/recommended",
-        "plugin:prettier/recommended",
-        "plugin:node/recommended"
+  "root": true,
+  "env": {
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:prettier/recommended",
+    "plugin:node/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "semi": ["error", "always"],
+    "import/no-extraneous-dependencies": ["error", {}],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": ["error", {
+      "tryExtensions": [".js", ".ts", ".json", ".node"]
+    }],
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "project": "./tsconfig.json"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "semi": ["error", "always"],
-        "import/no-extraneous-dependencies": ["error", {}],
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": ["error", {
-            "tryExtensions": [".js", ".ts", ".json", ".node"]
-        }],
-        "prettier/prettier": "error",
-        "block-scoped-var": "error",
-        "eqeqeq": "error",
-        "no-var": "error",
-        "prefer-const": "error",
-        "eol-last": "error",
-        "prefer-arrow-callback": "error",
-        "no-trailing-spaces": "error",
-        "quotes": ["warn", "single", { "avoidEscape": true }],
-        "no-restricted-properties": [
-            "error",
-            {
-                "object": "describe",
-                "property": "only"
-            },
-            {
-                "object": "it",
-                "property": "only"
-            }
-        ],
-        // async without await is often an error and in other uses it obfuscates
-        // the intent of the developer. Functions are async when they want to await.
-        "require-await": "error",
-        "import/no-duplicates": "error",
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-          "warn",
-          {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "node": {
-                "extensions": [".js", ".jsx", ".ts", ".tsx"]
-            }
-        }
+    // async without await is often an error and in other uses it obfuscates
+    // the intent of the developer. Functions are async when they want to await.
+    "require-await": "error",
+    "import/no-duplicates": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
+  }
 }

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -30,11 +30,11 @@ export class PubsubClient<
 > extends AbstractPubsubClient<RpcError> {
   private readonly client: pubsub.PubsubClient;
   private readonly configuration: TopicConfiguration;
-  protected readonly credentialProvider: CredentialProvider;
+  protected override readonly credentialProvider: CredentialProvider;
   private readonly requestTimeoutMs: number;
   private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
-  protected readonly logger: MomentoLogger;
-  protected readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
+  protected override readonly logger: MomentoLogger;
+  protected override readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly clientMetadataProvider: ClientMetadataProvider;
 
   private static readonly RST_STREAM_NO_ERROR_MESSAGE =
@@ -69,7 +69,7 @@ export class PubsubClient<
     });
   }
 
-  public getEndpoint(): string {
+  public override getEndpoint(): string {
     const endpoint = getWebCacheEndpoint(this.credentialProvider);
     this.logger.debug(`Using cache endpoint: ${endpoint}`);
     return endpoint;

--- a/packages/client-sdk-web/tsconfig.json
+++ b/packages/client-sdk-web/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],

--- a/packages/client-sdk-web/tsconfig.json
+++ b/packages/client-sdk-web/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/packages/common-integration-tests/.eslintrc.json
+++ b/packages/common-integration-tests/.eslintrc.json
@@ -1,68 +1,69 @@
 {
-    "root": true,
-    "env": {
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:import/recommended",
-        "plugin:prettier/recommended",
-        "plugin:node/recommended"
+  "root": true,
+  "env": {
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:prettier/recommended",
+    "plugin:node/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "semi": ["error", "always"],
+    "import/no-extraneous-dependencies": ["error", {}],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": ["error", {
+      "tryExtensions": [".js", ".ts", ".json", ".node"]
+    }],
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "project": "**/tsconfig.json"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "semi": ["error", "always"],
-        "import/no-extraneous-dependencies": ["error", {}],
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": ["error", {
-            "tryExtensions": [".js", ".ts", ".json", ".node"]
-        }],
-        "prettier/prettier": "error",
-        "block-scoped-var": "error",
-        "eqeqeq": "error",
-        "no-var": "error",
-        "prefer-const": "error",
-        "eol-last": "error",
-        "prefer-arrow-callback": "error",
-        "no-trailing-spaces": "error",
-        "quotes": ["warn", "single", { "avoidEscape": true }],
-        "no-restricted-properties": [
-            "error",
-            {
-                "object": "describe",
-                "property": "only"
-            },
-            {
-                "object": "it",
-                "property": "only"
-            }
-        ],
-        // async without await is often an error and in other uses it obfuscates
-        // the intent of the developer. Functions are async when they want to await.
-        "require-await": "error",
-        "import/no-duplicates": "error",
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-          "warn",
-          {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "node": {
-                "extensions": [".js", ".jsx", ".ts", ".tsx"]
-            }
-        }
+    // async without await is often an error and in other uses it obfuscates
+    // the intent of the developer. Functions are async when they want to await.
+    "require-await": "error",
+    "import/no-duplicates": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
+  }
 }

--- a/packages/common-integration-tests/tsconfig.json
+++ b/packages/common-integration-tests/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "include": ["src/", "test/"],
   "exclude": ["node_modules", "dist", "examples/"]

--- a/packages/common-integration-tests/tsconfig.json
+++ b/packages/common-integration-tests/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,

--- a/packages/common-integration-tests/tsconfig.json
+++ b/packages/common-integration-tests/tsconfig.json
@@ -24,6 +24,7 @@
     // requires the `override` keyword to override a method/property from a parent class
     "noImplicitOverride": true
   },
+  "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],
   "exclude": ["node_modules", "dist", "examples/"]
 }

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,68 +1,69 @@
 {
-    "root": true,
-    "env": {
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "plugin:import/recommended",
-        "plugin:prettier/recommended",
-        "plugin:node/recommended"
+  "root": true,
+  "env": {
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:prettier/recommended",
+    "plugin:node/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "semi": ["error", "always"],
+    "import/no-extraneous-dependencies": ["error", {}],
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": ["error", {
+      "tryExtensions": [".js", ".ts", ".json", ".node"]
+    }],
+    "prettier/prettier": "error",
+    "block-scoped-var": "error",
+    "eqeqeq": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "eol-last": "error",
+    "prefer-arrow-callback": "error",
+    "no-trailing-spaces": "error",
+    "quotes": ["warn", "single", { "avoidEscape": true }],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "describe",
+        "property": "only"
+      },
+      {
+        "object": "it",
+        "property": "only"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "project": "./tsconfig.json"
-    },
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "semi": ["error", "always"],
-        "import/no-extraneous-dependencies": ["error", {}],
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": ["error", {
-            "tryExtensions": [".js", ".ts", ".json", ".node"]
-        }],
-        "prettier/prettier": "error",
-        "block-scoped-var": "error",
-        "eqeqeq": "error",
-        "no-var": "error",
-        "prefer-const": "error",
-        "eol-last": "error",
-        "prefer-arrow-callback": "error",
-        "no-trailing-spaces": "error",
-        "quotes": ["warn", "single", { "avoidEscape": true }],
-        "no-restricted-properties": [
-            "error",
-            {
-                "object": "describe",
-                "property": "only"
-            },
-            {
-                "object": "it",
-                "property": "only"
-            }
-        ],
-        // async without await is often an error and in other uses it obfuscates
-        // the intent of the developer. Functions are async when they want to await.
-        "require-await": "error",
-        "import/no-duplicates": "error",
-        "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": [
-          "warn",
-          {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
-    },
-    "settings": {
-        "import/resolver": {
-            "node": {
-                "extensions": [".js", ".jsx", ".ts", ".tsx"]
-            }
-        }
+    // async without await is often an error and in other uses it obfuscates
+    // the intent of the developer. Functions are async when they want to await.
+    "require-await": "error",
+    "import/no-duplicates": "error",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
     }
+  }
 }

--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -88,8 +88,8 @@ export abstract class SdkError extends Error {
  * one that doesn't already exist
  */
 export class AlreadyExistsError extends SdkError {
-  _errorCode = MomentoErrorCode.ALREADY_EXISTS_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.ALREADY_EXISTS_ERROR;
+  override _messageWrapper =
     'A cache with the specified name already exists.  To resolve this error, either delete the existing cache and make a new one, or use a different name';
 }
 
@@ -97,8 +97,8 @@ export class AlreadyExistsError extends SdkError {
  * Error when authentication with Cache Service fails
  */
 export class AuthenticationError extends SdkError {
-  _errorCode = MomentoErrorCode.AUTHENTICATION_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.AUTHENTICATION_ERROR;
+  override _messageWrapper =
     'Invalid authentication credentials to connect to cache service';
 }
 
@@ -106,8 +106,8 @@ export class AuthenticationError extends SdkError {
  * Error raised in response to an invalid request
  */
 export class BadRequestError extends SdkError {
-  _errorCode = MomentoErrorCode.BAD_REQUEST_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.BAD_REQUEST_ERROR;
+  override _messageWrapper =
     'The request was invalid; please contact us at support@momentohq.com';
 }
 
@@ -115,8 +115,8 @@ export class BadRequestError extends SdkError {
  * Error when an operation with Cache Service was cancelled
  */
 export class CancelledError extends SdkError {
-  _errorCode = MomentoErrorCode.CANCELLED_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
+  override _messageWrapper =
     'The request was cancelled by the server; please contact us at support@momentohq.com';
 }
 
@@ -124,15 +124,15 @@ export class CancelledError extends SdkError {
  * Error when there's a failure to connect to Momento servers.
  */
 export class ConnectionError extends SdkError {
-  _errorCode = MomentoErrorCode.CONNECTION_ERROR;
+  override _errorCode = MomentoErrorCode.CONNECTION_ERROR;
 }
 
 /**
  * Error raised when system in not in a state required for the operation's success
  */
 export class FailedPreconditionError extends SdkError {
-  _errorCode = MomentoErrorCode.FAILED_PRECONDITION_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.FAILED_PRECONDITION_ERROR;
+  override _messageWrapper =
     "System is not in a state required for the operation's execution";
 }
 
@@ -140,8 +140,8 @@ export class FailedPreconditionError extends SdkError {
  * Cache Service encountered an unexpected exception while trying to fulfill the request
  */
 export class InternalServerError extends SdkError {
-  _errorCode = MomentoErrorCode.INTERNAL_SERVER_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.INTERNAL_SERVER_ERROR;
+  override _messageWrapper =
     'An unexpected error occurred while trying to fulfill the request; please contact us at support@momentohq.com';
 }
 
@@ -149,16 +149,16 @@ export class InternalServerError extends SdkError {
  * Represents errors thrown when invalid parameters are passed to the Momento Cache
  */
 export class InvalidArgumentError extends SdkError {
-  _errorCode = MomentoErrorCode.INVALID_ARGUMENT_ERROR;
-  _messageWrapper = 'Invalid argument passed to Momento client';
+  override _errorCode = MomentoErrorCode.INVALID_ARGUMENT_ERROR;
+  override _messageWrapper = 'Invalid argument passed to Momento client';
 }
 
 /**
  * Error when calls are throttled due to request limit rate
  */
 export class LimitExceededError extends SdkError {
-  _errorCode = MomentoErrorCode.LIMIT_EXCEEDED_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.LIMIT_EXCEEDED_ERROR;
+  override _messageWrapper =
     'Request rate, bandwidth, or object size exceeded the limits for this account.  To resolve this error, reduce your usage as appropriate or contact us at support@momentohq.com to request a limit increase';
 }
 
@@ -167,8 +167,8 @@ export class LimitExceededError extends SdkError {
  * to get exists. If it doesn't create it first and then try again
  */
 export class NotFoundError extends SdkError {
-  _errorCode = MomentoErrorCode.NOT_FOUND_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.NOT_FOUND_ERROR;
+  override _messageWrapper =
     'A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it';
 }
 
@@ -176,8 +176,8 @@ export class NotFoundError extends SdkError {
  * Insufficient permissions to perform an operation on Cache Service
  */
 export class PermissionError extends SdkError {
-  _errorCode = MomentoErrorCode.PERMISSION_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.PERMISSION_ERROR;
+  override _messageWrapper =
     'Insufficient permissions to perform an operation on a cache';
 }
 
@@ -185,8 +185,8 @@ export class PermissionError extends SdkError {
  * Server was unable to handle the request.
  */
 export class ServerUnavailableError extends SdkError {
-  _errorCode = MomentoErrorCode.SERVER_UNAVAILABLE;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.SERVER_UNAVAILABLE;
+  override _messageWrapper =
     'The server was unable to handle the request; consider retrying.  If the error persists, please contact us at support@momentohq.com';
 }
 
@@ -194,8 +194,8 @@ export class ServerUnavailableError extends SdkError {
  * Error when an operation did not complete in time
  */
 export class TimeoutError extends SdkError {
-  _errorCode = MomentoErrorCode.TIMEOUT_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.TIMEOUT_ERROR;
+  override _messageWrapper =
     "The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts";
 }
 
@@ -203,15 +203,15 @@ export class TimeoutError extends SdkError {
  * Error raised when the underlying cause in unknown
  */
 export class UnknownError extends SdkError {
-  _errorCode = MomentoErrorCode.UNKNOWN_ERROR;
-  _messageWrapper = 'Unknown error has occurred';
+  override _errorCode = MomentoErrorCode.UNKNOWN_ERROR;
+  override _messageWrapper = 'Unknown error has occurred';
 }
 
 /**
  * Error raised when the service returns an unknown response
  */
 export class UnknownServiceError extends SdkError {
-  _errorCode = MomentoErrorCode.UNKNOWN_SERVICE_ERROR;
-  _messageWrapper =
+  override _errorCode = MomentoErrorCode.UNKNOWN_SERVICE_ERROR;
+  override _messageWrapper =
     'Service returned an unknown response; please contact us at support@momentohq.com';
 }

--- a/packages/core/src/messages/responses/cache-batch-get.ts
+++ b/packages/core/src/messages/responses/cache-batch-get.ts
@@ -53,7 +53,7 @@ class _Success extends Response {
    * Returns the status for each request in the batch as a list of CacheGet.Response objects.
    * @returns {CacheGet.Response[]}
    */
-  public results(): CacheGet.Response[] {
+  public override results(): CacheGet.Response[] {
     return this.items;
   }
 
@@ -63,7 +63,7 @@ class _Success extends Response {
    * {valueRecordStringString}.
    * @returns {Record<string, string>}
    */
-  public values(): Record<string, string> {
+  public override values(): Record<string, string> {
     return this.valuesRecordStringString();
   }
 

--- a/packages/core/src/messages/responses/cache-batch-set.ts
+++ b/packages/core/src/messages/responses/cache-batch-set.ts
@@ -41,7 +41,7 @@ class _Success extends Response {
    * Returns the status for each request in the batch as a list of CacheGet.Response objects.
    * @returns {CacheSet.Response[]}
    */
-  public results(): CacheSet.Response[] {
+  public override results(): CacheSet.Response[] {
     return this.body;
   }
 }

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -41,7 +41,7 @@ class _Success extends Response {
    * The new value of the element after incrementing.
    * @returns {number}
    */
-  public value(): number {
+  public override value(): number {
     return this._value;
   }
   public valueNumber(): number {

--- a/packages/core/src/messages/responses/cache-increment.ts
+++ b/packages/core/src/messages/responses/cache-increment.ts
@@ -41,7 +41,7 @@ class _Success extends Response {
    * The new value of the element after incrementing.
    * @returns {number}
    */
-  public value(): number {
+  public override value(): number {
     return this._value;
   }
   public valueNumber(): number {

--- a/packages/core/src/messages/responses/cache-list-concatenate-back.ts
+++ b/packages/core/src/messages/responses/cache-list-concatenate-back.ts
@@ -65,7 +65,7 @@ class _Error extends Response {}
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends ResponseError(_Error) {
-  constructor(public _innerException: SdkError) {
+  constructor(public override _innerException: SdkError) {
     super();
   }
 }

--- a/packages/core/src/messages/responses/cache-list-concatenate-front.ts
+++ b/packages/core/src/messages/responses/cache-list-concatenate-front.ts
@@ -65,7 +65,7 @@ class _Error extends Response {}
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends ResponseError(_Error) {
-  constructor(public _innerException: SdkError) {
+  constructor(public override _innerException: SdkError) {
     super();
   }
 }

--- a/packages/core/src/messages/responses/cache-list-fetch.ts
+++ b/packages/core/src/messages/responses/cache-list-fetch.ts
@@ -75,7 +75,7 @@ class _Hit extends Response {
    * for {valueListString}
    * @returns {string[]}
    */
-  public value(): string[] {
+  public override value(): string[] {
     return this.valueListString();
   }
 

--- a/packages/core/src/messages/responses/cache-list-pop-back.ts
+++ b/packages/core/src/messages/responses/cache-list-pop-back.ts
@@ -57,7 +57,7 @@ class _Hit extends Response {
    * Returns the data as a utf-8 string, decoded from the underlying byte array.
    * @returns string
    */
-  public value(): string {
+  public override value(): string {
     return TEXT_DECODER.decode(this.body);
   }
 

--- a/packages/core/src/messages/responses/cache-list-pop-front.ts
+++ b/packages/core/src/messages/responses/cache-list-pop-front.ts
@@ -56,7 +56,7 @@ class _Hit extends Response {
    * Returns the data as a utf-8 string, decoded from the underlying byte array.
    * @returns string
    */
-  public value(): string {
+  public override value(): string {
     return TEXT_DECODER.decode(this.body);
   }
 

--- a/packages/core/src/messages/responses/cache-list-push-back.ts
+++ b/packages/core/src/messages/responses/cache-list-push-back.ts
@@ -65,7 +65,7 @@ class _Error extends Response {}
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends ResponseError(_Error) {
-  constructor(public _innerException: SdkError) {
+  constructor(public override _innerException: SdkError) {
     super();
   }
 }

--- a/packages/core/src/messages/responses/cache-list-push-front.ts
+++ b/packages/core/src/messages/responses/cache-list-push-front.ts
@@ -65,7 +65,7 @@ class _Error extends Response {}
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends ResponseError(_Error) {
-  constructor(public _innerException: SdkError) {
+  constructor(public override _innerException: SdkError) {
     super();
   }
 }

--- a/packages/core/src/messages/responses/cache-set-fetch.ts
+++ b/packages/core/src/messages/responses/cache-set-fetch.ts
@@ -77,7 +77,7 @@ class _Hit extends Response {
    * This is a convenience alias for {valueArrayString}.
    * @returns {string[]}
    */
-  public value(): string[] {
+  public override value(): string[] {
     return this.valueArrayString();
   }
 

--- a/packages/core/src/messages/responses/cache-set-sample.ts
+++ b/packages/core/src/messages/responses/cache-set-sample.ts
@@ -77,7 +77,7 @@ class _Hit extends Response {
    * This is a convenience alias for {valueArrayString}.
    * @returns {string[]}
    */
-  public value(): string[] {
+  public override value(): string[] {
     return this.valueArrayString();
   }
 

--- a/packages/core/src/messages/responses/cache-sorted-set-fetch.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-fetch.ts
@@ -91,7 +91,7 @@ class _Hit extends Response {
    * This is a convenience alias for {valueArrayStringNumber}.
    * @returns {value: string; score: number}[]
    */
-  public value(): {value: string; score: number}[] {
+  public override value(): {value: string; score: number}[] {
     return this.valueArrayStringElements();
   }
 

--- a/packages/core/src/messages/responses/cache-sorted-set-get-score.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-get-score.ts
@@ -67,7 +67,7 @@ class _Hit extends Response {
    * @return {*}  {number}
    * @memberof _Hit
    */
-  public score(): number {
+  public override score(): number {
     return this._score;
   }
 

--- a/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-get-scores.ts
@@ -126,7 +126,7 @@ class _Hit extends Response {
    * {valueRecordStringString}.
    * @returns {Record<string, number>}
    */
-  public value(): Record<string, number> {
+  public override value(): Record<string, number> {
     return this.valueRecord();
   }
 

--- a/packages/core/src/messages/responses/cache-sorted-set-increment-score.ts
+++ b/packages/core/src/messages/responses/cache-sorted-set-increment-score.ts
@@ -41,7 +41,7 @@ class _Success extends Response {
    * The new score of the element after incrementing.
    * @returns {number}
    */
-  public score(): number {
+  public override score(): number {
     return this._score;
   }
 

--- a/packages/core/src/messages/responses/response-base.ts
+++ b/packages/core/src/messages/responses/response-base.ts
@@ -51,7 +51,7 @@ export abstract class BaseResponseError extends ResponseBase {
     return this._innerException.errorCode();
   }
 
-  public toString(): string {
+  public override toString(): string {
     return this.message();
   }
 }
@@ -72,7 +72,7 @@ export function ResponseError<TBase extends Constructor>(Base: TBase) {
       return this._innerException.errorCode();
     }
 
-    public toString(): string {
+    public override toString(): string {
       return this.message();
     }
   };

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -20,7 +20,9 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "typeRoots": ["./node_modules/@types"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // requires the `override` keyword to override a method/property from a parent class
+    "noImplicitOverride": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],
   "include": ["src/", "test/"],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
closes https://github.com/momentohq/dev-eco-issue-tracker/issues/831 This pr addresses/fixes the following inconsistencies in this repo

- every tsconfig.json file should have the `noImplicitOverride` and the `noFallthroughCasesInSwitch` flags set to `true`. 
  - The `noImplicitOverride` tsconfig setting requires that a user specifies the `override` keyword when overriding a function or property attribute. 
  - The `noFallthroughCasesInSwitch` prevents the user from writing a code block that looks like
```
switch(value) {
  default: { console.log('default'); }
}
```

- adds the `override` keyword in all places where we are overriding a method/property of a class to satisfy the updated `tsconfig.json` rule
- changes the `test nodejs` step to use the `macos-latest` runner so that it doesn't time out after 4 min

<img width="1039" alt="image" src="https://github.com/momentohq/client-sdk-javascript/assets/11823378/8202c965-0b3e-4658-a311-6a129371954a">
