### PR TITLE
chore: switch back to using Ubuntu 24 for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,7 @@ jobs:
       matrix:
         node: [18]
     name: Test Cache on Node ${{ matrix.node }}
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_SESSION_TOKEN: ${{ secrets.MOMENTO_PREPROD_SESSION_TOKEN }}


### PR DESCRIPTION
Follow up to https://github.com/momentohq/client-sdk-javascript/pull/1296

Looks like the [issue](https://github.com/actions/runner-images/issues/9959) was resolved yesterday!