### PR TITLE
chore: improve log message for unexpected connection state

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -340,7 +340,7 @@ export class CacheDataClient implements IDataClient {
           } else {
             const errorMessage = `Unable to connect to Momento: Unexpected connection state: ${this.connectionStateToString(
               newState
-            )}., oldState: ${currentState}
+            )}., oldState: ${this.connectionStateToString(currentState)}
               Please contact Momento if this persists.`;
             this.logger.error(errorMessage);
             reject(new ConnectionError(errorMessage));


### PR DESCRIPTION
Error messages regarding connection state now look like:
```
ERROR (Momento: CacheDataClient): Unable to connect to Momento: Unexpected connection state: SHUTDOWN., oldState: IDLE
              Please contact Momento if this persists.
```