### PR TITLE
feat: add withMomentoLocal and option to connect without TLS to CredentialProvider

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -42,6 +42,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -73,6 +74,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -42,7 +42,6 @@
       }
     },
     "../common-integration-tests": {
-      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -74,7 +73,6 @@
       }
     },
     "../core": {
-      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -59,7 +59,9 @@ export class CacheControlClient {
       clientFactoryFn: () =>
         new grpcControl.ScsControlClient(
           props.credentialProvider.getControlEndpoint(),
-          ChannelCredentials.createSsl()
+          props.credentialProvider.isControlEndpointInsecure()
+            ? ChannelCredentials.createInsecure()
+            : ChannelCredentials.createSsl()
         ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration

--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -59,9 +59,9 @@ export class CacheControlClient {
       clientFactoryFn: () =>
         new grpcControl.ScsControlClient(
           props.credentialProvider.getControlEndpoint(),
-          props.credentialProvider.isControlEndpointInsecure()
-            ? ChannelCredentials.createInsecure()
-            : ChannelCredentials.createSsl()
+          props.credentialProvider.isControlEndpointSecure()
+            ? ChannelCredentials.createSsl()
+            : ChannelCredentials.createInsecure()
         ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -209,9 +209,9 @@ export class CacheDataClient implements IDataClient {
         this.logger.debug(`Constructing channel for clientID ${dataClientID}`);
         return new grpcCache.ScsClient(
           this.credentialProvider.getCacheEndpoint(),
-          this.credentialProvider.isCacheEndpointInsecure()
-            ? ChannelCredentials.createInsecure()
-            : ChannelCredentials.createSsl(),
+          this.credentialProvider.isCacheEndpointSecure()
+            ? ChannelCredentials.createSsl()
+            : ChannelCredentials.createInsecure(),
           channelOptions
         );
       },

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -209,7 +209,9 @@ export class CacheDataClient implements IDataClient {
         this.logger.debug(`Constructing channel for clientID ${dataClientID}`);
         return new grpcCache.ScsClient(
           this.credentialProvider.getCacheEndpoint(),
-          ChannelCredentials.createSsl(),
+          this.credentialProvider.isCacheEndpointInsecure()
+            ? ChannelCredentials.createInsecure()
+            : ChannelCredentials.createSsl(),
           channelOptions
         );
       },

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -80,11 +80,15 @@ export class InternalAuthClient implements IAuthClient {
     ];
     this.tokenClient = new token.token.TokenClient(
       this.creds.getTokenEndpoint(),
-      ChannelCredentials.createSsl()
+      this.creds.isTokenEndpointInsecure()
+        ? ChannelCredentials.createInsecure()
+        : ChannelCredentials.createSsl()
     );
     this.authClient = new grpcAuth.AuthClient(
       this.creds.getControlEndpoint(),
-      ChannelCredentials.createSsl()
+      this.creds.isTokenEndpointInsecure()
+        ? ChannelCredentials.createInsecure()
+        : ChannelCredentials.createSsl()
     );
   }
 

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -80,15 +80,15 @@ export class InternalAuthClient implements IAuthClient {
     ];
     this.tokenClient = new token.token.TokenClient(
       this.creds.getTokenEndpoint(),
-      this.creds.isTokenEndpointInsecure()
-        ? ChannelCredentials.createInsecure()
-        : ChannelCredentials.createSsl()
+      this.creds.isTokenEndpointSecure()
+        ? ChannelCredentials.createSsl()
+        : ChannelCredentials.createInsecure()
     );
     this.authClient = new grpcAuth.AuthClient(
       this.creds.getControlEndpoint(),
-      this.creds.isTokenEndpointInsecure()
-        ? ChannelCredentials.createInsecure()
-        : ChannelCredentials.createSsl()
+      this.creds.isTokenEndpointSecure()
+        ? ChannelCredentials.createSsl()
+        : ChannelCredentials.createInsecure()
     );
   }
 

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -91,7 +91,9 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
           clientFactoryFn: () =>
             new leaderboard.LeaderboardClient(
               this.credentialProvider.getCacheEndpoint(),
-              ChannelCredentials.createSsl(),
+              this.credentialProvider.isCacheEndpointSecure()
+                ? ChannelCredentials.createSsl()
+                : ChannelCredentials.createInsecure(),
               channelOptions
             ),
           loggerFactory: this.configuration.getLoggerFactory(),

--- a/packages/client-sdk-nodejs/src/internal/ping-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/ping-client.ts
@@ -38,9 +38,9 @@ export class InternalNodeGrpcPingClient {
       clientFactoryFn: () =>
         new grpcPing.PingClient(
           props.endpoint,
-          props.credentialProvider.isCacheEndpointInsecure()
-            ? ChannelCredentials.createInsecure()
-            : ChannelCredentials.createSsl()
+          props.credentialProvider.isCacheEndpointSecure()
+            ? ChannelCredentials.createSsl()
+            : ChannelCredentials.createInsecure()
         ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration

--- a/packages/client-sdk-nodejs/src/internal/ping-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/ping-client.ts
@@ -7,11 +7,12 @@ import {version} from '../../package.json';
 import {IdleGrpcClientWrapper} from './grpc/idle-grpc-client-wrapper';
 import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
 import {Configuration} from '../config/configuration';
-import {MomentoLogger} from '../';
+import {CredentialProvider, MomentoLogger} from '../';
 
 export interface PingClientProps {
   configuration: Configuration;
   endpoint: string;
+  credentialProvider: CredentialProvider;
 }
 
 export class InternalNodeGrpcPingClient {
@@ -35,7 +36,12 @@ export class InternalNodeGrpcPingClient {
     );
     this.clientWrapper = new IdleGrpcClientWrapper({
       clientFactoryFn: () =>
-        new grpcPing.PingClient(props.endpoint, ChannelCredentials.createSsl()),
+        new grpcPing.PingClient(
+          props.endpoint,
+          props.credentialProvider.isCacheEndpointInsecure()
+            ? ChannelCredentials.createInsecure()
+            : ChannelCredentials.createSsl()
+        ),
       loggerFactory: props.configuration.getLoggerFactory(),
       maxIdleMillis: props.configuration
         .getTransportStrategy()

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -69,7 +69,9 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
 
     this.client = new grpcPubsub.PubsubClient(
       this.credentialProvider.getCacheEndpoint(),
-      ChannelCredentials.createSsl(),
+      this.credentialProvider.isCacheEndpointInsecure()
+        ? ChannelCredentials.createInsecure()
+        : ChannelCredentials.createSsl(),
       channelOptions
     );
 

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -69,9 +69,9 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
 
     this.client = new grpcPubsub.PubsubClient(
       this.credentialProvider.getCacheEndpoint(),
-      this.credentialProvider.isCacheEndpointInsecure()
-        ? ChannelCredentials.createInsecure()
-        : ChannelCredentials.createSsl(),
+      this.credentialProvider.isCacheEndpointSecure()
+        ? ChannelCredentials.createSsl()
+        : ChannelCredentials.createInsecure(),
       channelOptions
     );
 

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -52,7 +52,9 @@ export class WebhookClient implements IWebhookClient {
     ];
     this.webhookClient = new webhook.webhook.WebhookClient(
       props.credentialProvider.getControlEndpoint(),
-      ChannelCredentials.createSsl()
+      this.credentialProvider.isControlEndpointInsecure()
+        ? ChannelCredentials.createInsecure()
+        : ChannelCredentials.createSsl()
     );
   }
 

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -52,9 +52,9 @@ export class WebhookClient implements IWebhookClient {
     ];
     this.webhookClient = new webhook.webhook.WebhookClient(
       props.credentialProvider.getControlEndpoint(),
-      this.credentialProvider.isControlEndpointInsecure()
-        ? ChannelCredentials.createInsecure()
-        : ChannelCredentials.createSsl()
+      props.credentialProvider.isControlEndpointSecure()
+        ? ChannelCredentials.createSsl()
+        : ChannelCredentials.createInsecure()
     );
   }
 

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -64,15 +64,15 @@ function sessionCredsProvider(): CredentialProvider {
       endpointOverrides: {
         cacheEndpoint: {
           endpoint: credsProvider().getCacheEndpoint(),
-          insecureConnection: false,
+          secureConnection: credsProvider().isCacheEndpointSecure(),
         },
         controlEndpoint: {
           endpoint: credsProvider().getControlEndpoint(),
-          insecureConnection: false,
+          secureConnection: credsProvider().isControlEndpointSecure(),
         },
         tokenEndpoint: {
           endpoint: credsProvider().getTokenEndpoint(),
-          insecureConnection: false,
+          secureConnection: credsProvider().isTokenEndpointSecure(),
         },
       },
     });

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -62,9 +62,18 @@ function sessionCredsProvider(): CredentialProvider {
       // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
       // steal them from the auth-token-based creds provider.
       endpointOverrides: {
-        cacheEndpoint: credsProvider().getCacheEndpoint(),
-        controlEndpoint: credsProvider().getControlEndpoint(),
-        tokenEndpoint: credsProvider().getTokenEndpoint(),
+        cacheEndpoint: {
+          endpoint: credsProvider().getCacheEndpoint(),
+          insecureConnection: false,
+        },
+        controlEndpoint: {
+          endpoint: credsProvider().getControlEndpoint(),
+          insecureConnection: false,
+        },
+        tokenEndpoint: {
+          endpoint: credsProvider().getTokenEndpoint(),
+          insecureConnection: false,
+        },
       },
     });
   }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -32,9 +32,18 @@ export function credsProvider(): CredentialProvider {
       _credsProvider = CredentialProvider.fromEnvironmentVariable({
         environmentVariableName: 'MOMENTO_API_KEY',
         endpointOverrides: {
-          controlEndpoint: 'https://no-controlplane-requests-allowed:9001',
-          cacheEndpoint: 'https://localhost:9001',
-          tokenEndpoint: 'https://localhost:9001',
+          controlEndpoint: {
+            endpoint: 'https://no-controlplane-requests-allowed:9001',
+            insecureConnection: false,
+          },
+          cacheEndpoint: {
+            endpoint: 'https://localhost:9001',
+            insecureConnection: false,
+          },
+          tokenEndpoint: {
+            endpoint: 'https://localhost:9001',
+            insecureConnection: false,
+          },
         },
       });
     } else {
@@ -53,9 +62,18 @@ function sessionCredsProvider(): CredentialProvider {
       // session tokens don't include cache/control endpoints, so we must provide them.  In this case we just hackily
       // steal them from the auth-token-based creds provider.
       endpointOverrides: {
-        cacheEndpoint: credsProvider().getCacheEndpoint(),
-        controlEndpoint: credsProvider().getControlEndpoint(),
-        tokenEndpoint: credsProvider().getTokenEndpoint(),
+        cacheEndpoint: {
+          endpoint: credsProvider().getCacheEndpoint(),
+          insecureConnection: credsProvider().isCacheEndpointInsecure(),
+        },
+        controlEndpoint: {
+          endpoint: credsProvider().getControlEndpoint(),
+          insecureConnection: credsProvider().isControlEndpointInsecure(),
+        },
+        tokenEndpoint: {
+          endpoint: credsProvider().getTokenEndpoint(),
+          insecureConnection: credsProvider().isTokenEndpointInsecure(),
+        },
       },
     });
   }

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -34,15 +34,12 @@ export function credsProvider(): CredentialProvider {
         endpointOverrides: {
           controlEndpoint: {
             endpoint: 'https://no-controlplane-requests-allowed:9001',
-            secureConnection: false,
           },
           cacheEndpoint: {
             endpoint: 'https://localhost:9001',
-            secureConnection: false,
           },
           tokenEndpoint: {
             endpoint: 'https://localhost:9001',
-            secureConnection: false,
           },
         },
       });

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -34,15 +34,15 @@ export function credsProvider(): CredentialProvider {
         endpointOverrides: {
           controlEndpoint: {
             endpoint: 'https://no-controlplane-requests-allowed:9001',
-            insecureConnection: false,
+            secureConnection: false,
           },
           cacheEndpoint: {
             endpoint: 'https://localhost:9001',
-            insecureConnection: false,
+            secureConnection: false,
           },
           tokenEndpoint: {
             endpoint: 'https://localhost:9001',
-            insecureConnection: false,
+            secureConnection: false,
           },
         },
       });
