### PR TITLE
feat: migrate auth responses to new pattern

### DIFF
--- a/packages/core/src/messages/responses/enums/auth/generate-api-key.ts
+++ b/packages/core/src/messages/responses/enums/auth/generate-api-key.ts
@@ -1,0 +1,4 @@
+export enum GenerateApiKeyResponse {
+  Success = 'Success',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/auth/generate-disposable-token.ts
+++ b/packages/core/src/messages/responses/enums/auth/generate-disposable-token.ts
@@ -1,0 +1,4 @@
+export enum GenerateDisposableTokenResponse {
+  Success = 'Success',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/auth/index.ts
+++ b/packages/core/src/messages/responses/enums/auth/index.ts
@@ -1,0 +1,3 @@
+export {GenerateApiKeyResponse} from './generate-api-key';
+export {GenerateDisposableTokenResponse} from './generate-disposable-token';
+export {RefreshApiKeyResponse} from './refresh-api-key';

--- a/packages/core/src/messages/responses/enums/auth/refresh-api-key.ts
+++ b/packages/core/src/messages/responses/enums/auth/refresh-api-key.ts
@@ -1,0 +1,4 @@
+export enum RefreshApiKeyResponse {
+  Success = 'Success',
+  Error = 'Error',
+}

--- a/packages/core/src/messages/responses/enums/index.ts
+++ b/packages/core/src/messages/responses/enums/index.ts
@@ -1,1 +1,2 @@
+export * from './auth';
 export * from './cache';

--- a/packages/core/src/messages/responses/generate-api-key.ts
+++ b/packages/core/src/messages/responses/generate-api-key.ts
@@ -1,11 +1,17 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseSuccess, BaseResponseError} from './response-base';
+import {GenerateApiKeyResponse} from './enums';
 import {SdkError} from '../../errors';
 import {encodeToBase64} from '../../internal/utils';
 import {ExpiresAt} from '../../utils';
 
-export abstract class Response extends ResponseBase {}
+interface IResponse {
+  readonly type: GenerateApiKeyResponse;
+}
 
-class _Success extends Response {
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: GenerateApiKeyResponse.Success =
+    GenerateApiKeyResponse.Success;
+
   readonly apiKey: string;
   readonly refreshToken: string;
   readonly endpoint: string;
@@ -35,17 +41,6 @@ class _Success extends Response {
 }
 
 /**
- * Indicates a Successful generate api token request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
  * Indicates that an error occurred during the generate api token request.
  *
  * This response object includes the following fields that you can use to determine
@@ -55,4 +50,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(innerException: SdkError) {
+    super(innerException);
+  }
+
+  readonly type: GenerateApiKeyResponse.Error = GenerateApiKeyResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/generate-disposable-token.ts
+++ b/packages/core/src/messages/responses/generate-disposable-token.ts
@@ -1,11 +1,17 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseSuccess, BaseResponseError} from './response-base';
+import {GenerateDisposableTokenResponse} from './enums';
 import {SdkError} from '../../errors';
 import {encodeToBase64} from '../../internal/utils';
 import {ExpiresAt} from '../../utils';
 
-export abstract class Response extends ResponseBase {}
+interface IResponse {
+  readonly type: GenerateDisposableTokenResponse;
+}
 
-class _Success extends Response {
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: GenerateDisposableTokenResponse.Success =
+    GenerateDisposableTokenResponse.Success;
+
   readonly authToken: string;
   readonly endpoint: string;
   readonly expiresAt: ExpiresAt;
@@ -21,17 +27,6 @@ class _Success extends Response {
 }
 
 /**
- * Indicates a Successful generate disposable token request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
  * Indicates that an error occurred during the generate disposable token request.
  *
  * This response object includes the following fields that you can use to determine
@@ -41,4 +36,13 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(innerException: SdkError) {
+    super(innerException);
+  }
+
+  readonly type: GenerateDisposableTokenResponse.Error =
+    GenerateDisposableTokenResponse.Error;
+}
+
+export type Response = Success | Error;

--- a/packages/core/src/messages/responses/refresh-api-key.ts
+++ b/packages/core/src/messages/responses/refresh-api-key.ts
@@ -1,11 +1,16 @@
-import {ResponseBase, ResponseError, ResponseSuccess} from './response-base';
+import {BaseResponseSuccess, BaseResponseError} from './response-base';
+import {RefreshApiKeyResponse} from './enums';
 import {SdkError} from '../../errors';
 import {encodeToBase64} from '../../internal/utils';
 import {ExpiresAt} from '../../utils';
 
-export abstract class Response extends ResponseBase {}
+interface IResponse {
+  readonly type: RefreshApiKeyResponse;
+}
 
-class _Success extends Response {
+export class Success extends BaseResponseSuccess implements IResponse {
+  readonly type: RefreshApiKeyResponse.Success = RefreshApiKeyResponse.Success;
+
   readonly apiKey: string;
   readonly refreshToken: string;
   readonly endpoint: string;
@@ -36,17 +41,6 @@ class _Success extends Response {
 }
 
 /**
- * Indicates a Successful generate api token request.
- */
-export class Success extends ResponseSuccess(_Success) {}
-
-class _Error extends Response {
-  constructor(protected _innerException: SdkError) {
-    super();
-  }
-}
-
-/**
  * Indicates that an error occurred during the generate api token request.
  *
  * This response object includes the following fields that you can use to determine
@@ -56,4 +50,12 @@ class _Error extends Response {
  * - `message()` - a human-readable description of the error
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
-export class Error extends ResponseError(_Error) {}
+export class Error extends BaseResponseError implements IResponse {
+  constructor(innerException: SdkError) {
+    super(innerException);
+  }
+
+  readonly type: RefreshApiKeyResponse.Error = RefreshApiKeyResponse.Error;
+}
+
+export type Response = Success | Error;


### PR DESCRIPTION
Migrates the auth responses to the new response pattern. Introduces
enums for `GenerateApiKeyResponse`, `RefreshApiKeyResponse`, and
`GenerateDisposableTokenResponse`.