### PR TITLE
chore: run cache tests on macos-latest instead of ubuntu 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node: [18]
     name: Test Cache on Node ${{ matrix.node }}
-    runs-on: ubuntu-24.04
+    runs-on: macos-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}


### PR DESCRIPTION
Only the `Build` job gets cancelled after 4 minutes when using ubuntu 24, so trying to revert that one to macos-latest for now