### PR TITLE
feat: add set contains element and set contains elements

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -30,6 +30,7 @@ import * as DeleteCache from '@gomomento/sdk-core/dist/src/messages/responses/de
 import * as ListCaches from '@gomomento/sdk-core/dist/src/messages/responses/list-caches';
 import * as CacheSetFetch from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-fetch';
 import * as CacheSetContainsElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-element';
+import * as CacheSetContainsElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-elements';
 import * as CacheDictionaryFetch from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-fetch';
 import * as CacheDictionarySetField from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-set-field';
 import * as CacheDictionarySetFields from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-set-fields';
@@ -337,6 +338,7 @@ export {
   ListCaches,
   CacheIncrement,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetFetch,
   CacheDictionaryFetch,
   CacheDictionarySetField,

--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -29,6 +29,7 @@ import * as CreateCache from '@gomomento/sdk-core/dist/src/messages/responses/cr
 import * as DeleteCache from '@gomomento/sdk-core/dist/src/messages/responses/delete-cache';
 import * as ListCaches from '@gomomento/sdk-core/dist/src/messages/responses/list-caches';
 import * as CacheSetFetch from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-fetch';
+import * as CacheSetContainsElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-element';
 import * as CacheDictionaryFetch from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-fetch';
 import * as CacheDictionarySetField from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-set-field';
 import * as CacheDictionarySetFields from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-set-fields';
@@ -335,6 +336,7 @@ export {
   DeleteCache,
   ListCaches,
   CacheIncrement,
+  CacheSetContainsElement,
   CacheSetFetch,
   CacheDictionaryFetch,
   CacheDictionarySetField,

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -614,7 +614,7 @@ export class CacheDataClient implements IDataClient {
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err => new CacheSetContainsElement.Error(err, this.convert(element))
+        err => new CacheSetContainsElement.Error(err)
       );
     }
 
@@ -650,25 +650,21 @@ export class CacheDataClient implements IDataClient {
             if (found_mask === undefined || found_mask.length === 0) {
               return reject(
                 new CacheSetContainsElement.Error(
-                  new UnknownError(
-                    'SetContains response missing contains mask'
-                  ),
-                  element
+                  new UnknownError('SetContains response missing contains mask')
                 )
               );
             }
             if (found_mask[0]) {
-              resolve(new CacheSetContainsElement.Hit(element));
+              resolve(new CacheSetContainsElement.Hit());
             } else {
-              resolve(new CacheSetContainsElement.Miss(element));
+              resolve(new CacheSetContainsElement.Miss());
             }
           } else if (resp?.missing) {
-            resolve(new CacheSetContainsElement.Miss(element));
+            resolve(new CacheSetContainsElement.Miss());
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
-              errorResponseFactoryFn: e =>
-                new CacheSetContainsElement.Error(e, element),
+              errorResponseFactoryFn: e => new CacheSetContainsElement.Error(e),
               resolveFn: resolve,
               rejectFn: reject,
             });

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -655,11 +655,7 @@ export class CacheDataClient implements IDataClient {
                 )
               );
             }
-            if (found_mask[0]) {
-              resolve(new CacheSetContainsElement.Hit());
-            } else {
-              resolve(new CacheSetContainsElement.Miss());
-            }
+            resolve(new CacheSetContainsElement.Hit(found_mask[0]));
           } else if (resp?.missing) {
             resolve(new CacheSetContainsElement.Miss());
           } else {

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -38,6 +38,7 @@ import * as CacheDictionaryIncrement from '@gomomento/sdk-core/dist/src/messages
 import * as CacheDictionaryLength from '@gomomento/sdk-core/dist/src/messages/responses/cache-dictionary-length';
 import * as CacheSetAddElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-add-elements';
 import * as CacheSetAddElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-add-element';
+import * as CacheSetContainsElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-element';
 import * as CacheSetRemoveElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-remove-elements';
 import * as CacheSetRemoveElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-remove-element';
 import * as CacheSetSample from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-sample';
@@ -240,6 +241,7 @@ export {
   ListCaches,
   CacheIncrement,
   CacheSetFetch,
+  CacheSetContainsElement,
   CacheDictionaryFetch,
   CacheDictionarySetField,
   CacheDictionarySetFields,

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -39,6 +39,7 @@ import * as CacheDictionaryLength from '@gomomento/sdk-core/dist/src/messages/re
 import * as CacheSetAddElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-add-elements';
 import * as CacheSetAddElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-add-element';
 import * as CacheSetContainsElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-element';
+import * as CacheSetContainsElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-contains-elements';
 import * as CacheSetRemoveElements from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-remove-elements';
 import * as CacheSetRemoveElement from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-remove-element';
 import * as CacheSetSample from '@gomomento/sdk-core/dist/src/messages/responses/cache-set-sample';
@@ -242,6 +243,7 @@ export {
   CacheIncrement,
   CacheSetFetch,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheDictionaryFetch,
   CacheDictionarySetField,
   CacheDictionarySetFields,

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1413,11 +1413,11 @@ export class CacheDataClient<
                   )
                 );
               }