@@ -64,15 +64,15 @@ function sessionCredsProvider(): CredentialProvider {
       endpointOverrides: {
         cacheEndpoint: {
           endpoint: credsProvider().getCacheEndpoint(),
-          insecureConnection: credsProvider().isCacheEndpointInsecure(),
+          secureConnection: credsProvider().isCacheEndpointSecure(),
         },
         controlEndpoint: {
           endpoint: credsProvider().getControlEndpoint(),
-          insecureConnection: credsProvider().isControlEndpointInsecure(),
+          secureConnection: credsProvider().isControlEndpointSecure(),
         },
         tokenEndpoint: {
           endpoint: credsProvider().getTokenEndpoint(),
-          insecureConnection: credsProvider().isTokenEndpointInsecure(),
+          secureConnection: credsProvider().isTokenEndpointSecure(),
         },
       },
     });

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -52,15 +52,12 @@ describe('getWeb*Endpoint', () => {
       endpointOverrides: {
         controlEndpoint: {
           endpoint: 'some-control-endpoint',
-          insecureConnection: false,
         },
         cacheEndpoint: {
           endpoint: 'some-cache-endpoint',
-          insecureConnection: false,
         },
         tokenEndpoint: {
           endpoint: 'some-token-endpoint',
-          insecureConnection: false,
         },
       },
     });
