### PR TITLE
test: support testing aganst momento local by env var presence

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -86,11 +86,20 @@ function sessionCredsProvider(): CredentialProvider {
   return _sessionCredsProvider;
 }
 
+function testAgainstMomentoLocal(): boolean {
+  return process.env.MOMENTO_LOCAL !== undefined;
+}
+
 export function integrationTestCacheClientProps(): CacheClientPropsWithConfig {
+  let credentialProvider = credsProvider();
+  if (testAgainstMomentoLocal()) {
+    credentialProvider = credentialProvider.withMomentoLocal();
+  }
+
   return {
     configuration:
       Configurations.Laptop.latest().withClientTimeoutMillis(90000),
-    credentialProvider: credsProvider(),
+    credentialProvider,
     defaultTtlSeconds: 1111,
   };
 }


### PR DESCRIPTION
To simplify testing against momento local, we use the momento local
credential provider when the `MOMENTO_LOCAL` environment variable
exists.