-              if (found?.getContainsList().at(0)) {
-                resolve(new CacheSetContainsElement.Hit());
-              } else {
-                resolve(new CacheSetContainsElement.Miss());
-              }
+              resolve(
+                new CacheSetContainsElement.Hit(
+                  found?.getContainsList().at(0) ?? false
+                )
+              );
             }
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1418,6 +1418,8 @@ export class CacheDataClient<
                   found?.getContainsList().at(0) ?? false
                 )
               );
+            } else {
+              resolve(new CacheSetContainsElement.Miss());
             }
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({
@@ -1495,6 +1497,8 @@ export class CacheDataClient<
               } else {
                 resolve(new CacheSetContainsElements.Miss());
               }
+            } else {
+              resolve(new CacheSetContainsElements.Miss());
             }
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1487,16 +1487,12 @@ export class CacheDataClient<
                   )
                 );
               }
-              if (found?.getContainsList().at(0)) {
-                resolve(
-                  new CacheSetContainsElements.Hit(
-                    elementsAsUint8,
-                    found.getContainsList()
-                  )
-                );
-              } else {
-                resolve(new CacheSetContainsElements.Miss());
-              }
+              resolve(
+                new CacheSetContainsElements.Hit(
+                  elementsAsUint8,
+                  found?.getContainsList() ?? []
+                )
+              );
             } else {
               resolve(new CacheSetContainsElements.Miss());
             }

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1372,11 +1372,7 @@ export class CacheDataClient<
     } catch (err) {
       return this.cacheServiceErrorMapper.returnOrThrowError(
         err as Error,
-        err =>
-          new CacheSetContainsElement.Error(
-            err,
-            this.convertToUint8Array(element)
-          )
+        err => new CacheSetContainsElement.Error(err)
       );
     }
     return await this.sendSetContainsElement(
@@ -1396,7 +1392,6 @@ export class CacheDataClient<
     request.setElementsList([element]);
 
     return await new Promise((resolve, reject) => {
-      const elementAsUint8Array = this.convertToUint8Array(element);
       this.clientWrapper.setContains(
         request,
         {
@@ -1413,24 +1408,20 @@ export class CacheDataClient<
               ) {
                 resolve(
                   new CacheSetContainsElement.Error(
-                    new UnknownError(
-                      'SetContains responded with an empty list'
-                    ),
-                    elementAsUint8Array
+                    new UnknownError('SetContains responded with an empty list')
                   )
                 );
               }
               if (found?.getContainsList().at(0)) {
-                resolve(new CacheSetContainsElement.Hit(elementAsUint8Array));
+                resolve(new CacheSetContainsElement.Hit());
               } else {
-                resolve(new CacheSetContainsElement.Miss(elementAsUint8Array));
+                resolve(new CacheSetContainsElement.Miss());
               }
             }
           } else {
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,
-              errorResponseFactoryFn: e =>
-                new CacheSetContainsElement.Error(e, elementAsUint8Array),
+              errorResponseFactoryFn: e => new CacheSetContainsElement.Error(e),
               resolveFn: resolve,
               rejectFn: reject,
             });

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -1449,14 +1449,16 @@ export class CacheDataClient<
     return await this.sendSetContainsElements(
       cacheName,
       convertToB64String(setName),
-      this.convertArrayToB64Strings(elements)
+      this.convertArrayToB64Strings(elements),
+      this.convertArrayToUint8(elements)
     );
   }
 
   private async sendSetContainsElements(
     cacheName: string,
     setName: string,
-    elements: string[]
+    elements: string[],
+    elementsAsUint8: Uint8Array[]
   ): Promise<CacheSetContainsElements.Response> {
     const request = new _SetContainsRequest();
     request.setSetName(setName);
@@ -1486,7 +1488,7 @@ export class CacheDataClient<
               if (found?.getContainsList().at(0)) {
                 resolve(
                   new CacheSetContainsElements.Hit(
-                    elements.map(element => this.convertToUint8Array(element)),
+                    elementsAsUint8,
                     found.getContainsList()
                   )
                 );

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -3,13 +3,14 @@ import {
   CacheDelete,
   CacheSetAddElements,
   CacheSetAddElement,
+  CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetFetch,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheSetSample,
   CollectionTtl,
   MomentoErrorCode,
-  CacheSetContainsElement,
 } from '@gomomento/sdk-core';
 import {
   ValidateCacheProps,
@@ -182,6 +183,60 @@ export function runSetTests(
         'foo'
       );
       expect(response).toBeInstanceOf(CacheSetContainsElement.Hit);
+    });
+  });
+
+  describe('#containsElements', () => {
+    it('should be a miss when the set does not exist', async () => {
+      const setName = v4();
+      const response = await cacheClient.setContainsElements(
+        integrationTestCacheName,
+        setName,
+        ['foo', 'bar', 'baz']
+      );
+      expect(response).toBeInstanceOf(CacheSetContainsElements.Miss);
+    });
+
+    it('should be a hit when the set does not contain any of the elements', async () => {
+      const setName = v4();
+      const addResponse = await cacheClient.setAddElement(
+        integrationTestCacheName,
+        setName,
+        'foo'
+      );
+      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+
+      const response = await cacheClient.setContainsElements(
+        integrationTestCacheName,
+        setName,
+        ['bar', 'baz']
+      );
+      expect(response).toBeInstanceOf(CacheSetContainsElements.Hit);
+      expect((response as CacheSetContainsElements.Hit).contains()).toEqual({
+        bar: false,
+        baz: false,
+      });
+    });
+
+    it('should be a hit when the set contains some of the elements', async () => {
+      const setName = v4();
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
+        setName,
+        ['foo', 'bar']
+      );
+      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
+
+      const response = await cacheClient.setContainsElements(
+        integrationTestCacheName,
+        setName,
+        ['foo', 'baz']
+      );
+      expect(response).toBeInstanceOf(CacheSetContainsElements.Hit);
+      expect((response as CacheSetContainsElements.Hit).contains()).toEqual({
+        foo: true,
+        baz: false,
+      });
     });
   });
 

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -149,6 +149,40 @@ export function runSetTests(
       );
       expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
     });
