### PR TITLE
chore: refactor AbstractPubSubClient to ensure safe use of required vars

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -62,7 +62,7 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
 
     const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
 
-    console.log(
+    this.getLogger().trace(
       `Creating pubsub client with channel options: ${JSON.stringify(
         channelOptions,
         null,

--- a/packages/core/src/internal/clients/pubsub/IPubsubClient.ts
+++ b/packages/core/src/internal/clients/pubsub/IPubsubClient.ts
@@ -5,7 +5,6 @@ import {
 } from '../../../index';
 
 export interface IPubsubClient {
-  getEndpoint(): string;
   publish(
     cacheName: string,
     topicName: string,

--- a/packages/core/src/internal/subscription-state.ts
+++ b/packages/core/src/internal/subscription-state.ts
@@ -38,4 +38,15 @@ export class SubscriptionState {
       this.setUnsubscribed();
     }
   }
+
+  public toString(): string {
+    return JSON.stringify(
+      {
+        lastTopicSequenceNumber: this.lastTopicSequenceNumber,
+        isSubscribed: this._isSubscribed,
+      },
+      null,
+      2
+    );
+  }
 }

--- a/packages/core/src/messages/responses/topic-subscribe.ts
+++ b/packages/core/src/messages/responses/topic-subscribe.ts
@@ -2,6 +2,7 @@ import {SdkError} from '../../errors';
 import {BaseResponseError, BaseResponseSubscription} from './response-base';
 import {SubscriptionState} from '../../internal/subscription-state';
 import {TopicSubscribeResponse} from './enums';
+import {MomentoLogger, MomentoLoggerFactory} from '../../config/logging';
 
 interface IResponse {
   readonly type: TopicSubscribeResponse;
@@ -19,11 +20,16 @@ export class Subscription
   implements IResponse
 {
   private subscriptionState: SubscriptionState;
+  private readonly logger: MomentoLogger;
   readonly type: TopicSubscribeResponse.Subscription =
     TopicSubscribeResponse.Subscription;
 
-  constructor(subscriptionState: SubscriptionState) {
+  constructor(
+    loggerFactory: MomentoLoggerFactory,
+    subscriptionState: SubscriptionState
+  ) {
     super();
+    this.logger = loggerFactory.getLogger(this);
     this.subscriptionState = subscriptionState;
   }
 
@@ -33,6 +39,9 @@ export class Subscription
    * @returns void
    */
   public unsubscribe(): void {
+    this.logger.trace(
+      `Unsubscribing from subscription: ${this.subscriptionState.toString()}`
+    );
     this.subscriptionState.unsubscribe();
   }
 


### PR DESCRIPTION
This commit contains no functional changes; simply refactors the
AbstractPubSubClient to stop leaking out member variables to its
subclasses. The way it was previously defined, there were several
member variables that were required to be initialized by the child
classes, which, if you did not initialize them would result in
a runtime error instead of a compile-time error. This commit
changes the variables to be private, provides protected accessor
functions as needed, and creates a constructor function that requires
them to be passed in at initialization time. This moves any related
bugs from run time to compile time and makes it simpler to reason
about the ownership of the variables.