@@ -77,15 +74,12 @@ describe('getWeb*Endpoint', () => {
       endpointOverrides: {
         controlEndpoint: {
           endpoint: 'https://some-control-endpoint',
-          insecureConnection: false,
         },
         cacheEndpoint: {
           endpoint: 'https://some-cache-endpoint',
-          insecureConnection: false,
         },
         tokenEndpoint: {
           endpoint: 'https://some-token-endpoint',
-          insecureConnection: false,
         },
       },
     });
@@ -103,15 +97,12 @@ describe('getWeb*Endpoint', () => {
         endpointOverrides: {
           controlEndpoint: {
             endpoint: 'some-control-endpoint:9001',
-            insecureConnection: false,
           },
           cacheEndpoint: {
             endpoint: 'some-cache-endpoint:9001',
-            insecureConnection: false,
           },
           tokenEndpoint: {
             endpoint: 'some-token-endpoint:9001',
-            insecureConnection: false,
           },
         },
       });
@@ -128,15 +119,12 @@ describe('getWeb*Endpoint', () => {
         endpointOverrides: {
           controlEndpoint: {
             endpoint: 'https://some-control-endpoint:9001',
-            insecureConnection: false,
           },
           cacheEndpoint: {
             endpoint: 'https://some-cache-endpoint:9001',
-            insecureConnection: false,
           },
           tokenEndpoint: {
             endpoint: 'https://some-token-endpoint:9001',
-            insecureConnection: false,
           },
         },
       });

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -50,9 +50,18 @@ describe('getWeb*Endpoint', () => {
     const credProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
-        controlEndpoint: 'some-control-endpoint',
-        cacheEndpoint: 'some-cache-endpoint',
-        tokenEndpoint: 'some-token-endpoint',
+        controlEndpoint: {
+          endpoint: 'some-control-endpoint',
+          insecureConnection: false,
+        },
+        cacheEndpoint: {
+          endpoint: 'some-cache-endpoint',
+          insecureConnection: false,
+        },
+        tokenEndpoint: {
+          endpoint: 'some-token-endpoint',
+          insecureConnection: false,
+        },
       },
     });
     const webControlEndpoint = getWebControlEndpoint(credProvider);