+
+    it("should be a miss on a set that exists but doesn't contain the element", async () => {
+      const setName = v4();
+      const addResponse = await cacheClient.setAddElement(
+        integrationTestCacheName,
+        setName,
+        'bar'
+      );
+      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+
+      const response = await cacheClient.setContainsElement(
+        integrationTestCacheName,
+        setName,
+        'foo'
+      );
+      expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
+    });
+
+    it('should be a hit on a set that exists and does contain the element', async () => {
+      const setName = v4();
+      const addResponse = await cacheClient.setAddElements(
+        integrationTestCacheName,
+        setName,
+        ['foo', 'bar', 'baz']
+      );
+      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+
+      const response = await cacheClient.setContainsElement(
+        integrationTestCacheName,
+        setName,
+        'foo'
+      );
+      expect(response).toBeInstanceOf(CacheSetContainsElement.Hit);
+    });
   });
 
   describe('#removeElement', () => {

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -151,7 +151,7 @@ export function runSetTests(
       expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
     });
 
-    it("should be a miss on a set that exists but doesn't contain the element", async () => {
+    it("should be a hit on a set that exists but doesn't contain the element", async () => {
       const setName = v4();
       const addResponse = await cacheClient.setAddElement(
         integrationTestCacheName,
@@ -165,7 +165,8 @@ export function runSetTests(
         setName,
         'foo'
       );
-      expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
+      expect(response).toBeInstanceOf(CacheSetContainsElement.Hit);
+      expect(response.containsElement()).toBeFalse();
     });
 
     it('should be a hit on a set that exists and does contain the element', async () => {
@@ -183,6 +184,7 @@ export function runSetTests(
         'foo'
       );
       expect(response).toBeInstanceOf(CacheSetContainsElement.Hit);
+      expect(response.containsElement()).toBeTrue();
     });
   });
 

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -9,6 +9,7 @@ import {
   CacheSetSample,
   CollectionTtl,
   MomentoErrorCode,
+  CacheSetContainsElement,
 } from '@gomomento/sdk-core';
 import {
   ValidateCacheProps,
@@ -146,7 +147,7 @@ export function runSetTests(
         setName,
         'foo'
       );
-      expect(response).toBeInstanceOf(CacheSetFetch.Miss);
+      expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
     });
   });
 

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -138,6 +138,18 @@ export function runSetTests(
     });
   });
 
