### PR TITLE
fix: correct convertToB64String function to correctly handle internat…

### DIFF
--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -45,6 +45,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -76,6 +77,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -11,6 +11,23 @@ export function convertToB64String(v: string | Uint8Array): string {
   }
 }
 
+export function convertToBytesFromB64String(b64: string): Uint8Array {
+  const binaryString = atob(b64);
+  const binaryLength = binaryString.length;
+  const bytes = new Uint8Array(binaryLength);
+
+  for (let i = 0; i < binaryLength; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+export function convertToStringFromB64String(b64: string): string {
+  const bytes = convertToBytesFromB64String(b64);
+  return new TextDecoder().decode(bytes);
+}
+
 export function createCallMetadata(
   cacheName: string,
   timeoutMillis: number

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -2,11 +2,26 @@ import {CredentialProvider} from '@gomomento/sdk-core';
 
 export function convertToB64String(v: string | Uint8Array): string {
   if (typeof v === 'string') {
-    return btoa(v);
+    const encodedString = encodeURIComponent(v);
+    let decodedString = '';
+    for (let i = 0; i < encodedString.length; i++) {
+      if (encodedString[i] === '%') {
+        const hex = encodedString.substr(i + 1, 2);
+        decodedString += String.fromCharCode(parseInt(hex, 16));
+        i += 2;
+      } else {
+        decodedString += encodedString[i];
+      }
+    }
+    return btoa(decodedString);
+  } else {
+    const chars = new Uint8Array(v);
+    let binary = '';
+    for (let i = 0; i < chars.length; i++) {
+      binary += String.fromCharCode(chars[i]);
+    }
+    return btoa(binary);
   }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  return btoa(String.fromCharCode.apply(null, v));
 }
 
 export function createCallMetadata(

--- a/packages/client-sdk-web/src/utils/web-client-utils.ts
+++ b/packages/client-sdk-web/src/utils/web-client-utils.ts
@@ -2,25 +2,12 @@ import {CredentialProvider} from '@gomomento/sdk-core';
 
 export function convertToB64String(v: string | Uint8Array): string {
   if (typeof v === 'string') {
-    const encodedString = encodeURIComponent(v);
-    let decodedString = '';
-    for (let i = 0; i < encodedString.length; i++) {
-      if (encodedString[i] === '%') {
-        const hex = encodedString.substr(i + 1, 2);
-        decodedString += String.fromCharCode(parseInt(hex, 16));
-        i += 2;
-      } else {
-        decodedString += encodedString[i];
-      }
-    }
-    return btoa(decodedString);
+    const utf8Bytes = new TextEncoder().encode(v);
+    const binaryString = String.fromCharCode(...utf8Bytes);
+    return btoa(binaryString);
   } else {
-    const chars = new Uint8Array(v);
-    let binary = '';
-    for (let i = 0; i < chars.length; i++) {
-      binary += String.fromCharCode(chars[i]);
-    }
-    return btoa(binary);
+    const binaryString = String.fromCharCode(...v);
+    return btoa(binaryString);
   }
 }
 

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {CredentialProvider} from '@gomomento/sdk-core';
 import {
+  convertToB64String,
   getWebCacheEndpoint,
   getWebControlEndpoint,
   getWebTokenEndpoint,
@@ -134,6 +135,34 @@ describe('getWeb*Endpoint', () => {
       expect(webCacheEndpoint).toEqual('https://some-cache-endpoint:9001');
       const webTokenEndpoint = getWebTokenEndpoint(credProvider);
       expect(webTokenEndpoint).toEqual('http://some-token-endpoint:9001');
+    });
+  });
+
+  describe('convertB64ToString', () => {
+    it('should convert a simple string to base64', () => {
+      const input = 'hello';
+      const expected = 'aGVsbG8=';
+      expect(convertToB64String(input)).toEqual(expected);
+    });
+    it('should convert a string with special characters to base64', () => {
+      const input = 'héllö wörld';
+      const expectedOutput = 'aMOpbGzDtiB3w7ZybGQ=';
+      expect(convertToB64String(input)).toBe(expectedOutput);
+    });
+    it('should convert a string with emojis to base64', () => {
+      const input = 'hello 🌍';
+      const expectedOutput = 'aGVsbG8g8J+MjQ==';
+      expect(convertToB64String(input)).toBe(expectedOutput);
+    });
+    it('should convert a Uint8Array to base64', () => {
+      const input = new Uint8Array([104, 101, 108, 108, 111]);
+      const expectedOutput = 'aGVsbG8=';
+      expect(convertToB64String(input)).toBe(expectedOutput);
+    });
+    it('should convert a Uint8Array with special characters to base64', () => {
+      const input = new Uint8Array([104, 195, 169, 108, 108, 195, 182]);
+      const expectedOutput = 'aMOpbGzDtg==';
+      expect(convertToB64String(input)).toBe(expectedOutput);
     });
   });
 });

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -5,6 +5,8 @@ import {
 import {CredentialProvider} from '@gomomento/sdk-core';
 import {
   convertToB64String,
+  convertToBytesFromB64String,
+  convertToStringFromB64String,
   getWebCacheEndpoint,
   getWebControlEndpoint,
   getWebTokenEndpoint,
@@ -138,31 +140,46 @@ describe('getWeb*Endpoint', () => {
     });
   });
 
-  describe('convertB64ToString', () => {
-    it('should convert a simple string to base64', () => {
+  describe('convertToB64String', () => {
+    it('should convert a simple string to base64 and back to string', () => {
       const input = 'hello';
       const expected = 'aGVsbG8=';
-      expect(convertToB64String(input)).toEqual(expected);
+      const output = convertToB64String(input);
+      expect(output).toEqual(expected);
+      const simpleString = convertToStringFromB64String(output);
+      expect(simpleString).toEqual(input);
     });
-    it('should convert a string with special characters to base64', () => {
+    it('should convert a string with special characters to base64 and back to string with special characters', () => {
       const input = 'héllö wörld';
       const expectedOutput = 'aMOpbGzDtiB3w7ZybGQ=';
-      expect(convertToB64String(input)).toBe(expectedOutput);
+      const output = convertToB64String(input);
+      expect(output).toBe(expectedOutput);
+      const specialString = convertToStringFromB64String(output);
+      expect(specialString).toEqual(input);
     });
     it('should convert a string with emojis to base64', () => {
       const input = 'hello 🌍';
       const expectedOutput = 'aGVsbG8g8J+MjQ==';
-      expect(convertToB64String(input)).toBe(expectedOutput);
+      const output = convertToB64String(input);
+      expect(output).toBe(expectedOutput);
+      const emojiString = convertToStringFromB64String(output);
+      expect(emojiString).toEqual(input);
     });
     it('should convert a Uint8Array to base64', () => {
       const input = new Uint8Array([104, 101, 108, 108, 111]);
       const expectedOutput = 'aGVsbG8=';
-      expect(convertToB64String(input)).toBe(expectedOutput);
+      const output = convertToB64String(input);
+      expect(output).toBe(expectedOutput);
+      const simpleUint8Array = convertToBytesFromB64String(output);
+      expect(simpleUint8Array).toEqual(input);
     });
     it('should convert a Uint8Array with special characters to base64', () => {
       const input = new Uint8Array([104, 195, 169, 108, 108, 195, 182]);
       const expectedOutput = 'aMOpbGzDtg==';
-      expect(convertToB64String(input)).toBe(expectedOutput);
+      const output = convertToB64String(input);
+      expect(output).toBe(expectedOutput);
+      const specialUint8Array = convertToBytesFromB64String(output);
+      expect(specialUint8Array).toEqual(input);
     });
   });
 });

--- a/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
+++ b/packages/client-sdk-web/test/unit/utils/web-client-utils.test.ts
@@ -157,7 +157,7 @@ describe('getWeb*Endpoint', () => {
       const specialString = convertToStringFromB64String(output);
       expect(specialString).toEqual(input);
     });
-    it('should convert a string with emojis to base64', () => {
+    it('should convert a string with emojis to base64 and back to string with emojis', () => {
       const input = 'hello 🌍';
       const expectedOutput = 'aGVsbG8g8J+MjQ==';
       const output = convertToB64String(input);
@@ -165,7 +165,7 @@ describe('getWeb*Endpoint', () => {
       const emojiString = convertToStringFromB64String(output);
       expect(emojiString).toEqual(input);
     });
-    it('should convert a Uint8Array to base64', () => {
+    it('should convert a Uint8Array to base64 and back to UintArray', () => {
       const input = new Uint8Array([104, 101, 108, 108, 111]);
       const expectedOutput = 'aGVsbG8=';
       const output = convertToB64String(input);
@@ -173,7 +173,7 @@ describe('getWeb*Endpoint', () => {
       const simpleUint8Array = convertToBytesFromB64String(output);
       expect(simpleUint8Array).toEqual(input);
     });
-    it('should convert a Uint8Array with special characters to base64', () => {
+    it('should convert a Uint8Array with special characters to base64 and back to UintArray with special characters', () => {
       const input = new Uint8Array([104, 195, 169, 108, 108, 195, 182]);
       const expectedOutput = 'aMOpbGzDtg==';
       const output = convertToB64String(input);

--- a/packages/common-integration-tests/src/get-set-delete.ts
+++ b/packages/common-integration-tests/src/get-set-delete.ts
@@ -67,9 +67,53 @@ export function runGetSetDeleteTests(
       }
     });
 
+    it('should set and get string with special characters from cache', async () => {
+      const cacheKey = v4();
+      const cacheValue = v4() + 'héllö wörld';
+
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
+        cacheKey,
+        cacheValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
+      if (getResponse instanceof CacheGet.Hit) {
+        expect(getResponse.valueString()).toEqual(cacheValue);
+      }
+    });
+
     it('should set and get bytes from cache', async () => {
       const cacheKey = new TextEncoder().encode(v4());
       const cacheValue = new TextEncoder().encode(v4());
+      const setResponse = await cacheClient.set(
+        integrationTestCacheName,
+        cacheKey,
+        cacheValue
+      );
+      expectWithMessage(() => {
+        expect(setResponse).toBeInstanceOf(CacheSet.Success);
+      }, `expected SUCCESS but got ${setResponse.toString()}`);
+      const getResponse = await cacheClient.get(
+        integrationTestCacheName,
+        cacheKey
+      );
+      expectWithMessage(() => {
+        expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+      }, `expected HIT but got ${getResponse.toString()}`);
+    });
+
+    it('should set and get bytes with special characters from cache', async () => {
+      const cacheKey = new TextEncoder().encode(v4());
+      const cacheValue = new TextEncoder().encode(v4() + 'héllö wörld');
       const setResponse = await cacheClient.set(
         integrationTestCacheName,
         cacheKey,


### PR DESCRIPTION
…ional characters

## Relevant Ticket:
https://github.com/momentohq/dev-eco-issue-tracker/issues/829


## Explanation:
**For Strings:**
- TextEncoder().encode(v) converts the string to a Uint8Array of UTF-8 bytes.
- String.fromCharCode(...utf8Bytes) converts the Uint8Array to a binary string.
- btoa(binaryString) converts the binary string to a base64-encoded string.

**For Uint8Array:**
- String.fromCharCode(...v) converts the Uint8Array directly to a binary string.
- btoa(binaryString) converts the binary string to a base64-encoded string.

## Testing:
Tested using the basic example in web directory. result:
```
npm run example                                                                                 

> momento-nodejs-example@1.0.0 example
> tsc && node dist/basic.js

cache already exists
Storing key=foo, value=çCMduo
Key stored successfully!
cache hit: çCMduo
success!!
```