### PR TITLE
fix: semver grpc-js dependency

### DIFF
--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@gomomento/generated-types": "0.108.2",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.10.5",
+    "@grpc/grpc-js": "^1.10.5",
     "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"


### PR DESCRIPTION
adding the `^` to node grpc-js depedency to allow npm resolve duplicate grpc-js depedencies between packages that use different versions of grpc-js. If we don't do this, and there is another package that a user installs which has a different version of grpc-js, they will get a runtime error looking like `ChannelCredentials is not an object`