### PR TITLE
Fix: Ensure endpoints starting with http:// are correctly prefixed wi…

### DIFF
--- a/examples/cloudflare-workers/http-api/src/worker.ts
+++ b/examples/cloudflare-workers/http-api/src/worker.ts
@@ -13,7 +13,11 @@ class MomentoFetcher {
 	private readonly baseurl: string;
 	constructor(key: string, endpoint: string) {
 		this.apiKey = key;
-		const correctedEndpoint = endpoint.replace(/^(http:\/\/)?/, "https://");
+		if ( !( endpoint.startsWith('https://') || endpoint.startsWith('http://') ) ) {
+			this.baseurl = `https://${endpoint}/cache`;
+		} else {
+			this.baseurl = `${endpoint}/cache`;
+		}
 		this.baseurl = `${correctedEndpoint}/cache`;
 	}
 

--- a/examples/cloudflare-workers/http-api/src/worker.ts
+++ b/examples/cloudflare-workers/http-api/src/worker.ts
@@ -13,11 +13,8 @@ class MomentoFetcher {
 	private readonly baseurl: string;
 	constructor(key: string, endpoint: string) {
 		this.apiKey = key;
-		if (!endpoint.startsWith('https://')) {
-			this.baseurl = `https://${endpoint}/cache`;
-		} else {
-			this.baseurl = `${endpoint}/cache`;
-		}
+		const correctedEndpoint = endpoint.replace(/^(http:\/\/)?/, "https://");
+		this.baseurl = `${correctedEndpoint}/cache`;
 	}
 
 	async get(cacheName: string, key: string) {

--- a/examples/cloudflare-workers/http-api/src/worker.ts
+++ b/examples/cloudflare-workers/http-api/src/worker.ts
@@ -18,7 +18,6 @@ class MomentoFetcher {
 		} else {
 			this.baseurl = `${endpoint}/cache`;
 		}
-		this.baseurl = `${correctedEndpoint}/cache`;
 	}
 
 	async get(cacheName: string, key: string) {


### PR DESCRIPTION
…th https://


Previously, endpoints starting with http:// were prefixed with https://, which could lead to incorrect URL formation. This commit adjusts the prefix process to use regex to handle these cases properly.