### PR TITLE
fix: storage get response should use Found and NotFound cases

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/storage-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/storage-data-client.ts
@@ -162,22 +162,22 @@ export class StorageDataClient implements IStorageDataClient {
             switch (value) {
               case 'double_value': {
                 return resolve(
-                  StorageGet.Success.ofDouble(resp.value.double_value)
+                  StorageGet.Found.ofDouble(resp.value.double_value)
                 );
               }
               case 'string_value': {
                 return resolve(
-                  StorageGet.Success.ofString(resp.value.string_value)
+                  StorageGet.Found.ofString(resp.value.string_value)
                 );
               }
               case 'bytes_value': {
                 return resolve(
-                  StorageGet.Success.ofBytes(resp.value.bytes_value)
+                  StorageGet.Found.ofBytes(resp.value.bytes_value)
                 );
               }
               case 'integer_value': {
                 return resolve(
-                  StorageGet.Success.ofInt(resp.value.integer_value)
+                  StorageGet.Found.ofInt(resp.value.integer_value)
                 );
               }
               case 'none': {
@@ -196,7 +196,7 @@ export class StorageDataClient implements IStorageDataClient {
               sdkError.errorCode() ===
               MomentoErrorCode.STORE_ITEM_NOT_FOUND_ERROR
             ) {
-              return resolve(new StorageGet.Success(undefined));
+              return resolve(new StorageGet.NotFound());
             }
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,

--- a/packages/client-sdk-web/src/internal/storage-data-client.ts
+++ b/packages/client-sdk-web/src/internal/storage-data-client.ts
@@ -122,22 +122,20 @@ export class StorageDataClient<
               }
               case ValueCase.BYTES_VALUE: {
                 return resolve(
-                  StorageGet.Success.ofBytes(value.getBytesValue_asU8())
+                  StorageGet.Found.ofBytes(value.getBytesValue_asU8())
                 );
               }
               case ValueCase.STRING_VALUE: {
                 return resolve(
-                  StorageGet.Success.ofString(value.getStringValue())
+                  StorageGet.Found.ofString(value.getStringValue())
                 );
               }
               case ValueCase.INTEGER_VALUE: {
-                return resolve(
-                  StorageGet.Success.ofInt(value.getIntegerValue())
-                );
+                return resolve(StorageGet.Found.ofInt(value.getIntegerValue()));
               }
               case ValueCase.DOUBLE_VALUE: {
                 return resolve(
-                  StorageGet.Success.ofDouble(value.getDoubleValue())
+                  StorageGet.Found.ofDouble(value.getDoubleValue())
                 );
               }
             }
@@ -147,7 +145,7 @@ export class StorageDataClient<
               sdkError.errorCode() ===
               MomentoErrorCode.STORE_ITEM_NOT_FOUND_ERROR
             ) {
-              return resolve(new StorageGet.Success(undefined));
+              return resolve(new StorageGet.NotFound());
             }
             this.cacheServiceErrorMapper.resolveOrRejectError({
               err: err,

--- a/packages/common-integration-tests/src/storage.ts
+++ b/packages/common-integration-tests/src/storage.ts
@@ -137,7 +137,7 @@ export function runStorageServiceTests(
         }
       }
       const getIntResponse = await storageClient.get(testingStoreName, key);
-      expect(getIntResponse.type).toEqual(StorageGetResponse.Success);
+      expect(getIntResponse.type).toEqual(StorageGetResponse.Found);
       expect(getIntResponse.value()?.int()).toEqual(intValue);
 
       // put/get a double value
@@ -158,7 +158,7 @@ export function runStorageServiceTests(
         }
       }
       const getDoubleResponse = await storageClient.get(testingStoreName, key);
-      expect(getDoubleResponse.type).toEqual(StorageGetResponse.Success);
+      expect(getDoubleResponse.type).toEqual(StorageGetResponse.Found);
       expect(getDoubleResponse.value()?.double()).toEqual(doubleValue);
 
       // put/get a string value