@@ -66,9 +75,18 @@ describe('getWeb*Endpoint', () => {
     const credProvider = CredentialProvider.fromString({
       authToken: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
-        controlEndpoint: 'https://some-control-endpoint',
-        cacheEndpoint: 'https://some-cache-endpoint',
-        tokenEndpoint: 'http://some-token-endpoint',
+        controlEndpoint: {
+          endpoint: 'https://some-control-endpoint',
+          insecureConnection: false,
+        },
+        cacheEndpoint: {
+          endpoint: 'https://some-cache-endpoint',
+          insecureConnection: false,
+        },
+        tokenEndpoint: {
+          endpoint: 'https://some-token-endpoint',
+          insecureConnection: false,
+        },
       },
     });
     const webControlEndpoint = getWebControlEndpoint(credProvider);
@@ -83,9 +101,18 @@ describe('getWeb*Endpoint', () => {
       const credProvider = CredentialProvider.fromString({
         authToken: base64EncodedFakeV1AuthToken,
         endpointOverrides: {
-          controlEndpoint: 'some-control-endpoint:9001',
-          cacheEndpoint: 'some-cache-endpoint:9001',
-          tokenEndpoint: 'some-token-endpoint:9001',
+          controlEndpoint: {
+            endpoint: 'some-control-endpoint:9001',
+            insecureConnection: false,
+          },
+          cacheEndpoint: {
+            endpoint: 'some-cache-endpoint:9001',
+            insecureConnection: false,
+          },
+          tokenEndpoint: {
+            endpoint: 'some-token-endpoint:9001',
+            insecureConnection: false,
+          },
         },
       });
       const webControlEndpoint = getWebControlEndpoint(credProvider);
@@ -99,9 +126,18 @@ describe('getWeb*Endpoint', () => {
       const credProvider = CredentialProvider.fromString({
         authToken: base64EncodedFakeV1AuthToken,
         endpointOverrides: {
-          controlEndpoint: 'https://some-control-endpoint:9001',
-          cacheEndpoint: 'https://some-cache-endpoint:9001',
-          tokenEndpoint: 'http://some-token-endpoint:9001',
+          controlEndpoint: {
+            endpoint: 'https://some-control-endpoint:9001',
+            insecureConnection: false,
+          },
+          cacheEndpoint: {
+            endpoint: 'https://some-cache-endpoint:9001',
+            insecureConnection: false,
+          },
+          tokenEndpoint: {
+            endpoint: 'https://some-token-endpoint:9001',
+            insecureConnection: false,
+          },
         },
       });
       const webControlEndpoint = getWebControlEndpoint(credProvider);

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -79,7 +79,7 @@ describe('getWeb*Endpoint', () => {
           endpoint: 'https://some-cache-endpoint',
         },
         tokenEndpoint: {
-          endpoint: 'https://some-token-endpoint',
+          endpoint: 'http://some-token-endpoint',
         },
       },
     });
@@ -124,7 +124,7 @@ describe('getWeb*Endpoint', () => {
             endpoint: 'https://some-cache-endpoint:9001',
           },
           tokenEndpoint: {
-            endpoint: 'https://some-token-endpoint:9001',
+            endpoint: 'http://some-token-endpoint:9001',
           },
         },
       });

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -204,15 +204,15 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
       this.allEndpoints = {
         controlEndpoint: {
           endpoint: decodedToken.controlEndpoint,
-          insecureConnection: !decodedToken.controlEndpoint.includes(':443'),
+          insecureConnection: false,
         },
         cacheEndpoint: {
           endpoint: decodedToken.cacheEndpoint,
-          insecureConnection: !decodedToken.controlEndpoint.includes(':443'),
+          insecureConnection: false,
         },
         tokenEndpoint: {
           endpoint: decodedToken.tokenEndpoint,
-          insecureConnection: !decodedToken.controlEndpoint.includes(':443'),
+          insecureConnection: false,
         },
       };
     } else if (isAllEndpoints(props.endpointOverrides)) {

--- a/packages/core/src/auth/credential-provider.ts
+++ b/packages/core/src/auth/credential-provider.ts
@@ -8,7 +8,7 @@ import {
 export interface BaseEndpointOverride {
   baseEndpoint: string;
   endpointPrefix?: string;
-  insecureConnection?: boolean;
+  secureConnection?: boolean;
 }
 
 export type EndpointOverrides = BaseEndpointOverride | AllEndpoints;
@@ -57,7 +57,7 @@ export abstract class CredentialProvider {
   /**
    * @returns {boolean} true if connecting to the control plane endpoint connection without TLS; false if using TLS
    */
-  abstract isControlEndpointInsecure(): boolean;
+  abstract isControlEndpointSecure(): boolean;
 
   /**
    * @returns {string} The host which the Momento client will connect to for Momento data plane operations
@@ -67,7 +67,7 @@ export abstract class CredentialProvider {
   /**
    * @returns {boolean} true if connecting to the data plane endpoint connection without TLS; false if using TLS
    */
-  abstract isCacheEndpointInsecure(): boolean;
+  abstract isCacheEndpointSecure(): boolean;
 
   /**
    * @returns {string} The host which the Momento client will connect to for Momento token operations
@@ -77,7 +77,7 @@ export abstract class CredentialProvider {
   /**
    * @returns {boolean} true if connecting to the token endpoint connection without TLS; false if using TLS
    */
-  abstract isTokenEndpointInsecure(): boolean;
+  abstract isTokenEndpointSecure(): boolean;
 
   /**
    * Modifies the instance of the credential provider to override endpoints to
@@ -114,15 +114,15 @@ abstract class CredentialProviderBase implements CredentialProvider {
 
   abstract getCacheEndpoint(): string;
 
-  abstract isCacheEndpointInsecure(): boolean;
+  abstract isCacheEndpointSecure(): boolean;
 
   abstract getControlEndpoint(): string;
 
-  abstract isControlEndpointInsecure(): boolean;
+  abstract isControlEndpointSecure(): boolean;
 
   abstract getTokenEndpoint(): string;
 
-  abstract isTokenEndpointInsecure(): boolean;
+  abstract isTokenEndpointSecure(): boolean;
 
   abstract areEndpointsOverridden(): boolean;
 
@@ -204,15 +204,12 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
       this.allEndpoints = {
         controlEndpoint: {
           endpoint: decodedToken.controlEndpoint,
-          insecureConnection: false,
         },
         cacheEndpoint: {
           endpoint: decodedToken.cacheEndpoint,
-          insecureConnection: false,
         },
         tokenEndpoint: {
           endpoint: decodedToken.tokenEndpoint,
-          insecureConnection: false,
         },
       };
     } else if (isAllEndpoints(props.endpointOverrides)) {
@@ -239,24 +236,33 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
     return this.allEndpoints.cacheEndpoint.endpoint;
   }
 
-  isCacheEndpointInsecure(): boolean {
-    return this.allEndpoints.cacheEndpoint.insecureConnection;
+  isCacheEndpointSecure(): boolean {
+    if (this.allEndpoints.cacheEndpoint.secureConnection === undefined) {
+      return true;
+    }
+    return this.allEndpoints.cacheEndpoint.secureConnection;
   }
 
   getControlEndpoint(): string {
     return this.allEndpoints.controlEndpoint.endpoint;
   }
 
-  isControlEndpointInsecure(): boolean {
-    return this.allEndpoints.controlEndpoint.insecureConnection;
+  isControlEndpointSecure(): boolean {
+    if (this.allEndpoints.controlEndpoint.secureConnection === undefined) {
+      return true;
+    }
+    return this.allEndpoints.controlEndpoint.secureConnection;
   }
 
   getTokenEndpoint(): string {
     return this.allEndpoints.tokenEndpoint.endpoint;
   }
 
-  isTokenEndpointInsecure(): boolean {
-    return this.allEndpoints.tokenEndpoint.insecureConnection;
+  isTokenEndpointSecure(): boolean {
+    if (this.allEndpoints.tokenEndpoint.secureConnection === undefined) {
+      return true;
+    }
+    return this.allEndpoints.tokenEndpoint.secureConnection;
   }
 
   areEndpointsOverridden(): boolean {
@@ -266,7 +272,7 @@ export class StringMomentoTokenProvider extends CredentialProviderBase {
   withMomentoLocal(): CredentialProvider {
     const momentoLocalOverride = {
       endpoint: '127.0.0.1:8080',
-      insecureConnection: true,
+      secureConnection: false,
     };
     return new StringMomentoTokenProvider({
       authToken: this.apiKey,

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -35,9 +35,9 @@ interface TokenAndEndpoints {
 }
 
 export interface AllEndpoints {
-  controlEndpoint: {endpoint: string; insecureConnection: boolean};
-  cacheEndpoint: {endpoint: string; insecureConnection: boolean};
-  tokenEndpoint: {endpoint: string; insecureConnection: boolean};
+  controlEndpoint: {endpoint: string; secureConnection?: boolean};
+  cacheEndpoint: {endpoint: string; secureConnection?: boolean};
+  tokenEndpoint: {endpoint: string; secureConnection?: boolean};
 }
 
 export function populateAllEndpointsFromBaseEndpoint(
@@ -50,15 +50,15 @@ export function populateAllEndpointsFromBaseEndpoint(
   return {
     controlEndpoint: {
       endpoint: `${prefix}control.${endpointOverride.baseEndpoint}`,
-      insecureConnection: endpointOverride.insecureConnection || false,
+      secureConnection: endpointOverride.secureConnection,
     },
     cacheEndpoint: {
       endpoint: `${prefix}cache.${endpointOverride.baseEndpoint}`,
-      insecureConnection: endpointOverride.insecureConnection || false,
+      secureConnection: endpointOverride.secureConnection,
     },
     tokenEndpoint: {
       endpoint: `${prefix}token.${endpointOverride.baseEndpoint}`,
-      insecureConnection: endpointOverride.insecureConnection || false,
+      secureConnection: endpointOverride.secureConnection,
     },
   };
 }

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -35,9 +35,9 @@ interface TokenAndEndpoints {
 }
 
 export interface AllEndpoints {
-  controlEndpoint: string;
-  cacheEndpoint: string;
-  tokenEndpoint: string;
+  controlEndpoint: {endpoint: string; insecureConnection: boolean};
+  cacheEndpoint: {endpoint: string; insecureConnection: boolean};
+  tokenEndpoint: {endpoint: string; insecureConnection: boolean};
 }
 
 export function populateAllEndpointsFromBaseEndpoint(
@@ -48,9 +48,18 @@ export function populateAllEndpointsFromBaseEndpoint(
     prefix = `${endpointOverride.endpointPrefix}.`;
   }
   return {
-    controlEndpoint: `${prefix}control.${endpointOverride.baseEndpoint}`,
-    cacheEndpoint: `${prefix}cache.${endpointOverride.baseEndpoint}`,
-    tokenEndpoint: `${prefix}token.${endpointOverride.baseEndpoint}`,
+    controlEndpoint: {
+      endpoint: `${prefix}control.${endpointOverride.baseEndpoint}`,
+      insecureConnection: endpointOverride.insecureConnection || false,
+    },
+    cacheEndpoint: {
+      endpoint: `${prefix}cache.${endpointOverride.baseEndpoint}`,
+      insecureConnection: endpointOverride.insecureConnection || false,
+    },
+    tokenEndpoint: {
+      endpoint: `${prefix}token.${endpointOverride.baseEndpoint}`,
+      insecureConnection: endpointOverride.insecureConnection || false,
+    },
   };
 }
 
@@ -76,10 +85,13 @@ export const decodeAuthToken = (token?: string): TokenAndEndpoints => {
       if (!base64DecodedToken.endpoint || !base64DecodedToken.api_key) {
         throw new InvalidArgumentError('failed to parse token');
       }
+      const endpoints = populateAllEndpointsFromBaseEndpoint({
+        baseEndpoint: base64DecodedToken.endpoint,
+      });
       return {
-        ...populateAllEndpointsFromBaseEndpoint({
-          baseEndpoint: base64DecodedToken.endpoint,
-        }),
+        controlEndpoint: endpoints.controlEndpoint.endpoint,
+        cacheEndpoint: endpoints.cacheEndpoint.endpoint,
+        tokenEndpoint: endpoints.tokenEndpoint.endpoint,
         authToken: base64DecodedToken.api_key,
       };
     } else {

--- a/packages/core/src/internal/utils/auth.ts
+++ b/packages/core/src/internal/utils/auth.ts
@@ -34,10 +34,15 @@ interface TokenAndEndpoints {
   authToken: string;
 }
 
+export interface Endpoint {
+  endpoint: string;
+  secureConnection?: boolean;
+}
+
 export interface AllEndpoints {
-  controlEndpoint: {endpoint: string; secureConnection?: boolean};
-  cacheEndpoint: {endpoint: string; secureConnection?: boolean};
-  tokenEndpoint: {endpoint: string; secureConnection?: boolean};
+  controlEndpoint: Endpoint;
+  cacheEndpoint: Endpoint;
+  tokenEndpoint: Endpoint;
 }
 
 export function populateAllEndpointsFromBaseEndpoint(

--- a/packages/core/test/unit/auth/credential-provider.test.ts
+++ b/packages/core/test/unit/auth/credential-provider.test.ts
@@ -86,9 +86,9 @@ describe('StringMomentoTokenProvider', () => {
     const legacyAuthProvider = CredentialProvider.fromString({
       apiKey: fakeTestLegacyToken,
       endpointOverrides: {
-        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
-        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
-        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
+        controlEndpoint: {endpoint: 'control.foo'},
+        cacheEndpoint: {endpoint: 'cache.foo'},
+        tokenEndpoint: {endpoint: 'token.foo'},
       },
     });
     expect(legacyAuthProvider.getControlEndpoint()).toEqual('control.foo');
@@ -99,9 +99,9 @@ describe('StringMomentoTokenProvider', () => {
     const v1AuthProvider = CredentialProvider.fromString({
       apiKey: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
-        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
-        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
-        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
+        controlEndpoint: {endpoint: 'control.foo'},
+        cacheEndpoint: {endpoint: 'cache.foo'},
+        tokenEndpoint: {endpoint: 'token.foo'},
       },
     });
     expect(v1AuthProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);
@@ -115,9 +115,9 @@ describe('StringMomentoTokenProvider', () => {
     const sessionTokenProvider = CredentialProvider.fromString({
       apiKey: fakeSessionToken,
       endpointOverrides: {
-        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
-        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
-        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
+        controlEndpoint: {endpoint: 'control.foo'},
+        cacheEndpoint: {endpoint: 'cache.foo'},
+        tokenEndpoint: {endpoint: 'token.foo'},
       },
     });
     expect(sessionTokenProvider.getAuthToken()).toEqual(fakeSessionToken);
@@ -202,9 +202,9 @@ describe('EnvMomentoTokenProvider', () => {
     const legacyAuthProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       endpointOverrides: {
-        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
-        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
-        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
+        controlEndpoint: {endpoint: 'control.foo'},
+        cacheEndpoint: {endpoint: 'cache.foo'},
+        tokenEndpoint: {endpoint: 'token.foo'},
       },
     });
     expect(legacyAuthProvider.getAuthToken()).toEqual(fakeTestLegacyToken);
@@ -217,9 +217,9 @@ describe('EnvMomentoTokenProvider', () => {
     const v1AuthProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       endpointOverrides: {
-        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
-        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
-        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
+        controlEndpoint: {endpoint: 'control.foo'},
+        cacheEndpoint: {endpoint: 'cache.foo'},
+        tokenEndpoint: {endpoint: 'token.foo'},
       },
     });
     expect(v1AuthProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);

--- a/packages/core/test/unit/auth/credential-provider.test.ts
+++ b/packages/core/test/unit/auth/credential-provider.test.ts
@@ -86,9 +86,9 @@ describe('StringMomentoTokenProvider', () => {
     const legacyAuthProvider = CredentialProvider.fromString({
       apiKey: fakeTestLegacyToken,
       endpointOverrides: {
-        controlEndpoint: 'control.foo',
-        cacheEndpoint: 'cache.foo',
-        tokenEndpoint: 'token.foo',
+        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
+        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
+        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
       },
     });
     expect(legacyAuthProvider.getControlEndpoint()).toEqual('control.foo');
@@ -99,9 +99,9 @@ describe('StringMomentoTokenProvider', () => {
     const v1AuthProvider = CredentialProvider.fromString({
       apiKey: base64EncodedFakeV1AuthToken,
       endpointOverrides: {
-        controlEndpoint: 'control.foo',
-        cacheEndpoint: 'cache.foo',
-        tokenEndpoint: 'token.foo',
+        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
+        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
+        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
       },
     });
     expect(v1AuthProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);
@@ -115,9 +115,9 @@ describe('StringMomentoTokenProvider', () => {
     const sessionTokenProvider = CredentialProvider.fromString({
       apiKey: fakeSessionToken,
       endpointOverrides: {
-        controlEndpoint: 'control.foo',
-        cacheEndpoint: 'cache.foo',
-        tokenEndpoint: 'token.foo',
+        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
+        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
+        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
       },
     });
     expect(sessionTokenProvider.getAuthToken()).toEqual(fakeSessionToken);
@@ -202,9 +202,9 @@ describe('EnvMomentoTokenProvider', () => {
     const legacyAuthProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       endpointOverrides: {
-        controlEndpoint: 'control.foo',
-        cacheEndpoint: 'cache.foo',
-        tokenEndpoint: 'token.foo',
+        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
+        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
+        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
       },
     });
     expect(legacyAuthProvider.getAuthToken()).toEqual(fakeTestLegacyToken);
@@ -217,9 +217,9 @@ describe('EnvMomentoTokenProvider', () => {
     const v1AuthProvider = CredentialProvider.fromEnvironmentVariable({
       environmentVariableName: testEnvVarName,
       endpointOverrides: {
-        controlEndpoint: 'control.foo',
-        cacheEndpoint: 'cache.foo',
-        tokenEndpoint: 'token.foo',
+        controlEndpoint: {endpoint: 'control.foo', insecureConnection: false},
+        cacheEndpoint: {endpoint: 'cache.foo', insecureConnection: false},
+        tokenEndpoint: {endpoint: 'token.foo', insecureConnection: false},
       },
     });
     expect(v1AuthProvider.getAuthToken()).toEqual(fakeTestV1ApiKey);


### PR DESCRIPTION
Allows a user to specify whether each overridden endpoint should use TLS or not. 

~~Also changes `StringMomentoTokenProvider` to detect whether `:443` is contained in the endpoint to determine secure vs insecure when given no overrides.~~
Removed the auto-detect port `443` because it turns out endpoints like `cache.etc.etc.momentohq.com` don't contain the port number.