+  describe('#containsElement', () => {
+    it('should be a miss on a set that does not exist', async () => {
+      const setName = v4();
+      const response = await cacheClient.setContainsElement(
+        integrationTestCacheName,
+        setName,
+        'foo'
+      );
+      expect(response).toBeInstanceOf(CacheSetFetch.Miss);
+    });
+  });
+
   describe('#removeElement', () => {
     it('should succeed for removeElement with a byte array happy path', async () => {
       const setName = v4();

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -149,6 +149,7 @@ export function runSetTests(
         'foo'
       );
       expect(response).toBeInstanceOf(CacheSetContainsElement.Miss);
+      expect(response.containsElement()).toBeUndefined();
     });
 
     it("should be a hit on a set that exists but doesn't contain the element", async () => {
@@ -197,6 +198,7 @@ export function runSetTests(
         ['foo', 'bar', 'baz']
       );
       expect(response).toBeInstanceOf(CacheSetContainsElements.Miss);
+      expect(response.containsElements()).toBeUndefined();
     });
 
     it('should be a hit when the set does not contain any of the elements', async () => {
@@ -214,7 +216,7 @@ export function runSetTests(
         ['bar', 'baz']
       );
       expect(response).toBeInstanceOf(CacheSetContainsElements.Hit);
-      expect((response as CacheSetContainsElements.Hit).contains()).toEqual({
+      expect(response.containsElements()).toEqual({
         bar: false,
         baz: false,
       });
@@ -235,7 +237,7 @@ export function runSetTests(
         ['foo', 'baz']
       );
       expect(response).toBeInstanceOf(CacheSetContainsElements.Hit);
-      expect((response as CacheSetContainsElements.Hit).contains()).toEqual({
+      expect(response.containsElements()).toEqual({
         foo: true,
         baz: false,
       });

--- a/packages/common-integration-tests/src/set.ts
+++ b/packages/common-integration-tests/src/set.ts
@@ -174,7 +174,7 @@ export function runSetTests(
         setName,
         ['foo', 'bar', 'baz']
       );
-      expect(addResponse).toBeInstanceOf(CacheSetAddElement.Success);
+      expect(addResponse).toBeInstanceOf(CacheSetAddElements.Success);
 
       const response = await cacheClient.setContainsElement(
         integrationTestCacheName,

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -7,6 +7,7 @@ import {
   CacheSetFetch,
   CacheSetAddElements,
   CacheSetAddElement,
+  CacheSetContainsElement,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheListFetch,
@@ -201,6 +202,11 @@ export interface ICacheClient extends IControlClient, IPingClient {
     elements: string[] | Uint8Array[],
     options?: SetAddElementsOptions
   ): Promise<CacheSetAddElements.Response>;
+  setContainsElement(
+    cacheName: string,
+    setName: string,
+    element: string | Uint8Array
+  ): Promise<CacheSetContainsElement.Response>;
   setRemoveElement(
     cacheName: string,
     setName: string,

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -8,6 +8,7 @@ import {
   CacheSetAddElements,
   CacheSetAddElement,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheListFetch,
@@ -207,6 +208,11 @@ export interface ICacheClient extends IControlClient, IPingClient {
     setName: string,
     element: string | Uint8Array
   ): Promise<CacheSetContainsElement.Response>;
+  setContainsElements(
+    cacheName: string,
+    setName: string,
+    elements: string[] | Uint8Array[]
+  ): Promise<CacheSetContainsElements.Response>;
   setRemoveElement(
     cacheName: string,
     setName: string,

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -13,6 +13,8 @@ import {
   CacheSetFetch,
   CacheSetAddElements,
   CacheSetAddElement,
+  CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheSetSample,
@@ -55,7 +57,6 @@ import {
   CacheGetBatch,
   CacheSetBatch,
   CacheSortedSetRemoveElements,
-  CacheSetContainsElement,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -172,6 +173,10 @@ export interface IMomentoCache {
     setName: string,
     element: string | Uint8Array
   ): Promise<CacheSetContainsElement.Response>;
+  setContainsElements(
+    setName: string,
+    elements: string[] | Uint8Array[]
+  ): Promise<CacheSetContainsElements.Response>;
   setRemoveElement(
     setName: string,
     element: string | Uint8Array

--- a/packages/core/src/clients/IMomentoCache.ts
+++ b/packages/core/src/clients/IMomentoCache.ts
@@ -55,6 +55,7 @@ import {
   CacheGetBatch,
   CacheSetBatch,
   CacheSortedSetRemoveElements,
+  CacheSetContainsElement,
 } from '../index';
 import {
   ScalarCallOptions,
@@ -167,6 +168,10 @@ export interface IMomentoCache {
     elements: string[] | Uint8Array[],
     options?: SetAddElementsOptions
   ): Promise<CacheSetAddElements.Response>;
+  setContainsElement(
+    setName: string,
+    element: string | Uint8Array
+  ): Promise<CacheSetContainsElement.Response>;
   setRemoveElement(
     setName: string,
     element: string | Uint8Array

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ import * as CacheDictionaryIncrement from './messages/responses/cache-dictionary
 import * as CacheDictionaryLength from './messages/responses/cache-dictionary-length';
 import * as CacheSetAddElements from './messages/responses/cache-set-add-elements';
 import * as CacheSetAddElement from './messages/responses/cache-set-add-element';
+import * as CacheSetContainsElement from './messages/responses/cache-set-contains-element';
 import * as CacheSetRemoveElements from './messages/responses/cache-set-remove-elements';
 import * as CacheSetRemoveElement from './messages/responses/cache-set-remove-element';
 import * as CacheSetSample from './messages/responses/cache-set-sample';
@@ -255,6 +256,7 @@ export {
   CacheDictionaryLength,
   CacheSetAddElements,
   CacheSetAddElement,
+  CacheSetContainsElement,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheSetSample,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ import * as CacheDictionaryLength from './messages/responses/cache-dictionary-le
 import * as CacheSetAddElements from './messages/responses/cache-set-add-elements';
 import * as CacheSetAddElement from './messages/responses/cache-set-add-element';
 import * as CacheSetContainsElement from './messages/responses/cache-set-contains-element';
+import * as CacheSetContainsElements from './messages/responses/cache-set-contains-elements';
 import * as CacheSetRemoveElements from './messages/responses/cache-set-remove-elements';
 import * as CacheSetRemoveElement from './messages/responses/cache-set-remove-element';
 import * as CacheSetSample from './messages/responses/cache-set-sample';
@@ -257,6 +258,7 @@ export {
   CacheSetAddElements,
   CacheSetAddElement,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheSetSample,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -19,6 +19,7 @@ import {
   CacheSetFetch,
   CacheSetAddElement,
   CacheSetAddElements,
+  CacheSetContainsElement,
   CacheSetRemoveElement,
   CacheSetRemoveElements,
   CacheListFetch,
@@ -642,6 +643,25 @@ export abstract class AbstractCacheClient implements ICacheClient {
       elements,
       options?.ttl
     );
+  }
+
+  /**
+   * Tests if the given set contains the given element.
+   * @param cacheName - The cache containing the set.
+   * @param setName - The set to check.
+   * @param element - The element to check for.
+   * @returns {Promise<CacheSetContainsElement.Response>} -
+   * {@link CacheSetContainsElement.Hit} if the set exists and contains the element.
+   * {@link CacheSetContainsElement.Miss} if the set does not contain the element.
+   * {@link CacheSetContainsElement.Error} on failure.
+   */
+  public async setContainsElement(
+    cacheName: string,
+    setName: string,
+    element: string | Uint8Array
+  ): Promise<CacheSetContainsElement.Response> {
+    const client = this.getNextDataClient();
+    return await client.setContainsElement(cacheName, setName, element);
   }
 
   /**

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -20,6 +20,7 @@ import {
   CacheSetAddElement,
   CacheSetAddElements,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElement,
   CacheSetRemoveElements,
   CacheListFetch,
@@ -662,6 +663,25 @@ export abstract class AbstractCacheClient implements ICacheClient {
   ): Promise<CacheSetContainsElement.Response> {
     const client = this.getNextDataClient();
     return await client.setContainsElement(cacheName, setName, element);
+  }
+
+  /**
+   * Tests if the given set contains the given elements.
+   * @param cacheName - The cache containing the set.
+   * @param setName - The set to check.
+   * @param elements - The elements to check for.
+   * @returns {Promise<CacheSetContainsElements.Response>} -
+   * {@link CacheSetContainsElements.Hit} containing the elements to their presence in the cache.
+   * {@link CacheSetContainsElements.Miss} if the set does not contain the elements.
+   * {@link CacheSetContainsElements.Error} on failure.
+   */
+  public async setContainsElements(
+    cacheName: string,
+    setName: string,
+    elements: string[] | Uint8Array[]
+  ): Promise<CacheSetContainsElements.Response> {
+    const client = this.getNextDataClient();
+    return await client.setContainsElements(cacheName, setName, elements);
   }
 
   /**

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -7,6 +7,7 @@ import {
   CacheSetFetch,
   CacheSetAddElements,
   CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElements,
   CacheListFetch,
   CacheListLength,
@@ -159,6 +160,11 @@ export interface IDataClient {
     setName: string,
     element: string | Uint8Array
   ): Promise<CacheSetContainsElement.Response>;
+  setContainsElements(
+    cacheName: string,
+    setName: string,
+    elements: string[] | Uint8Array[]
+  ): Promise<CacheSetContainsElements.Response>;
   setRemoveElements(
     cacheName: string,
     setName: string,

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -6,6 +6,7 @@ import {
   CacheSetIfNotExists,
   CacheSetFetch,
   CacheSetAddElements,
+  CacheSetContainsElement,
   CacheSetRemoveElements,
   CacheListFetch,
   CacheListLength,
@@ -153,6 +154,11 @@ export interface IDataClient {
     elements: string[] | Uint8Array[],
     ttl?: CollectionTtl
   ): Promise<CacheSetAddElements.Response>;
+  setContainsElement(
+    cacheName: string,
+    setName: string,
+    element: string | Uint8Array
+  ): Promise<CacheSetContainsElement.Response>;
   setRemoveElements(
     cacheName: string,
     setName: string,

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -13,6 +13,8 @@ import {
   CacheSetFetch,
   CacheSetAddElements,
   CacheSetAddElement,
+  CacheSetContainsElement,
+  CacheSetContainsElements,
   CacheSetRemoveElements,
   CacheSetRemoveElement,
   CacheListFetch,
@@ -56,7 +58,6 @@ import {
   CacheGetBatch,
   CacheSetBatch,
   CacheSetSample,
-  CacheSetContainsElement,
 } from '../../../index';
 import {
   ScalarCallOptions,
@@ -251,6 +252,16 @@ export class MomentoCache implements IMomentoCache {
       this.cacheName,
       setName,
       element
+    );
+  }
+  setContainsElements(
+    setName: string,
+    elements: string[] | Uint8Array[]
+  ): Promise<CacheSetContainsElements.Response> {
+    return this.cacheClient.setContainsElements(
+      this.cacheName,
+      setName,
+      elements
     );
   }
   setRemoveElement(

--- a/packages/core/src/internal/clients/cache/momento-cache.ts
+++ b/packages/core/src/internal/clients/cache/momento-cache.ts
@@ -56,6 +56,7 @@ import {
   CacheGetBatch,
   CacheSetBatch,
   CacheSetSample,
+  CacheSetContainsElement,
 } from '../../../index';
 import {
   ScalarCallOptions,
@@ -240,6 +241,16 @@ export class MomentoCache implements IMomentoCache {
       setName,
       elements,
       options
+    );
+  }
+  setContainsElement(
+    setName: string,
+    element: string | Uint8Array
+  ): Promise<CacheSetContainsElement.Response> {
+    return this.cacheClient.setContainsElement(
+      this.cacheName,
+      setName,
+      element
     );
   }
   setRemoveElement(

--- a/packages/core/src/messages/responses/cache-set-contains-element.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-element.ts
@@ -7,13 +7,18 @@ import {
 import {CacheSetContainsElementResponse} from './enums';
 
 interface IResponse {
+  /**
+   * Returns a boolean indicating whether the element was found in the cache.
+   * @returns {boolean | undefined} A boolean indicating whether the element was found in the cache.
+   * If the set itself was not found, (ie the response was a `Miss` or `Error`), this method returns `undefined`.
+   */
   containsElement(): boolean | undefined;
   readonly type: CacheSetContainsElementResponse;
 }
 
 /**
- * Indicates that the requested data was successfully retrieved from the cache.  Provides
- * `value*` accessors to retrieve the data in the appropriate format.
+ * Indicates that the requested set was in the cache.
+ * Provides a `containsElement` accessor that returns a boolean indicating whether the element was found.
  */
 export class Hit extends ResponseBase implements IResponse {
   private readonly _containsElement: boolean;
@@ -41,7 +46,7 @@ export class Hit extends ResponseBase implements IResponse {
 }
 
 /**
- * Indicates that the requested data was not available in the cache.
+ * Indicates that the requested set was not available in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
   readonly type: CacheSetContainsElementResponse.Miss =

--- a/packages/core/src/messages/responses/cache-set-contains-element.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-element.ts
@@ -4,13 +4,9 @@ import {
   BaseResponseMiss,
   ResponseBase,
 } from './response-base';
-import {truncateString} from '../../internal/utils';
 import {CacheSetContainsElementResponse} from './enums';
 
-const TEXT_DECODER = new TextDecoder();
-
 interface IResponse {
-  element(): string | undefined;
   readonly type: CacheSetContainsElementResponse;
 }
 
@@ -19,42 +15,15 @@ interface IResponse {
  * `value*` accessors to retrieve the data in the appropriate format.
  */
 export class Hit extends ResponseBase implements IResponse {
-  private readonly _element: Uint8Array;
   readonly type: CacheSetContainsElementResponse.Hit =
     CacheSetContainsElementResponse.Hit;
 
-  constructor(element: Uint8Array) {
+  constructor() {
     super();
-    this._element = element;
-  }
-
-  /**
-   * Returns the element as a utf-8 string, decoded from the underlying byte array.
-   * @returns string
-   */
-  public element(): string {
-    return this.elementString();
-  }
-
-  /**
-   * Returns the element as a utf-8 string, decoded from the underlying byte array.
-   * @returns string
-   */
-  public elementString(): string {
-    return TEXT_DECODER.decode(this._element);
-  }
-
-  /**
-   * Returns the element as a byte array.
-   * @returns Uint8Array
-   */
-  public elementUint8Array(): Uint8Array {
-    return this._element;
   }
 
   public override toString(): string {
-    const display = truncateString(this.elementString());
-    return `${super.toString()}: ${display}`;
+    return `${super.toString()}: Hit`;
   }
 }
 
@@ -62,33 +31,11 @@ export class Hit extends ResponseBase implements IResponse {
  * Indicates that the requested data was not available in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
-  private readonly _element: Uint8Array;
   readonly type: CacheSetContainsElementResponse.Miss =
     CacheSetContainsElementResponse.Miss;
 
-  constructor(element: Uint8Array) {
+  constructor() {
     super();
-    this._element = element;
-  }
-
-  /**
-   * Returns the element as a utf-8 string decoded from the underlying byte array.
-   * @returns {string}
-   */
-  public elementString(): string {
-    return TEXT_DECODER.decode(this._element);
-  }
-
-  /**
-   * Returns the element name as a byte array.
-   * @returns {Uint8Array}
-   */
-  public elementUint8Array(): Uint8Array {
-    return this._element;
-  }
-
-  element(): string | undefined {
-    return undefined;
   }
 }
 
@@ -103,37 +50,11 @@ export class Miss extends BaseResponseMiss implements IResponse {
  * - `innerException()` - the original error that caused the failure; can be re-thrown.
  */
 export class Error extends BaseResponseError implements IResponse {
-  private readonly _element: Uint8Array;
   readonly type: CacheSetContainsElementResponse.Error =
     CacheSetContainsElementResponse.Error;
 
-  constructor(_innerException: SdkError, element: Uint8Array) {
+  constructor(_innerException: SdkError) {
     super(_innerException);
-    this._element = element;
-  }
-
-  /**
-   * Returns the element as a utf-8 string, decoded from the underlying byte array.
-   * @returns string
-   */
-  public element(): string {
-    return this.elementString();
-  }
-
-  /**
-   * Returns the element as a utf-8 string, decoded from the underlying byte array.
-   * @returns string
-   */
-  public elementString(): string {
-    return TEXT_DECODER.decode(this._element);
-  }
-
-  /**
-   * Returns the element as a byte array.
-   * @returns Uint8Array
-   */
-  public elementUint8Array(): Uint8Array {
-    return this._element;
   }
 }
 

--- a/packages/core/src/messages/responses/cache-set-contains-element.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-element.ts
@@ -7,6 +7,7 @@ import {
 import {CacheSetContainsElementResponse} from './enums';
 
 interface IResponse {
+  containsElement(): boolean | undefined;
   readonly type: CacheSetContainsElementResponse;
 }
 
@@ -15,15 +16,27 @@ interface IResponse {
  * `value*` accessors to retrieve the data in the appropriate format.
  */
 export class Hit extends ResponseBase implements IResponse {
+  private readonly _containsElement: boolean;
   readonly type: CacheSetContainsElementResponse.Hit =
     CacheSetContainsElementResponse.Hit;
 
-  constructor() {
+  constructor(found: boolean) {
     super();
+    this._containsElement = found;
+  }
+
+  /**
+   * Returns a boolean indicating whether the element was found in the cache.
+   * @returns {boolean}
+   */
+  public containsElement(): boolean {
+    return this._containsElement;
   }
 
   public override toString(): string {
-    return `${super.toString()}: Hit`;
+    return `${super.toString()}: Hit - ${
+      this._containsElement ? 'true' : 'false'
+    }`;
   }
 }
 
@@ -36,6 +49,10 @@ export class Miss extends BaseResponseMiss implements IResponse {
 
   constructor() {
     super();
+  }
+
+  public containsElement(): undefined {
+    return undefined;
   }
 }
 
@@ -55,6 +72,10 @@ export class Error extends BaseResponseError implements IResponse {
 
   constructor(_innerException: SdkError) {
     super(_innerException);
+  }
+
+  public containsElement(): undefined {
+    return undefined;
   }
 }
 

--- a/packages/core/src/messages/responses/cache-set-contains-element.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-element.ts
@@ -1,0 +1,140 @@
+import {SdkError} from '../../errors';
+import {
+  BaseResponseError,
+  BaseResponseMiss,
+  ResponseBase,
+} from './response-base';
+import {truncateString} from '../../internal/utils';
+import {CacheSetContainsElementResponse} from './enums';
+
+const TEXT_DECODER = new TextDecoder();
+
+interface IResponse {
+  element(): string | undefined;
+  readonly type: CacheSetContainsElementResponse;
+}
+
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Hit extends ResponseBase implements IResponse {
+  private readonly _element: Uint8Array;
+  readonly type: CacheSetContainsElementResponse.Hit =
+    CacheSetContainsElementResponse.Hit;
+
+  constructor(element: Uint8Array) {
+    super();
+    this._element = element;
+  }
+
+  /**
+   * Returns the element as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public element(): string {
+    return this.elementString();
+  }
+
+  /**
+   * Returns the element as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public elementString(): string {
+    return TEXT_DECODER.decode(this._element);
+  }
+
+  /**
+   * Returns the element as a byte array.
+   * @returns Uint8Array
+   */
+  public elementUint8Array(): Uint8Array {
+    return this._element;
+  }
+
+  public override toString(): string {
+    const display = truncateString(this.elementString());
+    return `${super.toString()}: ${display}`;
+  }
+}
+
+/**
+ * Indicates that the requested data was not available in the cache.
+ */
+export class Miss extends BaseResponseMiss implements IResponse {
+  private readonly _element: Uint8Array;
+  readonly type: CacheSetContainsElementResponse.Miss =
+    CacheSetContainsElementResponse.Miss;
+
+  constructor(element: Uint8Array) {
+    super();
+    this._element = element;
+  }
+
+  /**
+   * Returns the element as a utf-8 string decoded from the underlying byte array.
+   * @returns {string}
+   */
+  public elementString(): string {
+    return TEXT_DECODER.decode(this._element);
+  }
+
+  /**
+   * Returns the element name as a byte array.
+   * @returns {Uint8Array}
+   */
+  public elementUint8Array(): Uint8Array {
+    return this._element;
+  }
+
+  element(): string | undefined {
+    return undefined;
+  }
+}
+
+/**
+ * Indicates that an error occurred during the set contains element request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends BaseResponseError implements IResponse {
+  private readonly _element: Uint8Array;
+  readonly type: CacheSetContainsElementResponse.Error =
+    CacheSetContainsElementResponse.Error;
+
+  constructor(_innerException: SdkError, element: Uint8Array) {
+    super(_innerException);
+    this._element = element;
+  }
+
+  /**
+   * Returns the element as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public element(): string {
+    return this.elementString();
+  }
+
+  /**
+   * Returns the element as a utf-8 string, decoded from the underlying byte array.
+   * @returns string
+   */
+  public elementString(): string {
+    return TEXT_DECODER.decode(this._element);
+  }
+
+  /**
+   * Returns the element as a byte array.
+   * @returns Uint8Array
+   */
+  public elementUint8Array(): Uint8Array {
+    return this._element;
+  }
+}
+
+export type Response = Hit | Miss | Error;

--- a/packages/core/src/messages/responses/cache-set-contains-elements.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-elements.ts
@@ -1,0 +1,97 @@
+import {SdkError} from '../../errors';
+import {
+  BaseResponseError,
+  BaseResponseMiss,
+  ResponseBase,
+} from './response-base';
+import {truncateString} from '../../internal/utils';
+import {CacheSetContainsElementsResponse} from './enums';
+
+const TEXT_DECODER = new TextDecoder();
+
+interface IResponse {
+  contains(): Record<string, boolean> | undefined;
+  readonly type: CacheSetContainsElementsResponse;
+}
+
+/**
+ * Indicates that the requested data was successfully retrieved from the cache.  Provides
+ * `value*` accessors to retrieve the data in the appropriate format.
+ */
+export class Hit extends ResponseBase implements IResponse {
+  private readonly _contains: Record<string, boolean>;
+  readonly type: CacheSetContainsElementsResponse.Hit =
+    CacheSetContainsElementsResponse.Hit;
+
+  constructor(elements: Uint8Array[], found: boolean[]) {
+    super();
+    this._contains = elements.reduce<Record<string, boolean>>(
+      (acc, element, index) => {
+        acc[TEXT_DECODER.decode(element)] = found[index];
+        return acc;
+      },
+      {}
+    );
+  }
+
+  /**
+   * Returns a mapping of the elements to their presence in the cache.
+   * @returns {Record<string, boolean>}
+   */
+  public contains(): Record<string, boolean> {
+    return this._contains;
+  }
+
+  public override toString(): string {
+    const display = truncateString(
+      Object.entries(this._contains)
+        .map(
+          ([element, isPresent]) =>
+            `${element}: ${isPresent ? 'true' : 'false'}`
+        )
+        .join(', ')
+    );
+    return `${super.toString()}: ${display}`;
+  }
+}
+
+/**
+ * Indicates that the requested data was not available in the cache.
+ */
+export class Miss extends BaseResponseMiss implements IResponse {
+  readonly type: CacheSetContainsElementsResponse.Miss =
+    CacheSetContainsElementsResponse.Miss;
+
+  constructor() {
+    super();
+  }
+
+  public contains(): Record<string, boolean> | undefined {
+    return undefined;
+  }
+}
+
+/**
+ * Indicates that an error occurred during the set contains element request.
+ *
+ * This response object includes the following fields that you can use to determine
+ * how you would like to handle the error:
+ *
+ * - `errorCode()` - a unique Momento error code indicating the type of error that occurred.
+ * - `message()` - a human-readable description of the error
+ * - `innerException()` - the original error that caused the failure; can be re-thrown.
+ */
+export class Error extends BaseResponseError implements IResponse {
+  readonly type: CacheSetContainsElementsResponse.Error =
+    CacheSetContainsElementsResponse.Error;
+
+  constructor(_innerException: SdkError) {
+    super(_innerException);
+  }
+
+  public contains(): Record<string, boolean> | undefined {
+    return undefined;
+  }
+}
+
+export type Response = Hit | Miss | Error;

--- a/packages/core/src/messages/responses/cache-set-contains-elements.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-elements.ts
@@ -10,7 +10,7 @@ import {CacheSetContainsElementsResponse} from './enums';
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
-  contains(): Record<string, boolean> | undefined;
+  containsElements(): Record<string, boolean> | undefined;
   readonly type: CacheSetContainsElementsResponse;
 }
 
@@ -38,7 +38,7 @@ export class Hit extends ResponseBase implements IResponse {
    * Returns a mapping of the elements to their presence in the cache.
    * @returns {Record<string, boolean>}
    */
-  public contains(): Record<string, boolean> {
+  public containsElements(): Record<string, boolean> {
     return this._contains;
   }
 
@@ -66,7 +66,7 @@ export class Miss extends BaseResponseMiss implements IResponse {
     super();
   }
 
-  public contains(): Record<string, boolean> | undefined {
+  public containsElements(): Record<string, boolean> | undefined {
     return undefined;
   }
 }
@@ -89,7 +89,7 @@ export class Error extends BaseResponseError implements IResponse {
     super(_innerException);
   }
 
-  public contains(): Record<string, boolean> | undefined {
+  public containsElements(): Record<string, boolean> | undefined {
     return undefined;
   }
 }

--- a/packages/core/src/messages/responses/cache-set-contains-elements.ts
+++ b/packages/core/src/messages/responses/cache-set-contains-elements.ts
@@ -10,13 +10,19 @@ import {CacheSetContainsElementsResponse} from './enums';
 const TEXT_DECODER = new TextDecoder();
 
 interface IResponse {
+  /**
+   * Returns a mapping of the elements to their presence in the cache.
+   * @returns {Record<string, boolean> | undefined} A mapping of the elements to their presence in the cache.
+   * If the set itself was not found, (ie the response was a `Miss` or `Error`), this method returns `undefined`.
+   */
   containsElements(): Record<string, boolean> | undefined;
   readonly type: CacheSetContainsElementsResponse;
 }
 
 /**
- * Indicates that the requested data was successfully retrieved from the cache.  Provides
- * `value*` accessors to retrieve the data in the appropriate format.
+ * Indicates that the requested set was in the cache.  Provides
+ * a `containsElements` accessor that returns a mapping of the elements of the set
+ * to their presence in the cache.
  */
 export class Hit extends ResponseBase implements IResponse {
   private readonly _contains: Record<string, boolean>;
@@ -56,7 +62,7 @@ export class Hit extends ResponseBase implements IResponse {
 }
 
 /**
- * Indicates that the requested data was not available in the cache.
+ * Indicates that the requested set was not in the cache.
  */
 export class Miss extends BaseResponseMiss implements IResponse {
   readonly type: CacheSetContainsElementsResponse.Miss =

--- a/packages/core/src/messages/responses/enums/cache/set/index.ts
+++ b/packages/core/src/messages/responses/enums/cache/set/index.ts
@@ -14,6 +14,18 @@ export enum CacheSetFetchResponse {
   Error = 'Error',
 }
 
+export enum CacheSetContainsElementResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
+export enum CacheSetContainsElementsResponse {
+  Hit = 'Hit',
+  Miss = 'Miss',
+  Error = 'Error',
+}
+
 export enum CacheSetRemoveElementResponse {
   Success = 'Success',
   Error = 'Error',


### PR DESCRIPTION
Adds the `setContainsElement` command and `setContainsElements` command.

Exposes the result of a `setContainsElements` as a record from the element name to a boolean flag indicating presence/absence.

Addresses #1341 