@@ -179,7 +179,7 @@ export function runStorageServiceTests(
         }
       }
       const getStringResponse = await storageClient.get(testingStoreName, key);
-      expect(getStringResponse.type).toEqual(StorageGetResponse.Success);
+      expect(getStringResponse.type).toEqual(StorageGetResponse.Found);
       expect(getStringResponse.value()?.string()).toEqual(stringValue);
 
       // put/get a bytes value
@@ -200,7 +200,7 @@ export function runStorageServiceTests(
         }
       }
       const getBytesResponse = await storageClient.get(testingStoreName, key);
-      expect(getBytesResponse.type).toEqual(StorageGetResponse.Success);
+      expect(getBytesResponse.type).toEqual(StorageGetResponse.Found);
       expect(getBytesResponse.value()?.bytes()).toEqual(bytesValue);
 
       const deleteResponse = await storageClient.delete(testingStoreName, key);
@@ -233,7 +233,7 @@ export function runStorageServiceTests(
         }
       }
       const getResponse = await storageClient.get(testingStoreName, key);
-      expect(getResponse.type).toEqual(StorageGetResponse.Success);
+      expect(getResponse.type).toEqual(StorageGetResponse.Found);
       expect(getResponse.value()).toBeUndefined();
     });
     it('should return store not found error for deleting a store that doesnt exist', async () => {

--- a/packages/common-integration-tests/src/storage.ts
+++ b/packages/common-integration-tests/src/storage.ts
@@ -233,7 +233,7 @@ export function runStorageServiceTests(
         }
       }
       const getResponse = await storageClient.get(testingStoreName, key);
-      expect(getResponse.type).toEqual(StorageGetResponse.Found);
+      expect(getResponse.type).toEqual(StorageGetResponse.NotFound);
       expect(getResponse.value()).toBeUndefined();
     });
     it('should return store not found error for deleting a store that doesnt exist', async () => {

--- a/packages/core/src/messages/responses/enums/store/scalar/index.ts
+++ b/packages/core/src/messages/responses/enums/store/scalar/index.ts
@@ -1,5 +1,6 @@
 export enum StorageGetResponse {
-  Success = 'Success',
+  Found = 'Found',
+  NotFound = 'NotFound',
   Error = 'Error',
 }
 

--- a/packages/core/src/messages/responses/storage/scalar/storage-get.ts
+++ b/packages/core/src/messages/responses/storage/scalar/storage-get.ts
@@ -9,73 +9,88 @@ interface IResponse {
 }
 
 /**
- * Indicates that the store get request was successful.
+ * Indicates that the item was fetched from the store.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the successful response:
  *
  * - `value()` - the value associated with the key that was retrieved from the cache.
  */
-export class Success extends ResponseBase implements IResponse {
-  readonly type: StorageGetResponse.Success = StorageGetResponse.Success;
-  private readonly _value: StorageValue | undefined;
+export class Found extends ResponseBase implements IResponse {
+  readonly type: StorageGetResponse.Found = StorageGetResponse.Found;
+  private readonly _value: StorageValue;
 
   /**
-   * Creates an instance of the Success response.
-   * @param {StorageValue | undefined} value - The value associated with the key that was retrieved from the cache.
+   * Creates an instance of the Found response.
+   * @param {StorageValue} value - The value associated with the key that was retrieved from the cache.
    */
-  constructor(value: StorageValue | undefined) {
+  constructor(value: StorageValue) {
     super();
     this._value = value;
   }
 
   /**
-   * Creates a Success response with an integer value.
+   * Creates a Found response with an integer value.
    * @param {number} value - The integer value to be stored.
-   * @returns {Success} - A Success response object containing the integer value.
+   * @returns {Found} - A Found response object containing the integer value.
    */
-  static ofInt(value: number): Success {
-    return new Success(StorageValue.ofInt(value));
+  static ofInt(value: number): Found {
+    return new Found(StorageValue.ofInt(value));
   }
 
   /**
-   * Creates a Success response with a double value.
+   * Creates a Found response with a double value.
    * @param {number} value - The double value to be stored.
-   * @returns {Success} - A Success response object containing the double value.
+   * @returns {Found} - A Found response object containing the double value.
    */
-  static ofDouble(value: number): Success {
-    return new Success(StorageValue.ofDouble(value));
+  static ofDouble(value: number): Found {
+    return new Found(StorageValue.ofDouble(value));
   }
 
   /**
-   * Creates a Success response with a string value.
+   * Creates a Found response with a string value.
    * @param {string} value - The string value to be stored.
-   * @returns {Success} - A Success response object containing the string value.
+   * @returns {Found} - A Found response object containing the string value.
    */
-  static ofString(value: string): Success {
-    return new Success(StorageValue.ofString(value));
+  static ofString(value: string): Found {
+    return new Found(StorageValue.ofString(value));
   }
 
   /**
-   * Creates a Success response with a byte array value.
+   * Creates a Found response with a byte array value.
    * @param {Uint8Array} value - The byte array value to be stored.
-   * @returns {Success} - A Success response object containing the byte array value.
+   * @returns {Found} - A Found response object containing the byte array value.
    */
-  static ofBytes(value: Uint8Array): Success {
-    return new Success(StorageValue.ofBytes(value));
+  static ofBytes(value: Uint8Array): Found {
+    return new Found(StorageValue.ofBytes(value));
   }
 
   /**
    * Retrieves the value associated with the key that was retrieved from the cache.
-   * @returns {StorageValue | undefined} - The value associated with the key, or undefined if no value is present.
+   * @returns {StorageValue} - The value associated with the key, or undefined if no value is present.
    */
-  value(): StorageValue | undefined {
+  value(): StorageValue {
     return this._value;
   }
 }
 
 /**
- * Indicates that an error occurred during the cache get request.
+ * Indicates that the item was not found in the store.
+ */
+export class NotFound extends ResponseBase implements IResponse {
+  readonly type: StorageGetResponse.NotFound = StorageGetResponse.NotFound;
+
+  constructor() {
+    super();
+  }
+
+  value(): undefined {
+    return undefined;
+  }
+}
+
+/**
+ * Indicates that an error occurred during the storage get request.
  *
  * This response object includes the following fields that you can use to determine
  * how you would like to handle the error:
@@ -86,6 +101,7 @@ export class Success extends ResponseBase implements IResponse {
  */
 export class Error extends BaseResponseError implements IResponse {
   readonly type: StorageGetResponse.Error = StorageGetResponse.Error;
+
   constructor(_innerException: SdkError) {
     super(_innerException);
   }
@@ -95,4 +111,4 @@ export class Error extends BaseResponseError implements IResponse {
   }
 }
 
-export type Response = Success | Error;
+export type Response = Found | NotFound | Error;


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/935

Based on written notes, I don't believe there's anything else to address in the JS storage clients, but please let me know if there are other issues.

This PR replaces `StorageGetResponse.Success` with `Found` (always returns a `StorageValue`) and `NotFound` (always returns `undefined`).

```
const getResponse = await client.get(storeName, 'key');

// quick check
console.log('what is the value?', getResponse.value()?.string());

// full switch check
switch (getResponse.type) {
    case StorageGetResponse.Found:
      console.log(`Got string value: ${getResponse.value().string() ?? 'not a string'}`);
      console.log(`Got string value: ${getResponse.value().int() ?? 'not an int'}`);
      break;
    case StorageGetResponse.NotFound: {
      console.log('Key not found: hello');
      break;
    }
    case StorageGetResponse.Error:
      console.error('Failed to get string value: world');
      break;
  }
```

When locally testing, VSCode pointed out incomplete switch statements when `"@typescript-eslint/switch-exhaustiveness-check": "error"` was specified in the `eslintrc.json` file.
