### PR TITLE
feat: clean up response type enum folders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node: [18]
     name: Test Cache on Node ${{ matrix.node }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}
@@ -558,7 +558,7 @@ jobs:
         node: [ 18 ]
       fail-fast: true
     name: Verify packages are installable on node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node: [18]
     name: Test Cache on Node ${{ matrix.node }}
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
     steps:
       - name: Setup repo
         uses: actions/checkout@v3

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -695,7 +695,7 @@ export class CacheDataClient implements IDataClient {
     cacheName: string,
     setName: Uint8Array,
     limit: number
-  ): Promise<CacheSetFetch.Response> {
+  ): Promise<CacheSetSample.Response> {
     const request = new grpcCache._SetSampleRequest({
       set_name: setName,
       limit: limit,

--- a/packages/core/src/messages/responses/cache-dictionary-fetch.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-fetch.ts
@@ -5,13 +5,13 @@ import {
 } from './response-base';
 import {SdkError} from '../../errors';
 import {_DictionaryFieldValuePair} from './grpc-response-types';
-import {DictionaryFetchResponse} from './enums';
+import {CacheDictionaryFetchResponse} from './enums';
 
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
   value(): Record<string, string> | undefined;
-  type: DictionaryFetchResponse;
+  type: CacheDictionaryFetchResponse;
 }
 
 /**
@@ -21,7 +21,8 @@ interface IResponse {
 export class Hit extends ResponseBase implements IResponse {
   private readonly items: _DictionaryFieldValuePair[];
   private readonly _displayListSizeLimit = 5;
-  readonly type: DictionaryFetchResponse.Hit = DictionaryFetchResponse.Hit;
+  readonly type: CacheDictionaryFetchResponse.Hit =
+    CacheDictionaryFetchResponse.Hit;
 
   constructor(items: _DictionaryFieldValuePair[]) {
     super();
@@ -132,7 +133,8 @@ export class Hit extends ResponseBase implements IResponse {
  * Indicates that the requested data was not available in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
-  readonly type: DictionaryFetchResponse.Miss = DictionaryFetchResponse.Miss;
+  readonly type: CacheDictionaryFetchResponse.Miss =
+    CacheDictionaryFetchResponse.Miss;
 
   value(): Record<string, string> | undefined {
     return undefined;
@@ -150,7 +152,8 @@ export class Miss extends BaseResponseMiss implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
-  readonly type: DictionaryFetchResponse.Error = DictionaryFetchResponse.Error;
+  readonly type: CacheDictionaryFetchResponse.Error =
+    CacheDictionaryFetchResponse.Error;
   constructor(_innerException: SdkError) {
     super(_innerException);
   }

--- a/packages/core/src/messages/responses/cache-dictionary-get-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-field.ts
@@ -5,13 +5,13 @@ import {
   ResponseBase,
 } from './response-base';
 import {truncateString} from '../../internal/utils';
-import {DictionaryGetFieldResponse} from './enums';
+import {CacheDictionaryGetFieldResponse} from './enums';
 
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
   value(): string | undefined;
-  type: DictionaryGetFieldResponse;
+  type: CacheDictionaryGetFieldResponse;
 }
 
 /**
@@ -21,8 +21,8 @@ interface IResponse {
 export class Hit extends ResponseBase implements IResponse {
   private readonly body: Uint8Array;
   private readonly field: Uint8Array;
-  readonly type: DictionaryGetFieldResponse.Hit =
-    DictionaryGetFieldResponse.Hit;
+  readonly type: CacheDictionaryGetFieldResponse.Hit =
+    CacheDictionaryGetFieldResponse.Hit;
 
   constructor(body: Uint8Array, field: Uint8Array) {
     super();
@@ -81,8 +81,8 @@ export class Hit extends ResponseBase implements IResponse {
  */
 export class Miss extends BaseResponseMiss implements IResponse {
   private readonly field: Uint8Array;
-  readonly type: DictionaryGetFieldResponse.Miss =
-    DictionaryGetFieldResponse.Miss;
+  readonly type: CacheDictionaryGetFieldResponse.Miss =
+    CacheDictionaryGetFieldResponse.Miss;
 
   constructor(field: Uint8Array) {
     super();
@@ -122,8 +122,8 @@ export class Miss extends BaseResponseMiss implements IResponse {
  */
 export class Error extends BaseResponseError implements IResponse {
   private readonly field: Uint8Array;
-  readonly type: DictionaryGetFieldResponse.Error =
-    DictionaryGetFieldResponse.Error;
+  readonly type: CacheDictionaryGetFieldResponse.Error =
+    CacheDictionaryGetFieldResponse.Error;
 
   constructor(_innerException: SdkError, field: Uint8Array) {
     super(_innerException);

--- a/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-get-fields.ts
@@ -11,13 +11,13 @@ import {
   Error as CacheDictionaryGetFieldResponseError,
 } from './cache-dictionary-get-field';
 import {_DictionaryGetResponsePart, _ECacheResult} from './grpc-response-types';
-import {DictionaryGetFieldsResponse} from './enums';
+import {CacheDictionaryGetFieldsResponse} from './enums';
 
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
   value(): Record<string, string> | undefined;
-  type: DictionaryGetFieldsResponse;
+  type: CacheDictionaryGetFieldsResponse;
 }
 
 /**
@@ -27,8 +27,8 @@ interface IResponse {
 export class Hit extends ResponseBase implements IResponse {
   private readonly items: _DictionaryGetResponsePart[];
   private readonly fields: Uint8Array[];
-  public readonly type: DictionaryGetFieldsResponse.Hit =
-    DictionaryGetFieldsResponse.Hit;
+  public readonly type: CacheDictionaryGetFieldsResponse.Hit =
+    CacheDictionaryGetFieldsResponse.Hit;
   public responses: CacheDictionaryGetFieldResponseType[] = [];
 
   constructor(items: _DictionaryGetResponsePart[], fields: Uint8Array[]) {
@@ -162,8 +162,8 @@ export class Hit extends ResponseBase implements IResponse {
  * Indicates that the requested data was not available in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
-  public readonly type: DictionaryGetFieldsResponse.Miss =
-    DictionaryGetFieldsResponse.Miss;
+  public readonly type: CacheDictionaryGetFieldsResponse.Miss =
+    CacheDictionaryGetFieldsResponse.Miss;
 
   value(): Record<string, string> | undefined {
     return undefined;
@@ -181,8 +181,8 @@ export class Miss extends BaseResponseMiss implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
-  public readonly type: DictionaryGetFieldsResponse.Error =
-    DictionaryGetFieldsResponse.Error;
+  public readonly type: CacheDictionaryGetFieldsResponse.Error =
+    CacheDictionaryGetFieldsResponse.Error;
   constructor(_innerException: SdkError) {
     super(_innerException);
   }

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -1,10 +1,10 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {DictionaryIncrementResponse} from './enums';
+import {CacheDictionaryIncrementResponse} from './enums';
 
 interface IResponse {
   value(): number | undefined;
-  type: DictionaryIncrementResponse;
+  type: CacheDictionaryIncrementResponse;
 }
 
 /**
@@ -12,8 +12,8 @@ interface IResponse {
  */
 export class Success extends BaseResponseSuccess implements IResponse {
   private readonly _value: number;
-  readonly type: DictionaryIncrementResponse.Success =
-    DictionaryIncrementResponse.Success;
+  readonly type: CacheDictionaryIncrementResponse.Success =
+    CacheDictionaryIncrementResponse.Success;
 
   constructor(value: number) {
     super();
@@ -47,8 +47,8 @@ export class Success extends BaseResponseSuccess implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
-  readonly type: DictionaryIncrementResponse.Error =
-    DictionaryIncrementResponse.Error;
+  readonly type: CacheDictionaryIncrementResponse.Error =
+    CacheDictionaryIncrementResponse.Error;
   constructor(_innerException: SdkError) {
     super(_innerException);
   }

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -1,36 +1,19 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {DictionaryIncrementResponse} from './enums';
 
-/**
- * Parent response type for a dictionary increment request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionaryIncrement.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionaryIncrement.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {
-  public value(): number | undefined {
-    if (this instanceof Success) {
-      return (this as Success).value();
-    }
-    return undefined;
-  }
+interface IResponse {
+  value(): number | undefined;
+  type: DictionaryIncrementResponse;
 }
 
-class _Success extends Response {
+/**
+ * Indicates a Successful dictionary increment request.
+ */
+class Success extends BaseResponseSuccess implements IResponse {
   private readonly _value: number;
+  readonly type: DictionaryIncrementResponse.Success =
+    DictionaryIncrementResponse.Success;
 
   constructor(value: number) {
     super();
@@ -54,17 +37,6 @@ class _Success extends Response {
 }
 
 /**
- * Indicates a Successful dictionary increment request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
  * Indicates that an error occurred during the dictionary increment request.
  *
  * This response object includes the following fields that you can use to determine
@@ -74,4 +46,16 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+class Error extends BaseResponseError implements IResponse {
+  readonly type: DictionaryIncrementResponse.Error =
+    DictionaryIncrementResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  public value(): undefined {
+    return undefined;
+  }
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -10,7 +10,7 @@ interface IResponse {
 /**
  * Indicates a Successful dictionary increment request.
  */
-class Success extends BaseResponseSuccess implements IResponse {
+export class Success extends BaseResponseSuccess implements IResponse {
   private readonly _value: number;
   readonly type: DictionaryIncrementResponse.Success =
     DictionaryIncrementResponse.Success;
@@ -46,7 +46,7 @@ class Success extends BaseResponseSuccess implements IResponse {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-class Error extends BaseResponseError implements IResponse {
+export class Error extends BaseResponseError implements IResponse {
   readonly type: DictionaryIncrementResponse.Error =
     DictionaryIncrementResponse.Error;
   constructor(_innerException: SdkError) {

--- a/packages/core/src/messages/responses/cache-dictionary-increment.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-increment.ts
@@ -24,7 +24,7 @@ export class Success extends BaseResponseSuccess implements IResponse {
    * The new value of the element after incrementing.
    * @returns {number}
    */
-  public override value(): number {
+  public value(): number {
     return this._value;
   }
   public valueNumber(): number {

--- a/packages/core/src/messages/responses/cache-dictionary-length.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-length.ts
@@ -1,34 +1,21 @@
 import {SdkError} from '../../errors';
 import {
+  BaseResponseError,
+  BaseResponseMiss,
   ResponseBase,
-  ResponseError,
-  ResponseHit,
-  ResponseMiss,
 } from './response-base';
+import {DictionaryLengthResponse} from './enums';
+
+interface IResponse {
+  value(): number | undefined;
+  type: DictionaryLengthResponse;
+}
 
 /**
- * Parent response type for a dictionary length request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Hit}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionaryLength.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionaryLength.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
  */
-export abstract class Response extends ResponseBase {}
-
-class _Hit extends Response {
+export class Hit extends ResponseBase implements IResponse {
   private readonly _length: number;
   constructor(length: number) {
     super();
@@ -46,24 +33,22 @@ class _Hit extends Response {
   public override toString(): string {
     return `${super.toString()}: length ${this._length}`;
   }
+
+  readonly type: DictionaryLengthResponse.Hit = DictionaryLengthResponse.Hit;
+
+  value(): number {
+    return this._length;
+  }
 }
-
-/**
- * Indicates that the requested data was successfully retrieved from the cache.  Provides
- * `value*` accessors to retrieve the data in the appropriate format.
- */
-export class Hit extends ResponseHit(_Hit) {}
-
-class _Miss extends Response {}
 
 /**
  * Indicates that the requested data was not available in the cache.
  */
-export class Miss extends ResponseMiss(_Miss) {}
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: DictionaryLengthResponse.Miss = DictionaryLengthResponse.Miss;
 
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
+  value(): undefined {
+    return undefined;
   }
 }
 
@@ -77,4 +62,17 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: DictionaryLengthResponse.Error =
+    DictionaryLengthResponse.Error;
+
+  value(): undefined {
+    return undefined;
+  }
+}
+
+export type Response = Hit | Miss | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-length.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-length.ts
@@ -4,11 +4,11 @@ import {
   BaseResponseMiss,
   ResponseBase,
 } from './response-base';
-import {DictionaryLengthResponse} from './enums';
+import {CacheDictionaryLengthResponse} from './enums';
 
 interface IResponse {
   value(): number | undefined;
-  type: DictionaryLengthResponse;
+  type: CacheDictionaryLengthResponse;
 }
 
 /**
@@ -34,7 +34,8 @@ export class Hit extends ResponseBase implements IResponse {
     return `${super.toString()}: length ${this._length}`;
   }
 
-  readonly type: DictionaryLengthResponse.Hit = DictionaryLengthResponse.Hit;
+  readonly type: CacheDictionaryLengthResponse.Hit =
+    CacheDictionaryLengthResponse.Hit;
 
   value(): number {
     return this._length;
@@ -45,7 +46,8 @@ export class Hit extends ResponseBase implements IResponse {
  * Indicates that the requested data was not available in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
-  readonly type: DictionaryLengthResponse.Miss = DictionaryLengthResponse.Miss;
+  readonly type: CacheDictionaryLengthResponse.Miss =
+    CacheDictionaryLengthResponse.Miss;
 
   value(): undefined {
     return undefined;
@@ -67,8 +69,8 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  readonly type: DictionaryLengthResponse.Error =
-    DictionaryLengthResponse.Error;
+  readonly type: CacheDictionaryLengthResponse.Error =
+    CacheDictionaryLengthResponse.Error;
 
   value(): undefined {
     return undefined;

--- a/packages/core/src/messages/responses/cache-dictionary-remove-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-remove-field.ts
@@ -1,17 +1,17 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {DictionaryRemoveFieldResponse} from './enums';
+import {CacheDictionaryRemoveFieldResponse} from './enums';
 
 interface IResponse {
-  type: DictionaryRemoveFieldResponse;
+  type: CacheDictionaryRemoveFieldResponse;
 }
 
 /**
  * Indicates a Successful dictionary remove field request.
  */
 export class Success extends BaseResponseSuccess implements IResponse {
-  readonly type: DictionaryRemoveFieldResponse.Success =
-    DictionaryRemoveFieldResponse.Success;
+  readonly type: CacheDictionaryRemoveFieldResponse.Success =
+    CacheDictionaryRemoveFieldResponse.Success;
 }
 
 /**
@@ -25,8 +25,8 @@ export class Success extends BaseResponseSuccess implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
-  readonly type: DictionaryRemoveFieldResponse.Error =
-    DictionaryRemoveFieldResponse.Error;
+  readonly type: CacheDictionaryRemoveFieldResponse.Error =
+    CacheDictionaryRemoveFieldResponse.Error;
   constructor(_innerException: SdkError) {
     super(_innerException);
   }

--- a/packages/core/src/messages/responses/cache-dictionary-remove-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-remove-field.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {DictionaryRemoveFieldResponse} from './enums';
 
-/**
- * Parent response type for a dictionary remove field request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionaryRemoveField.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionaryRemoveField.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: DictionaryRemoveFieldResponse;
+}
 
 /**
  * Indicates a Successful dictionary remove field request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: DictionaryRemoveFieldResponse.Success =
+    DictionaryRemoveFieldResponse.Success;
 }
 
 /**
@@ -45,4 +24,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: DictionaryRemoveFieldResponse.Error =
+    DictionaryRemoveFieldResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-remove-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-remove-fields.ts
@@ -1,17 +1,17 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {DictionaryRemoveFieldsResponse} from './enums';
+import {CacheDictionaryRemoveFieldsResponse} from './enums';
 
 interface IResponse {
-  type: DictionaryRemoveFieldsResponse;
+  type: CacheDictionaryRemoveFieldsResponse;
 }
 
 /**
  * Indicates a Successful dictionary remove fields request.
  */
 export class Success extends BaseResponseSuccess implements IResponse {
-  readonly type: DictionaryRemoveFieldsResponse.Success =
-    DictionaryRemoveFieldsResponse.Success;
+  readonly type: CacheDictionaryRemoveFieldsResponse.Success =
+    CacheDictionaryRemoveFieldsResponse.Success;
 }
 
 /**
@@ -29,8 +29,8 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  readonly type: DictionaryRemoveFieldsResponse.Error =
-    DictionaryRemoveFieldsResponse.Error;
+  readonly type: CacheDictionaryRemoveFieldsResponse.Error =
+    CacheDictionaryRemoveFieldsResponse.Error;
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-remove-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-remove-fields.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {DictionaryRemoveFieldsResponse} from './enums';
 
-/**
- * Parent response type for a dictionary remove fields request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionaryRemoveFields.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionaryRemoveFields.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: DictionaryRemoveFieldsResponse;
+}
 
 /**
  * Indicates a Successful dictionary remove fields request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: DictionaryRemoveFieldsResponse.Success =
+    DictionaryRemoveFieldsResponse.Success;
 }
 
 /**
@@ -45,4 +24,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: DictionaryRemoveFieldsResponse.Error =
+    DictionaryRemoveFieldsResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-set-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-set-field.ts
@@ -1,17 +1,17 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {DictionarySetFieldResponse} from './enums';
+import {CacheDictionarySetFieldResponse} from './enums';
 
 interface IResponse {
-  type: DictionarySetFieldResponse;
+  type: CacheDictionarySetFieldResponse;
 }
 
 /**
  * Indicates a Successful dictionary set field request.
  */
 export class Success extends BaseResponseSuccess implements IResponse {
-  readonly type: DictionarySetFieldResponse.Success =
-    DictionarySetFieldResponse.Success;
+  readonly type: CacheDictionarySetFieldResponse.Success =
+    CacheDictionarySetFieldResponse.Success;
 }
 
 /**
@@ -29,8 +29,8 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  readonly type: DictionarySetFieldResponse.Error =
-    DictionarySetFieldResponse.Error;
+  readonly type: CacheDictionarySetFieldResponse.Error =
+    CacheDictionarySetFieldResponse.Error;
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-set-field.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-set-field.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {DictionarySetFieldResponse} from './enums';
 
-/**
- * Parent response type for a dictionary set field request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionarySetField.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionarySetField.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: DictionarySetFieldResponse;
+}
 
 /**
  * Indicates a Successful dictionary set field request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: DictionarySetFieldResponse.Success =
+    DictionarySetFieldResponse.Success;
 }
 
 /**
@@ -45,4 +24,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: DictionarySetFieldResponse.Error =
+    DictionarySetFieldResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-set-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-set-fields.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {DictionarySetFieldsResponse} from './enums';
 
-/**
- * Parent response type for a dictionary set fields request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDictionarySetFields.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDictionarySetFields.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: DictionarySetFieldsResponse;
+}
 
 /**
  * Indicates a Successful dictionary set fields request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: DictionarySetFieldsResponse.Success =
+    DictionarySetFieldsResponse.Success;
 }
 
 /**
@@ -45,4 +24,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: DictionarySetFieldsResponse.Error =
+    DictionarySetFieldsResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-dictionary-set-fields.ts
+++ b/packages/core/src/messages/responses/cache-dictionary-set-fields.ts
@@ -1,17 +1,17 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {DictionarySetFieldsResponse} from './enums';
+import {CacheDictionarySetFieldsResponse} from './enums';
 
 interface IResponse {
-  type: DictionarySetFieldsResponse;
+  type: CacheDictionarySetFieldsResponse;
 }
 
 /**
  * Indicates a Successful dictionary set fields request.
  */
 export class Success extends BaseResponseSuccess implements IResponse {
-  readonly type: DictionarySetFieldsResponse.Success =
-    DictionarySetFieldsResponse.Success;
+  readonly type: CacheDictionarySetFieldsResponse.Success =
+    CacheDictionarySetFieldsResponse.Success;
 }
 
 /**
@@ -29,8 +29,8 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  readonly type: DictionarySetFieldsResponse.Error =
-    DictionarySetFieldsResponse.Error;
+  readonly type: CacheDictionarySetFieldsResponse.Error =
+    CacheDictionarySetFieldsResponse.Error;
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-set-add-element.ts
+++ b/packages/core/src/messages/responses/cache-set-add-element.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {CacheSetAddElementResponse} from './enums';
 
-/**
- * Parent response type for a set add element request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheSetAddElement.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheSetAddElement.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: CacheSetAddElementResponse;
+}
 
 /**
  * Indicates a Successful set add element request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheSetAddElementResponse.Success =
+    CacheSetAddElementResponse.Success;
 }
 
 /**
@@ -45,4 +24,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheSetAddElementResponse.Error =
+    CacheSetAddElementResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-set-add-elements.ts
+++ b/packages/core/src/messages/responses/cache-set-add-elements.ts
@@ -1,48 +1,21 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
 import {SdkError} from '../../errors';
 import * as CacheSetAddElement from './cache-set-add-element';
+import {CacheSetAddElementsResponse} from './enums';
 
-/**
- * Parent response type for a set add elements request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheSetAddElements.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheSetAddElements.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {
-  abstract toSingularResponse(): CacheSetAddElement.Response;
-}
-
-class _Success extends Response {
-  toSingularResponse(): CacheSetAddElement.Response {
-    return new CacheSetAddElement.Success();
-  }
+interface IResponse {
+  type: CacheSetAddElementsResponse;
+  toSingularResponse(): CacheSetAddElement.Response;
 }
 
 /**
  * Indicates a Successful set add elements request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(public _innerException: SdkError) {
-    super();
-  }
-
-  toSingularResponse(): CacheSetAddElement.Response {
-    return new CacheSetAddElement.Error(this._innerException);
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheSetAddElementsResponse.Success =
+    CacheSetAddElementsResponse.Success;
+  toSingularResponse(): CacheSetAddElement.Success {
+    return new CacheSetAddElement.Success();
   }
 }
 
@@ -56,4 +29,16 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheSetAddElementsResponse.Error =
+    CacheSetAddElementsResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  toSingularResponse(): CacheSetAddElement.Error {
+    return new CacheSetAddElement.Error(this._innerException);
+  }
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-set-fetch.ts
+++ b/packages/core/src/messages/responses/cache-set-fetch.ts
@@ -1,45 +1,26 @@
 import {
   ResponseBase,
-  ResponseError,
-  ResponseMiss,
-  ResponseHit,
+  BaseResponseMiss,
+  BaseResponseError,
 } from './response-base';
 import {SdkError} from '../../errors';
 import {truncateStringArray} from '../../internal/utils';
+import {CacheSetFetchResponse} from './enums';
 
 const TEXT_DECODER = new TextDecoder();
 
-/**
- * Parent response type for a set fetch request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Hit}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheSetFetch.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheSetFetch.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {
-  public value(): string[] | undefined {
-    if (this instanceof Hit) {
-      return (this as Hit).value();
-    }
-    return undefined;
-  }
+interface IResponse {
+  value(): string[] | undefined;
+  type: CacheSetFetchResponse;
 }
 
-class _Hit extends Response {
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Hit extends ResponseBase implements IResponse {
   private readonly elements: Uint8Array[];
+  readonly type: CacheSetFetchResponse.Hit = CacheSetFetchResponse.Hit;
 
   constructor(elements: Uint8Array[]) {
     super();
@@ -77,7 +58,7 @@ class _Hit extends Response {
    * This is a convenience alias for {valueArrayString}.
    * @returns {string[]}
    */
-  public override value(): string[] {
+  public value(): string[] {
     return this.valueArrayString();
   }
 
@@ -118,21 +99,12 @@ class _Hit extends Response {
 }
 
 /**
- * Indicates that the requested data was successfully retrieved from the cache.  Provides
- * `value*` accessors to retrieve the data in the appropriate format.
- */
-export class Hit extends ResponseHit(_Hit) {}
-
-class _Miss extends Response {}
-
-/**
  * Indicates that the requested data was not available in the cache.
  */
-export class Miss extends ResponseMiss(_Miss) {}
-
-class _Error extends Response {
-  constructor(public _innerException: SdkError) {
-    super();
+export class Miss extends BaseResponseMiss {
+  readonly type: CacheSetFetchResponse.Miss = CacheSetFetchResponse.Miss;
+  public value(): undefined {
+    return undefined;
   }
 }
 
@@ -146,4 +118,15 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheSetFetchResponse.Error = CacheSetFetchResponse.Error;
+  public value(): undefined {
+    return undefined;
+  }
+}
+
+export type Response = Hit | Miss | Error;

--- a/packages/core/src/messages/responses/cache-set-remove-element.ts
+++ b/packages/core/src/messages/responses/cache-set-remove-element.ts
@@ -1,38 +1,17 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {CacheSetRemoveElementResponse} from './enums';
 
-/**
- * Parent response type for a set remove element request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheSetRemoveElement.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheSetRemoveElement.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Success extends Response {}
+interface IResponse {
+  type: CacheSetRemoveElementResponse;
+}
 
 /**
  * Indicates a Successful set remove element request.
  */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheSetRemoveElementResponse.Success =
+    CacheSetRemoveElementResponse.Success;
 }
 
 /**
@@ -45,4 +24,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError {
+  readonly type: CacheSetRemoveElementResponse.Error =
+    CacheSetRemoveElementResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-set-remove-elements.ts
+++ b/packages/core/src/messages/responses/cache-set-remove-elements.ts
@@ -1,43 +1,20 @@
 import * as CacheSetRemoveElement from './cache-set-remove-element';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
 import {SdkError} from '../../errors';
+import {CacheSetRemoveElementsResponse} from './enums';
 
-class _Success extends ResponseBase {}
-
-class _Error extends ResponseBase {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
- * Parent response type for a set remove elements request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheSetRemoveElements.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheSetRemoveElements.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {
-  abstract toSingularResponse(): CacheSetRemoveElement.Response;
+interface IResponse {
+  type: CacheSetRemoveElementsResponse;
+  toSingularResponse(): CacheSetRemoveElement.Response;
 }
 
 /**
  * Indicates a Successful set remove elements request.
  */
-export class Success extends ResponseSuccess(_Success) {
-  toSingularResponse(): CacheSetRemoveElement.Response {
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheSetRemoveElementsResponse.Success =
+    CacheSetRemoveElementsResponse.Success;
+  toSingularResponse(): CacheSetRemoveElement.Success {
     return new CacheSetRemoveElement.Success();
   }
 }
@@ -52,8 +29,15 @@ export class Success extends ResponseSuccess(_Success) {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {
-  toSingularResponse(): CacheSetRemoveElement.Response {
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheSetRemoveElementsResponse.Error =
+    CacheSetRemoveElementsResponse.Error;
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+  toSingularResponse(): CacheSetRemoveElement.Error {
     return new CacheSetRemoveElement.Error(this._innerException);
   }
 }
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-set.ts
+++ b/packages/core/src/messages/responses/cache-set.ts
@@ -1,16 +1,16 @@
 import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSuccess} from './response-base';
-import {MomentoResponse} from './enums';
+import {CacheSetResponse} from './enums';
 
 interface IResponse {
-  type: MomentoResponse;
+  type: CacheSetResponse;
 }
 
 /**
  * Indicates a Successful cache set request.
  */
 export class Success extends BaseResponseSuccess implements IResponse {
-  readonly type: MomentoResponse.Success = MomentoResponse.Success;
+  readonly type: CacheSetResponse.Success = CacheSetResponse.Success;
 }
 
 /**
@@ -28,7 +28,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  readonly type: MomentoResponse.Error = MomentoResponse.Error;
+  readonly type: CacheSetResponse.Error = CacheSetResponse.Error;
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
@@ -15,3 +15,34 @@ export enum DictionaryFetchResponse {
   Miss = 'Miss',
   Error = 'Error',
 }
+
+export enum DictionaryIncrementResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum DictionaryLengthResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum DictionaryRemoveFieldResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum DictionaryRemoveFieldsResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum DictionarySetFieldResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum DictionarySetFieldsResponse {
+  Success = 'Success',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
@@ -1,0 +1,17 @@
+export enum DictionaryGetFieldsResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum DictionaryGetFieldResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum DictionaryFetchResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/dictionary/index.ts
@@ -1,48 +1,48 @@
-export enum DictionaryGetFieldsResponse {
+export enum CacheDictionaryGetFieldsResponse {
   Hit = 'Hit',
   Miss = 'Miss',
   Error = 'Error',
 }
 
-export enum DictionaryGetFieldResponse {
+export enum CacheDictionaryGetFieldResponse {
   Hit = 'Hit',
   Miss = 'Miss',
   Error = 'Error',
 }
 
-export enum DictionaryFetchResponse {
+export enum CacheDictionaryFetchResponse {
   Hit = 'Hit',
   Miss = 'Miss',
   Error = 'Error',
 }
 
-export enum DictionaryIncrementResponse {
+export enum CacheDictionaryIncrementResponse {
   Success = 'Success',
   Error = 'Error',
 }
 
-export enum DictionaryLengthResponse {
+export enum CacheDictionaryLengthResponse {
   Hit = 'Hit',
   Miss = 'Miss',
   Error = 'Error',
 }
 
-export enum DictionaryRemoveFieldResponse {
+export enum CacheDictionaryRemoveFieldResponse {
   Success = 'Success',
   Error = 'Error',
 }
 
-export enum DictionaryRemoveFieldsResponse {
+export enum CacheDictionaryRemoveFieldsResponse {
   Success = 'Success',
   Error = 'Error',
 }
 
-export enum DictionarySetFieldResponse {
+export enum CacheDictionarySetFieldResponse {
   Success = 'Success',
   Error = 'Error',
 }
 
-export enum DictionarySetFieldsResponse {
+export enum CacheDictionarySetFieldsResponse {
   Success = 'Success',
   Error = 'Error',
 }

--- a/packages/core/src/messages/responses/enums/cache/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/index.ts
@@ -1,2 +1,3 @@
 export * from './dictionary';
 export * from './scalar';
+export * from './set';

--- a/packages/core/src/messages/responses/enums/cache/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/index.ts
@@ -1,0 +1,2 @@
+export * from './dictionary';
+export * from './scalar';

--- a/packages/core/src/messages/responses/enums/cache/scalar/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/scalar/index.ts
@@ -1,0 +1,5 @@
+export enum CacheGetResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/cache/scalar/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/scalar/index.ts
@@ -3,3 +3,8 @@ export enum CacheGetResponse {
   Miss = 'Miss',
   Error = 'Error',
 }
+
+export enum CacheSetResponse {
+  Success = 'Success',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/cache/set/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/set/index.ts
@@ -1,0 +1,31 @@
+export enum CacheSetAddElementResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheSetAddElementsResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheSetFetchResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheSetRemoveElementResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheSetRemoveElementsResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheSetSampleResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/index.ts
+++ b/packages/core/src/messages/responses/enums/index.ts
@@ -1,6 +1,1 @@
-export enum MomentoResponse {
-  Success = 'Success',
-  Error = 'Error',
-}
-
 export * from './cache';

--- a/packages/core/src/messages/responses/enums/index.ts
+++ b/packages/core/src/messages/responses/enums/index.ts
@@ -3,26 +3,4 @@ export enum MomentoResponse {
   Error = 'Error',
 }
 
-export enum CacheGetResponse {
-  Hit = 'Hit',
-  Miss = 'Miss',
-  Error = 'Error',
-}
-
-export enum DictionaryGetFieldsResponse {
-  Hit = 'Hit',
-  Miss = 'Miss',
-  Error = 'Error',
-}
-
-export enum DictionaryGetFieldResponse {
-  Hit = 'Hit',
-  Miss = 'Miss',
-  Error = 'Error',
-}
-
-export enum DictionaryFetchResponse {
-  Hit = 'Hit',
-  Miss = 'Miss',
-  Error = 'Error',
-}
+export * from './cache';


### PR DESCRIPTION
closes https://github.com/momentohq/dev-eco-issue-tracker/issues/842
closes https://github.com/momentohq/dev-eco-issue-tracker/issues/843

this pr moves the response enums into specific folders according to the
- service they are for (ie `cache`)
- data structure (ie `dictionary`)

Also completes the migration for all dictionary apis to the new pattern