### PR TITLE
fix: standardize typescript version to 4.9.5

### DIFF
--- a/examples/nodejs/access-control/package-lock.json
+++ b/examples/nodejs/access-control/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3064,9 +3064,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5132,7 +5133,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/access-control/package.json
+++ b/examples/nodejs/access-control/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.86.0",

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/index.ts
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/index.ts
@@ -5,7 +5,7 @@ import {
   DefaultMomentoLoggerFactory,
   DefaultMomentoLoggerLevel,
   CredentialProvider,
-  ExperimentalMetricsLoggingMiddleware
+  ExperimentalMetricsLoggingMiddleware,
 } from '@gomomento/sdk';
 
 const _secretsClient = new SecretsManagerClient({});
@@ -22,7 +22,7 @@ async function main() {
 
     logger.info('Issuing 10 minutes of set and get requests to generate data for the dashboard example');
     const delayBetweenRequestsMillis = 1000;
-    for (let i = 0; i < (60 /* seconds */ * 10 /* minutes */); i++) {
+    for (let i = 0; i < 60 /* seconds */ * 10 /* minutes */; i++) {
       await cacheClient.set('cache', `metrics-example-${i}`, 'VALUE');
       await cacheClient.get('cache', `metrics-example-${i}`);
       await delay(delayBetweenRequestsMillis);

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/package-lock.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4659,9 +4659,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8337,9 +8337,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/package.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/docker/ecs-code/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.470.0",

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/handler.ts
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/handler.ts
@@ -5,7 +5,7 @@ import {
   DefaultMomentoLoggerFactory,
   DefaultMomentoLoggerLevel,
   CredentialProvider,
-  ExperimentalMetricsLoggingMiddleware
+  ExperimentalMetricsLoggingMiddleware,
 } from '@gomomento/sdk';
 
 const _secretsClient = new SecretsManagerClient({});
@@ -22,7 +22,7 @@ export const handler = async () => {
 
     logger.info('Issuing 10 minutes of set and get requests to generate data for the dashboard example');
     const delayBetweenRequestsMillis = 1000;
-    for (let i = 0; i < (60 /* seconds */ * 10 /* minutes */); i++) {
+    for (let i = 0; i < 60 /* seconds */ * 10 /* minutes */; i++) {
       await cacheClient.set('cache', `metrics-example-${i}`, 'VALUE');
       await cacheClient.get('cache', `metrics-example-${i}`);
       await delay(delayBetweenRequestsMillis);

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/package-lock.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4659,9 +4659,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8337,9 +8337,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/package.json
+++ b/examples/nodejs/aws/lambda-examples/cloudwatch-metrics/lambda/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.468.0",

--- a/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/package-lock.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4659,9 +4659,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8337,9 +8337,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/package.json
+++ b/examples/nodejs/aws/lambda-examples/simple-get/lambda/simple-get/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.470.0",

--- a/examples/nodejs/aws/secrets-manager/package-lock.json
+++ b/examples/nodejs/aws/secrets-manager/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -4250,9 +4250,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7316,7 +7317,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/aws/secrets-manager/package.json
+++ b/examples/nodejs/aws/secrets-manager/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.370.0",

--- a/examples/nodejs/compression-zstd/package-lock.json
+++ b/examples/nodejs/compression-zstd/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       },
       "engines": {
         "node": ">=10.4.0"
@@ -3807,9 +3807,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/nodejs/compression-zstd/package.json
+++ b/examples/nodejs/compression-zstd/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.86.0",

--- a/examples/nodejs/compression/package-lock.json
+++ b/examples/nodejs/compression/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       },
       "engines": {
         "node": ">=10.4.0"
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/nodejs/compression/package.json
+++ b/examples/nodejs/compression/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.86.0",

--- a/examples/nodejs/load-gen/package-lock.json
+++ b/examples/nodejs/load-gen/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5757,9 +5757,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/load-gen/package.json
+++ b/examples/nodejs/load-gen/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.86.0",

--- a/examples/nodejs/observability/package-lock.json
+++ b/examples/nodejs/observability/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3895,9 +3895,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6839,9 +6839,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/examples/nodejs/observability/package.json
+++ b/examples/nodejs/observability/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@gomomento/sdk": "^1.86.0",

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4670,9 +4670,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/authorizer/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.485.0",

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package-lock.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "prettier": "2.7.1",
-        "typescript": "4.4.3"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4670,9 +4670,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package.json
+++ b/examples/nodejs/token-vending-machine/lambda/token-vending-machine/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.7.1",
-    "typescript": "4.4.3"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "3.485.0",


### PR DESCRIPTION
should fix the issue we are seeing in ci

```
Error: node_modules/@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-get-fields.d.ts(3,15): error TS1005: ',' expected.
Error: Process completed with exit code 2.
```