### PR TITLE
feat: add response type enums to exports for web sdk

### DIFF
--- a/packages/client-sdk-nodejs/src/index.ts
+++ b/packages/client-sdk-nodejs/src/index.ts
@@ -100,6 +100,8 @@ import * as GenerateDisposableToken from '@gomomento/sdk-core/dist/src/messages/
 // LeaderboardClient Response Types
 export {leaderboard} from '@gomomento/sdk-core';
 export * from '@gomomento/sdk-core/dist/src/messages/responses/leaderboard';
+
+// Enums representing the different types available for each response
 export * from '@gomomento/sdk-core/dist/src/messages/responses/enums';
 
 import {

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -169,6 +169,9 @@ import {
 
 export * from '@gomomento/sdk-core/dist/src/messages/responses/storage';
 
+// Enums representing the different types available for each response
+export * from '@gomomento/sdk-core/dist/src/messages/responses/enums';
+
 export {
   DefaultMomentoLoggerFactory,
   DefaultMomentoLogger,


### PR DESCRIPTION
Prior to this commit, the new response type enums are not exported
from the Web SDK, which means that the new pattern matching code
won't work. This is a blocker for finishing the docs updates.
