### PR TITLE
chore: add more logs and safeguards around 5mb test

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -7,7 +7,7 @@ const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
 describe('CacheClient', () => {
   it('should send and receive 5mb messages', async () => {
-    const value = 'a'.repeat(1_000_000);
+    const value = 'a'.repeat(5_000_000);
     const key = `js-5mb-key-${v4()}`;
     const ttlSeconds = 2000; // 2000 seconds == 30 minutes
 

--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -1,27 +1,30 @@
 import {expectWithMessage} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from './integration-setup';
 import {CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {v4} from 'uuid';
 
 const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
 describe('CacheClient', () => {
   it('should send and receive 5mb messages', async () => {
     const value = 'a'.repeat(5_000_000);
-    const key = '5mb';
+    const key = `js-5mb-key-${v4()}`;
+    const ttlSeconds = 2000; // 2000 seconds == 30 minutes
 
     const setResponse = await cacheClient.set(
       integrationTestCacheName,
       key,
-      value
+      value,
+      {ttl: ttlSeconds}
     );
     expectWithMessage(() => {
       expect(setResponse).toBeInstanceOf(CacheSet.Success);
-    }, `expected to successfully set 5mb string for key ${key}, received ${setResponse.toString()}`);
+    }, `[${new Date().toLocaleTimeString()}] expected to successfully set 5mb string for key ${key} with ttl ${ttlSeconds} seconds, received ${setResponse.toString()}`);
 
-    const getResponse = await cacheClient.get(integrationTestCacheName, '5mb');
+    const getResponse = await cacheClient.get(integrationTestCacheName, key);
     expectWithMessage(() => {
       expect(getResponse).toBeInstanceOf(CacheGet.Hit);
-    }, `expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
+    }, `[${new Date().toLocaleTimeString()}] expected to successfully get 5mb string for key ${key}, received ${getResponse.toString()}`);
 
     const responseValue = (getResponse as CacheGet.Hit).value();
     expectWithMessage(() => {

--- a/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/large-messages.test.ts
@@ -1,13 +1,13 @@
 import {expectWithMessage} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from './integration-setup';
-import {CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {CacheGet, CacheItemGetTtl, CacheSet} from '@gomomento/sdk-core';
 import {v4} from 'uuid';
 
 const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
 describe('CacheClient', () => {
   it('should send and receive 5mb messages', async () => {
-    const value = 'a'.repeat(5_000_000);
+    const value = 'a'.repeat(1_000_000);
     const key = `js-5mb-key-${v4()}`;
     const ttlSeconds = 2000; // 2000 seconds == 30 minutes
 
@@ -20,6 +20,19 @@ describe('CacheClient', () => {
     expectWithMessage(() => {
       expect(setResponse).toBeInstanceOf(CacheSet.Success);
     }, `[${new Date().toLocaleTimeString()}] expected to successfully set 5mb string for key ${key} with ttl ${ttlSeconds} seconds, received ${setResponse.toString()}`);
+
+    const ttlResponse = await cacheClient.itemGetTtl(
+      integrationTestCacheName,
+      key
+    );
+    expectWithMessage(() => {
+      expect(ttlResponse).toBeInstanceOf(CacheItemGetTtl.Hit);
+    }, `expected to successfully get ttl for key ${key}, received ${ttlResponse.toString()}`);
+
+    const ttlValue = (ttlResponse as CacheItemGetTtl.Hit).remainingTtlMillis();
+    expectWithMessage(() => {
+      expect(ttlValue).toBePositive();
+    }, `expected ttl for key ${key} to be positive, received ${ttlValue}`);
 
     const getResponse = await cacheClient.get(integrationTestCacheName, key);
     expectWithMessage(() => {


### PR DESCRIPTION
This test has been failing regularly in one of the canaries and we're not sure why, it only says that it's been receiving `Miss` instead of `Hit`.

This PR adds a uuid to the key to make sure it's unique, increases the ttl to 2000 seconds in the unlikely case the 5mb item has been ttl-ing out of the cache, calls `itemGetTtl` after `set` to sanity check, and adds the ttl value and a timestamp to the `expect` messages to try to get more info from the logs when it fails in the canary. 