### PR TITLE
fix: nodejs first-time headers should be sent per client

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/grpc/headers-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/headers-interceptor.ts
@@ -18,7 +18,7 @@ export class Header {
 export class HeaderInterceptorProvider {
   private readonly headersToAddEveryTime: Header[];
   private readonly headersToAddOnce: Header[];
-  private static areOnlyOnceHeadersSent = false;
+  private areOnlyOnceHeadersSent = false;
 
   /**
    * @param {Header[]} headers
@@ -39,8 +39,8 @@ export class HeaderInterceptorProvider {
           this.headersToAddEveryTime.forEach(h =>
             metadata.add(h.name, h.value)
           );
-          if (!HeaderInterceptorProvider.areOnlyOnceHeadersSent) {
-            HeaderInterceptorProvider.areOnlyOnceHeadersSent = true;
+          if (!this.areOnlyOnceHeadersSent) {
+            this.areOnlyOnceHeadersSent = true;
             this.headersToAddOnce.forEach(h => metadata.add(h.name, h.value));
           }
           next(metadata, {});


### PR DESCRIPTION
Each client creates an instance of `class HeaderInterceptorProvider` which is responsible for determining whether to send the first-request headers.

To ensure each client sends them on their first request, I switched the `areOnlyOnceHeadersSent` from a `static` variable to a non-static one.