### PR TITLE
feat: migrate item responses to new enum pattern

### DIFF
--- a/packages/common-integration-tests/src/keys-exist.ts
+++ b/packages/common-integration-tests/src/keys-exist.ts
@@ -103,7 +103,7 @@ export function runKeysExistTest(
         expect(response).toBeInstanceOf(CacheKeysExist.Success);
       }, `expected SUCCESS but got ${response.toString()}`);
 
-      const success = response as CacheKeyExists.Success;
+      const success = response as CacheKeysExist.Success;
       expect(success.exists()).toEqual([]);
     });
 

--- a/packages/core/src/messages/responses/cache-item-get-ttl.ts
+++ b/packages/core/src/messages/responses/cache-item-get-ttl.ts
@@ -7,6 +7,7 @@ import {
 import {CacheItemGetTtlResponse} from './enums';
 
 interface IResponse {
+  value(): number | undefined;
   readonly type: CacheItemGetTtlResponse;
 }
 
@@ -24,7 +25,15 @@ export class Hit extends ResponseBase implements IResponse {
 
   /**
    * Returns the remaining ttl in milliseconds for object stored at passed key.
-   * @returns string
+   * @returns number
+   */
+  public value(): number {
+    return this.ttlMillis;
+  }
+
+  /**
+   * Returns the remaining ttl in milliseconds for object stored at passed key.
+   * @returns number
    */
   public remainingTtlMillis(): number {
     return this.ttlMillis;
@@ -44,6 +53,10 @@ export class Miss extends BaseResponseMiss implements IResponse {
   constructor() {
     super();
   }
+
+  value(): undefined {
+    return undefined;
+  }
 }
 
 /**
@@ -61,6 +74,10 @@ export class Error extends BaseResponseError implements IResponse {
 
   constructor(_innerException: SdkError) {
     super(_innerException);
+  }
+
+  value(): undefined {
+    return undefined;
   }
 }
 

--- a/packages/core/src/messages/responses/cache-item-get-ttl.ts
+++ b/packages/core/src/messages/responses/cache-item-get-ttl.ts
@@ -7,7 +7,7 @@ import {
 import {CacheItemGetTtlResponse} from './enums';
 
 interface IResponse {
-  value(): number | undefined;
+  remainingTtlMillis(): number | undefined;
   readonly type: CacheItemGetTtlResponse;
 }
 
@@ -21,14 +21,6 @@ export class Hit extends ResponseBase implements IResponse {
   constructor(itemTTLMillisRemaining: number) {
     super();
     this.ttlMillis = itemTTLMillisRemaining;
-  }
-
-  /**
-   * Returns the remaining ttl in milliseconds for object stored at passed key.
-   * @returns number
-   */
-  public value(): number {
-    return this.ttlMillis;
   }
 
   /**
@@ -54,7 +46,7 @@ export class Miss extends BaseResponseMiss implements IResponse {
     super();
   }
 
-  value(): undefined {
+  remainingTtlMillis(): undefined {
     return undefined;
   }
 }
@@ -76,7 +68,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  value(): undefined {
+  remainingTtlMillis(): undefined {
     return undefined;
   }
 }

--- a/packages/core/src/messages/responses/cache-item-get-type.ts
+++ b/packages/core/src/messages/responses/cache-item-get-type.ts
@@ -8,7 +8,7 @@ import {CacheItemGetTypeResponse} from './enums';
 import {ItemType} from '../../utils';
 
 interface IResponse {
-  value(): ItemType | undefined;
+  itemType(): ItemType | undefined;
   readonly type: CacheItemGetTypeResponse;
 }
 
@@ -22,14 +22,6 @@ export class Hit extends ResponseBase implements IResponse {
   constructor(keyType: ItemType) {
     super();
     this.keyType = keyType;
-  }
-
-  /**
-   * Returns the type of key.
-   * @returns {ItemType}
-   */
-  public value(): ItemType {
-    return this.keyType;
   }
 
   /**
@@ -55,7 +47,7 @@ export class Miss extends BaseResponseMiss implements IResponse {
     super();
   }
 
-  value(): undefined {
+  itemType(): undefined {
     return undefined;
   }
 }
@@ -78,7 +70,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  value(): undefined {
+  itemType(): undefined {
     return undefined;
   }
 }

--- a/packages/core/src/messages/responses/cache-item-get-type.ts
+++ b/packages/core/src/messages/responses/cache-item-get-type.ts
@@ -1,36 +1,21 @@
 import {SdkError} from '../../errors';
 import {
+  BaseResponseError,
+  BaseResponseMiss,
   ResponseBase,
-  ResponseError,
-  ResponseHit,
-  ResponseMiss,
 } from './response-base';
+import {CacheItemGetTypeResponse} from './enums';
 import {ItemType} from '../../utils';
 
+interface IResponse {
+  readonly type: CacheItemGetTypeResponse;
+}
+
 /**
- * Parent response type for a item type request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Hit}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof ItemType.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `ItemType.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
+ * Indicates a successful item get type request.
  */
-
-export abstract class Response extends ResponseBase {}
-
-class _Hit extends Response {
+export class Hit extends ResponseBase implements IResponse {
+  readonly type: CacheItemGetTypeResponse.Hit = CacheItemGetTypeResponse.Hit;
   private readonly keyType: ItemType;
 
   constructor(keyType: ItemType) {
@@ -45,28 +30,25 @@ class _Hit extends Response {
   public itemType(): ItemType {
     return this.keyType;
   }
+
+  public override toString(): string {
+    return `${super.toString()}: item type: ${this.keyType}`;
+  }
 }
 
 /**
- * Indicates that the key exists.
+ * Indicates that the requested item was not available in the cache.
  */
-export class Hit extends ResponseHit(_Hit) {}
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: CacheItemGetTypeResponse.Miss = CacheItemGetTypeResponse.Miss;
 
-class _Miss extends Response {}
-
-/**
- * Indicates that the requested key was not available in the cache.
- */
-export class Miss extends ResponseMiss(_Miss) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
+  constructor() {
     super();
   }
 }
 
 /**
- * Indicates that an error occurred during the item type request.
+ * Indicates that an error occurred during the item get type request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -75,4 +57,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheItemGetTypeResponse.Error =
+    CacheItemGetTypeResponse.Error;
+
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+}
+
+export type Response = Hit | Miss | Error;

--- a/packages/core/src/messages/responses/cache-item-get-type.ts
+++ b/packages/core/src/messages/responses/cache-item-get-type.ts
@@ -8,6 +8,7 @@ import {CacheItemGetTypeResponse} from './enums';
 import {ItemType} from '../../utils';
 
 interface IResponse {
+  value(): ItemType | undefined;
   readonly type: CacheItemGetTypeResponse;
 }
 
@@ -25,7 +26,15 @@ export class Hit extends ResponseBase implements IResponse {
 
   /**
    * Returns the type of key.
-   * @returns string
+   * @returns {ItemType}
+   */
+  public value(): ItemType {
+    return this.keyType;
+  }
+
+  /**
+   * Returns the type of key.
+   * @returns {ItemType}
    */
   public itemType(): ItemType {
     return this.keyType;
@@ -45,6 +54,10 @@ export class Miss extends BaseResponseMiss implements IResponse {
   constructor() {
     super();
   }
+
+  value(): undefined {
+    return undefined;
+  }
 }
 
 /**
@@ -63,6 +76,10 @@ export class Error extends BaseResponseError implements IResponse {
 
   constructor(_innerException: SdkError) {
     super(_innerException);
+  }
+
+  value(): undefined {
+    return undefined;
   }
 }
 

--- a/packages/core/src/messages/responses/cache-key-exists.ts
+++ b/packages/core/src/messages/responses/cache-key-exists.ts
@@ -3,6 +3,7 @@ import {BaseResponseError, BaseResponseSuccess} from './response-base';
 import {CacheKeyExistsResponse} from './enums';
 
 interface IResponse {
+  value(): boolean | undefined;
   readonly type: CacheKeyExistsResponse;
 }
 
@@ -18,6 +19,14 @@ export class Success extends BaseResponseSuccess implements IResponse {
   constructor(exists: boolean[]) {
     super();
     this._exists = exists[0];
+  }
+
+  /**
+   * Returns the boolean indicating whether the given key was found in the cache.
+   * @returns {boolean}
+   */
+  public value(): boolean {
+    return this._exists;
   }
 
   /**
@@ -44,11 +53,15 @@ export class Success extends BaseResponseSuccess implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheKeyExistsResponse.Error = CacheKeyExistsResponse.Error;
+
   constructor(_innerException: SdkError) {
     super(_innerException);
   }
 
-  readonly type: CacheKeyExistsResponse.Error = CacheKeyExistsResponse.Error;
+  value(): undefined {
+    return undefined;
+  }
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-key-exists.ts
+++ b/packages/core/src/messages/responses/cache-key-exists.ts
@@ -1,28 +1,18 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {CacheKeyExistsResponse} from './enums';
+
+interface IResponse {
+  readonly type: CacheKeyExistsResponse;
+}
 
 /**
- * Parent response type for a cache key exists request. The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheKeyExists.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheKeyExists.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
+ * Indicates a successful key exists request.
  */
-export abstract class Response extends ResponseBase {}
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheKeyExistsResponse.Success =
+    CacheKeyExistsResponse.Success;
 
-class _Success extends Response {
   private readonly _exists: boolean;
 
   constructor(exists: boolean[]) {
@@ -31,7 +21,7 @@ class _Success extends Response {
   }
 
   /**
-   * The boolean indicating whether the given key was found in the cache.
+   * Returns the boolean indicating whether the given key was found in the cache.
    * @returns {boolean}
    */
   public exists(): boolean {
@@ -39,23 +29,12 @@ class _Success extends Response {
   }
 
   public override toString(): string {
-    return `${super.toString()}: exists: ${String(this.exists())}`;
+    return `${super.toString()}: exists: ${String(this._exists)}`;
   }
 }
 
 /**
- * Indicates a Successful cache key exists request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
- * Indicates that an error occurred during the cache key exists request.
+ * Indicates that an error occurred during the key exists request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -64,4 +43,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheKeyExistsResponse.Error = CacheKeyExistsResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-key-exists.ts
+++ b/packages/core/src/messages/responses/cache-key-exists.ts
@@ -3,7 +3,7 @@ import {BaseResponseError, BaseResponseSuccess} from './response-base';
 import {CacheKeyExistsResponse} from './enums';
 
 interface IResponse {
-  value(): boolean | undefined;
+  exists(): boolean | undefined;
   readonly type: CacheKeyExistsResponse;
 }
 
@@ -19,14 +19,6 @@ export class Success extends BaseResponseSuccess implements IResponse {
   constructor(exists: boolean[]) {
     super();
     this._exists = exists[0];
-  }
-
-  /**
-   * Returns the boolean indicating whether the given key was found in the cache.
-   * @returns {boolean}
-   */
-  public value(): boolean {
-    return this._exists;
   }
 
   /**
@@ -59,7 +51,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  value(): undefined {
+  exists(): undefined {
     return undefined;
   }
 }

--- a/packages/core/src/messages/responses/cache-keys-exist.ts
+++ b/packages/core/src/messages/responses/cache-keys-exist.ts
@@ -5,6 +5,7 @@ import {CacheKeysExistResponse} from './enums';
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
+  value(): boolean[] | undefined;
   readonly type: CacheKeysExistResponse;
 }
 
@@ -22,6 +23,14 @@ export class Success extends BaseResponseSuccess implements IResponse {
     super();
     this._keys = keys;
     this._exists = exists;
+  }
+
+  /**
+   * A list of booleans indicating whether each given key was found in the cache.
+   * @returns {boolean[]}
+   */
+  public value(): boolean[] {
+    return this._exists;
   }
 
   /**
@@ -60,11 +69,15 @@ export class Success extends BaseResponseSuccess implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheKeysExistResponse.Error = CacheKeysExistResponse.Error;
+
   constructor(_innerException: SdkError) {
     super(_innerException);
   }
 
-  readonly type: CacheKeysExistResponse.Error = CacheKeysExistResponse.Error;
+  value(): undefined {
+    return undefined;
+  }
 }
 
 export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-keys-exist.ts
+++ b/packages/core/src/messages/responses/cache-keys-exist.ts
@@ -1,30 +1,20 @@
 import {SdkError} from '../../errors';
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {CacheKeysExistResponse} from './enums';
 
 const TEXT_DECODER = new TextDecoder();
 
-/**
- * Parent response type for a cache keys exist request. The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Success}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheKeysExist.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheKeysExist.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
+interface IResponse {
+  readonly type: CacheKeysExistResponse;
+}
 
-class _Success extends Response {
+/**
+ * Indicates a successful keys exist request.
+ */
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: CacheKeysExistResponse.Success =
+    CacheKeysExistResponse.Success;
+
   private readonly _keys: Uint8Array[];
   private readonly _exists: boolean[];
 
@@ -60,18 +50,7 @@ class _Success extends Response {
 }
 
 /**
- * Indicates a Successful cache keys exist request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
- * Indicates that an error occurred during the cache keys exist request.
+ * Indicates that an error occurred during the keys exist request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -80,4 +59,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheKeysExistResponse.Error = CacheKeysExistResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/cache-keys-exist.ts
+++ b/packages/core/src/messages/responses/cache-keys-exist.ts
@@ -5,7 +5,7 @@ import {CacheKeysExistResponse} from './enums';
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
-  value(): boolean[] | undefined;
+  exists(): boolean[] | undefined;
   readonly type: CacheKeysExistResponse;
 }
 
@@ -29,20 +29,12 @@ export class Success extends BaseResponseSuccess implements IResponse {
    * A list of booleans indicating whether each given key was found in the cache.
    * @returns {boolean[]}
    */
-  public value(): boolean[] {
-    return this._exists;
-  }
-
-  /**
-   * A list of booleans indicating whether each given key was found in the cache.
-   * @returns {boolean[]}
-   */
   public exists(): boolean[] {
     return this._exists;
   }
 
   /**
-   * A record of key-value pairs indicating whether each given key was found in the cache.
+   * A record of key-exists pairs indicating whether each given key was found in the cache.
    * @returns {Record<string, boolean>}
    */
   public valueRecord(): Record<string, boolean> {
@@ -75,7 +67,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  value(): undefined {
+  exists(): undefined {
     return undefined;
   }
 }

--- a/packages/core/src/messages/responses/cache-set-if-absent-or-equal.ts
+++ b/packages/core/src/messages/responses/cache-set-if-absent-or-equal.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfAbsentOrEqualResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the new value was set because the key did not exist or the existing item was equal to the supplied `equal` value.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfAbsentOrEqualResponse.Stored =
     CacheSetIfAbsentOrEqualResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates that no value was set because the existing item was not equal to the supplied `equal` value.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfAbsentOrEqualResponse.NotStored =
     CacheSetIfAbsentOrEqualResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-absent.ts
+++ b/packages/core/src/messages/responses/cache-set-if-absent.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfAbsentResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the key did not exist and the value was set.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfAbsentResponse.Stored =
     CacheSetIfAbsentResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates the key already exists and no value was set.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfAbsentResponse.NotStored =
     CacheSetIfAbsentResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-equal.ts
+++ b/packages/core/src/messages/responses/cache-set-if-equal.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfEqualResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the new value was set because the key already exists and the existing item was equal to the supplied `equal` value.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfEqualResponse.Stored =
     CacheSetIfEqualResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates that no value was set because the key did not exist or because the existing item was not equal to the supplied `equal` value.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfEqualResponse.NotStored =
     CacheSetIfEqualResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-not-equal.ts
+++ b/packages/core/src/messages/responses/cache-set-if-not-equal.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfNotEqualResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the new value was set because the key did not exist or because the existing item was not equal to the supplied `notEqual` value.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfNotEqualResponse.Stored =
     CacheSetIfNotEqualResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates that no value was set because the existing item was equal to the supplied `notEqual` value.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfNotEqualResponse.NotStored =
     CacheSetIfNotEqualResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-not-exists.ts
+++ b/packages/core/src/messages/responses/cache-set-if-not-exists.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfNotExistsResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the key did not exist and the value was set.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfNotExistsResponse.Stored =
     CacheSetIfNotExistsResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates the key already exists and no value was set.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfNotExistsResponse.NotStored =
     CacheSetIfNotExistsResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-present-and-not-equal.ts
+++ b/packages/core/src/messages/responses/cache-set-if-present-and-not-equal.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfPresentAndNotEqualResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the new value was set because the key already exists and the existing item was not equal to the supplied `notEqual` value.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfPresentAndNotEqualResponse.Stored =
     CacheSetIfPresentAndNotEqualResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates that no value was set because the key did not exist or the existing item was equal to the supplied `notEqual` value.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfPresentAndNotEqualResponse.NotStored =
     CacheSetIfPresentAndNotEqualResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-set-if-present.ts
+++ b/packages/core/src/messages/responses/cache-set-if-present.ts
@@ -1,5 +1,5 @@
 import {SdkError} from '../../errors';
-import {BaseResponseError, BaseResponseSuccess} from './response-base';
+import {BaseResponseError, ResponseBase} from './response-base';
 import {CacheSetIfPresentResponse} from './enums';
 
 interface IResponse {
@@ -9,7 +9,7 @@ interface IResponse {
 /**
  * Indicates the key already exists and the value was set.
  */
-export class Stored extends BaseResponseSuccess implements IResponse {
+export class Stored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfPresentResponse.Stored =
     CacheSetIfPresentResponse.Stored;
 }
@@ -17,7 +17,7 @@ export class Stored extends BaseResponseSuccess implements IResponse {
 /**
  * Indicates the key did not exist and no value was set.
  */
-export class NotStored extends BaseResponseSuccess implements IResponse {
+export class NotStored extends ResponseBase implements IResponse {
   readonly type: CacheSetIfPresentResponse.NotStored =
     CacheSetIfPresentResponse.NotStored;
 }

--- a/packages/core/src/messages/responses/cache-ttl-decrease.ts
+++ b/packages/core/src/messages/responses/cache-ttl-decrease.ts
@@ -1,55 +1,39 @@
 import {SdkError} from '../../errors';
 import {
+  BaseResponseError,
+  BaseResponseMiss,
   ResponseBase,
-  ResponseError,
-  ResponseMiss,
-  ResponseSuccess,
 } from './response-base';
+import {CacheDecreaseTtlResponse} from './enums';
 
-/**
- * Parent response type for an decrease TTL request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Set}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheDecreaseTtl.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheDecreaseTtl.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Set extends Response {}
-
-/**
- * Indicates a successful decrease TTL request.
- */
-export class Set extends ResponseSuccess(_Set) {}
-
-class _Miss extends Response {}
-
-/**
- * Indicates a successful decrease TTL request.
- */
-export class Miss extends ResponseMiss(_Miss) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+interface IResponse {
+  readonly type: CacheDecreaseTtlResponse;
 }
 
 /**
- * Indicates that an error occurred during the decrease TTL request.
+ * Indicates the ttl was successfully decreased.
+ */
+export class Set extends ResponseBase implements IResponse {
+  readonly type: CacheDecreaseTtlResponse.Set = CacheDecreaseTtlResponse.Set;
+}
+
+/**
+ * Indicates the ttl was not updated due to a failed condition.
+ */
+export class NotSet extends ResponseBase implements IResponse {
+  readonly type: CacheDecreaseTtlResponse.NotSet =
+    CacheDecreaseTtlResponse.NotSet;
+}
+
+/**
+ * Indicates the requested item was not found in the cache.
+ */
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: CacheDecreaseTtlResponse.Miss = CacheDecreaseTtlResponse.Miss;
+}
+
+/**
+ * Indicates that an error occurred during the decrease ttl request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -58,4 +42,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheDecreaseTtlResponse.Error =
+    CacheDecreaseTtlResponse.Error;
+}
+
+export type Response = Set | NotSet | Miss | Error;

--- a/packages/core/src/messages/responses/cache-ttl-increase.ts
+++ b/packages/core/src/messages/responses/cache-ttl-increase.ts
@@ -1,55 +1,39 @@
 import {SdkError} from '../../errors';
 import {
+  BaseResponseError,
+  BaseResponseMiss,
   ResponseBase,
-  ResponseError,
-  ResponseMiss,
-  ResponseSuccess,
 } from './response-base';
+import {CacheIncreaseTtlResponse} from './enums';
 
-/**
- * Parent response type for an increase TTL request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Set}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheIncreaseTtl.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheIncreaseTtl.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Set extends Response {}
-
-/**
- * Indicates a successful increase TTL request.
- */
-export class Set extends ResponseSuccess(_Set) {}
-
-class _Miss extends Response {}
-
-/**
- * Indicates a successful increase TTL request.
- */
-export class Miss extends ResponseMiss(_Miss) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+interface IResponse {
+  readonly type: CacheIncreaseTtlResponse;
 }
 
 /**
- * Indicates that an error occurred during the increase TTL request.
+ * Indicates the ttl was successfully increased.
+ */
+export class Set extends ResponseBase implements IResponse {
+  readonly type: CacheIncreaseTtlResponse.Set = CacheIncreaseTtlResponse.Set;
+}
+
+/**
+ * Indicates the ttl was not updated due to a failed condition.
+ */
+export class NotSet extends ResponseBase implements IResponse {
+  readonly type: CacheIncreaseTtlResponse.NotSet =
+    CacheIncreaseTtlResponse.NotSet;
+}
+
+/**
+ * Indicates the requested item was not found in the cache.
+ */
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: CacheIncreaseTtlResponse.Miss = CacheIncreaseTtlResponse.Miss;
+}
+
+/**
+ * Indicates that an error occurred during the increase ttl request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -58,4 +42,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheIncreaseTtlResponse.Error =
+    CacheIncreaseTtlResponse.Error;
+}
+
+export type Response = Set | NotSet | Miss | Error;

--- a/packages/core/src/messages/responses/cache-ttl-update.ts
+++ b/packages/core/src/messages/responses/cache-ttl-update.ts
@@ -18,13 +18,6 @@ export class Set extends ResponseBase implements IResponse {
 }
 
 /**
- * Indicates the ttl was not updated due to a failed condition.
- */
-export class NotSet extends ResponseBase implements IResponse {
-  readonly type: CacheUpdateTtlResponse.NotSet = CacheUpdateTtlResponse.NotSet;
-}
-
-/**
  * Indicates the requested item was not found in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
@@ -49,4 +42,4 @@ export class Error extends BaseResponseError implements IResponse {
   readonly type: CacheUpdateTtlResponse.Error = CacheUpdateTtlResponse.Error;
 }
 
-export type Response = Set | NotSet | Miss | Error;
+export type Response = Set | Miss | Error;

--- a/packages/core/src/messages/responses/cache-ttl-update.ts
+++ b/packages/core/src/messages/responses/cache-ttl-update.ts
@@ -1,55 +1,38 @@
 import {SdkError} from '../../errors';
 import {
+  BaseResponseError,
+  BaseResponseMiss,
   ResponseBase,
-  ResponseError,
-  ResponseMiss,
-  ResponseSuccess,
 } from './response-base';
+import {CacheUpdateTtlResponse} from './enums';
 
-/**
- * Parent response type for an update TTL request.  The
- * response object is resolved to a type-safe object of one of
- * the following subtypes:
- *
- * - {Set}
- * - {Miss}
- * - {Error}
- *
- * `instanceof` type guards can be used to operate on the appropriate subtype.
- * @example
- * For example:
- * ```
- * if (response instanceof CacheUpdateTtl.Error) {
- *   // Handle error as appropriate.  The compiler will smart-cast `response` to type
- *   // `CacheUpdateTtl.Error` in this block, so you will have access to the properties
- *   // of the Error class; e.g. `response.errorCode()`.
- * }
- * ```
- */
-export abstract class Response extends ResponseBase {}
-
-class _Set extends Response {}
-
-/**
- * Indicates a successful update TTL request.
- */
-export class Set extends ResponseSuccess(_Set) {}
-
-class _Miss extends Response {}
-
-/**
- * Indicates a successful update TTL request.
- */
-export class Miss extends ResponseMiss(_Miss) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
+interface IResponse {
+  readonly type: CacheUpdateTtlResponse;
 }
 
 /**
- * Indicates that an error occurred during the update TTL request.
+ * Indicates the ttl was successfully overwritten.
+ */
+export class Set extends ResponseBase implements IResponse {
+  readonly type: CacheUpdateTtlResponse.Set = CacheUpdateTtlResponse.Set;
+}
+
+/**
+ * Indicates the ttl was not updated due to a failed condition.
+ */
+export class NotSet extends ResponseBase implements IResponse {
+  readonly type: CacheUpdateTtlResponse.NotSet = CacheUpdateTtlResponse.NotSet;
+}
+
+/**
+ * Indicates the requested item was not found in the cache.
+ */
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: CacheUpdateTtlResponse.Miss = CacheUpdateTtlResponse.Miss;
+}
+
+/**
+ * Indicates that an error occurred during the update ttl request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -58,4 +41,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  readonly type: CacheUpdateTtlResponse.Error = CacheUpdateTtlResponse.Error;
+}
+
+export type Response = Set | NotSet | Miss | Error;

--- a/packages/core/src/messages/responses/enums/cache/scalar/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/scalar/index.ts
@@ -70,3 +70,46 @@ export enum CacheSetIfNotExistsResponse {
   NotStored = 'NotStored',
   Error = 'Error',
 }
+
+export enum CacheKeyExistsResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheKeysExistResponse {
+  Success = 'Success',
+  Error = 'Error',
+}
+
+export enum CacheItemGetTypeResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheItemGetTtlResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheUpdateTtlResponse {
+  Set = 'Set',
+  NotSet = 'NotSet',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheIncreaseTtlResponse {
+  Set = 'Set',
+  NotSet = 'NotSet',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheDecreaseTtlResponse {
+  Set = 'Set',
+  NotSet = 'NotSet',
+  Miss = 'Miss',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/cache/scalar/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/scalar/index.ts
@@ -93,9 +93,11 @@ export enum CacheItemGetTtlResponse {
   Error = 'Error',
 }
 
+// Note: update ttl has no NotSet response type
+// as it sets the ttl unconditionally. We can still
+// add this NotSet case later if actually needed.
 export enum CacheUpdateTtlResponse {
   Set = 'Set',
-  NotSet = 'NotSet',
   Miss = 'Miss',
   Error = 'Error',
 }


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/867

Also includes a bug fix in a KeysExist test (was expecting the wrong response type).
Also updates the setIf Stored/NotStored responses so they extend ResponseBase instead of BaseResponseSuccess for consistency with the update ttl responses which use Set/NotSet/Miss.