### PR TITLE
fix: improve TopicClient connection resiliency

### DIFF
--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -32,6 +32,11 @@ export class Default extends TopicClientConfiguration {
       transportStrategy: new StaticTopicTransportStrategy({
         grpcConfiguration: new StaticTopicGrpcConfiguration({
           numClients: 1,
+          // TODO: when we introduce lambda configurations, we do not want to enable keepalives, because they
+          //  cause issues on lambda.
+          keepAlivePermitWithoutCalls: 1,
+          keepAliveTimeMs: 5000,
+          keepAliveTimeoutMs: 1000,
         }),
       }),
       throwOnErrors: false,

--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -32,13 +32,41 @@ export class Default extends TopicClientConfiguration {
       transportStrategy: new StaticTopicTransportStrategy({
         grpcConfiguration: new StaticTopicGrpcConfiguration({
           numClients: 1,
-          // TODO: when we introduce lambda configurations, we do not want to enable keepalives, because they
-          //  cause issues on lambda.
           keepAlivePermitWithoutCalls: 1,
           keepAliveTimeMs: 5000,
           keepAliveTimeoutMs: 1000,
         }),
       }),
+      throwOnErrors: false,
+    });
+  }
+}
+
+/**
+ * Default config provides defaults suitable for AWS lambda or similar environments; relaxes timeouts, disables keep-alives
+ * to avoid issues with execution environments being frozen and resumed, etc.
+ * @export
+ * @class Lambda
+ */
+export class Lambda extends TopicClientConfiguration {
+  /**
+   * Provides the latest recommended configuration for a lambda environment.  NOTE: this configuration may
+   * change in future releases to take advantage of improvements we identify for default configurations.
+   * @param {MomentoLoggerFactory} [loggerFactory=defaultLoggerFactory]
+   * @returns {CacheConfiguration}
+   */
+  static latest(
+    loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
+  ): TopicClientConfiguration {
+    const grpcConfig = new StaticTopicGrpcConfiguration({
+      numClients: 1,
+    });
+    const transportStrategy = new StaticTopicTransportStrategy({
+      grpcConfiguration: grpcConfig,
+    });
+    return new Lambda({
+      loggerFactory: loggerFactory,
+      transportStrategy: transportStrategy,
       throwOnErrors: false,
     });
   }

--- a/packages/client-sdk-nodejs/src/config/transport/topics/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/topics/grpc-configuration.ts
@@ -4,6 +4,40 @@ export interface TopicGrpcConfigurationProps {
    * more concurrent requests, at the cost of more open connections and the latency of setting up each client.
    */
   numClients?: number;
+
+  /**
+   * Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   */
+  keepAlivePermitWithoutCalls?: number;
+
+  /**
+   * After waiting for a duration of this time, if the keepalive ping sender does not receive the ping ack,
+   * it will close the transport.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   */
+  keepAliveTimeoutMs?: number;
+
+  /**
+   * After a duration of this time the client/server pings its peer to see if the transport is still alive.
+   *
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   */
+  keepAliveTimeMs?: number;
 }
 
 /**
@@ -24,4 +58,37 @@ export interface TopicGrpcConfiguration {
    * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified number of clients
    */
   withNumClients(numClients: number): TopicGrpcConfiguration;
+
+  /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
+   * @returns {number} 0 or 1, if it is permissible to send a keepalive/ping without any outstanding calls.
+   */
+  getKeepAlivePermitWithoutCalls(): number | undefined;
+
+  /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
+   * @returns {number} the time to wait for a response from a keepalive or ping.
+   */
+  getKeepAliveTimeoutMS(): number | undefined;
+
+  /**
+   * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+   * when the connection is idle. However, they are very problematic for lambda environments where the lambda
+   * runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+   * from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+   * Therefore, keep-alives should be disabled in lambda and similar environments.
+   *
+   * @returns {number} the interval at which to send the keepalive or ping.
+   */
+  getKeepAliveTimeMS(): number | undefined;
 }

--- a/packages/client-sdk-nodejs/src/config/transport/topics/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/topics/transport-strategy.ts
@@ -28,6 +28,9 @@ export interface TopicTransportStrategyProps {
 
 export class StaticTopicGrpcConfiguration implements TopicGrpcConfiguration {
   private readonly numClients: number;
+  private readonly keepAlivePermitWithoutCalls?: number;
+  private readonly keepAliveTimeoutMs?: number;
+  private readonly keepAliveTimeMs?: number;
 
   constructor(props: TopicGrpcConfigurationProps) {
     if (props.numClients !== undefined && props.numClients !== null) {
@@ -35,6 +38,10 @@ export class StaticTopicGrpcConfiguration implements TopicGrpcConfiguration {
     } else {
       this.numClients = 1;
     }
+
+    this.keepAliveTimeMs = props.keepAliveTimeMs;
+    this.keepAliveTimeoutMs = props.keepAliveTimeoutMs;
+    this.keepAlivePermitWithoutCalls = props.keepAlivePermitWithoutCalls;
   }
 
   getNumClients(): number {
@@ -44,7 +51,22 @@ export class StaticTopicGrpcConfiguration implements TopicGrpcConfiguration {
   withNumClients(numClients: number): TopicGrpcConfiguration {
     return new StaticTopicGrpcConfiguration({
       numClients: numClients,
+      keepAlivePermitWithoutCalls: this.keepAlivePermitWithoutCalls,
+      keepAliveTimeoutMs: this.keepAliveTimeoutMs,
+      keepAliveTimeMs: this.keepAliveTimeMs,
     });
+  }
+
+  getKeepAliveTimeoutMS(): number | undefined {
+    return this.keepAliveTimeoutMs;
+  }
+
+  getKeepAliveTimeMS(): number | undefined {
+    return this.keepAliveTimeMs;
+  }
+
+  getKeepAlivePermitWithoutCalls(): number | undefined {
+    return this.keepAlivePermitWithoutCalls;
   }
 }
 

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -189,8 +189,6 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
     return new Promise((resolve, _reject) => {
       const prepareCallbackOptions: PrepareSubscribeCallbackOptions = {
         ...options,
-        // restartedDueToError: false,
-        // firstMessage: true,
         resolve,
       };
       call.on('data', this.prepareDataCallback(prepareCallbackOptions));

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -5,12 +5,12 @@ import {Header, HeaderInterceptorProvider} from './grpc/headers-interceptor';
 import {ClientTimeoutInterceptor} from './grpc/client-timeout-interceptor';
 import {CacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
 import {ChannelCredentials, Interceptor, ServiceError} from '@grpc/grpc-js';
-import {Status} from '@grpc/grpc-js/build/src/constants';
 import {version} from '../../package.json';
 import {middlewaresInterceptor} from './grpc/middlewares-interceptor';
 import {
   CredentialProvider,
   StaticGrpcConfiguration,
+  TopicGrpcConfiguration,
   TopicItem,
   TopicPublish,
   TopicSubscribe,
@@ -35,8 +35,8 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
   private readonly unaryInterceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];
 
-  private static readonly RST_STREAM_NO_ERROR_MESSAGE =
-    'Received RST_STREAM with code 0';
+  // private static readonly RST_STREAM_NO_ERROR_MESSAGE =
+  //   'Received RST_STREAM with code 0';
 
   /**
    * @param {TopicClientProps} props
@@ -53,16 +53,24 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
       `Creating topic client using endpoint: '${this.credentialProvider.getCacheEndpoint()}'`
     );
 
+    const topicGrpcConfig: TopicGrpcConfiguration = props.configuration
+      .getTransportStrategy()
+      .getGrpcConfig();
+
     // NOTE: This is hard-coded for now but we may want to expose it via TopicConfiguration in the
     // future, as we do with some of the other clients.
     const grpcConfig = new StaticGrpcConfiguration({
       deadlineMillis: this.unaryRequestTimeoutMs,
       maxSessionMemoryMb: PubsubClient.DEFAULT_MAX_SESSION_MEMORY_MB,
+      keepAlivePermitWithoutCalls:
+        topicGrpcConfig.getKeepAlivePermitWithoutCalls(),
+      keepAliveTimeMs: topicGrpcConfig.getKeepAliveTimeMS(),
+      keepAliveTimeoutMs: topicGrpcConfig.getKeepAliveTimeoutMS(),
     });
 
     const channelOptions = grpcChannelOptionsFromGrpcConfig(grpcConfig);
 
-    this.getLogger().trace(
+    this.getLogger().debug(
       `Creating pubsub client with channel options: ${JSON.stringify(
         channelOptions,
         null,
@@ -151,7 +159,7 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
    * case we already returned a subscription object to the user, so we instead cancel the stream and
    * propagate an error to the user via the error handler.
    */
-  protected sendSubscribe(
+  protected override sendSubscribe(
     options: SendSubscribeOptions
   ): Promise<TopicSubscribe.Response> {
     const request = new grpcPubsub._SubscriptionRequest({
@@ -161,6 +169,10 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
         options.subscriptionState.resumeAtTopicSequenceNumber,
     });
 
+    this.getLogger().trace(
+      'Subscribing to topic with resume_at_topic_sequence_number: %s',
+      options.subscriptionState.resumeAtTopicSequenceNumber
+    );
     const call = this.client.Subscribe(request, {
       interceptors: this.streamingInterceptors,
     });
@@ -177,8 +189,8 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
     return new Promise((resolve, _reject) => {
       const prepareCallbackOptions: PrepareSubscribeCallbackOptions = {
         ...options,
-        restartedDueToError: false,
-        firstMessage: true,
+        // restartedDueToError: false,
+        // firstMessage: true,
         resolve,
       };
       call.on('data', this.prepareDataCallback(prepareCallbackOptions));
@@ -199,6 +211,11 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
       if (resp?.item) {
         options.subscriptionState.lastTopicSequenceNumber =
           resp.item.topic_sequence_number;
+        this.getLogger().trace(
+          'Received an item on subscription stream; topic: %s; sequence number: %s',
+          truncateString(options.topicName),
+          resp.item.topic_sequence_number
+        );
         if (resp.item.value.text) {
           options.onItem(
             new TopicItem(resp.item.value.text, {
@@ -256,13 +273,24 @@ export class PubsubClient extends AbstractPubsubClient<ServiceError> {
       }
 
       const serviceError = err as unknown as ServiceError;
-      const isRstStreamNoError =
-        serviceError.code === Status.INTERNAL &&
-        serviceError.details === PubsubClient.RST_STREAM_NO_ERROR_MESSAGE;
+      this.getLogger().trace(
+        `Subscription encountered an error: ${serviceError.code}: ${serviceError.message}: ${serviceError.details}`
+      );
+      const shouldReconnectSubscription =
+        // previously, we were only attempting a reconnect on this one very specific case, but our current expectation is that
+        // we should err on the side of retrying. This may become a sort of "deny list" of error types to *not* retry on
+        // in the future, but for now we will be aggressive about retrying.
+        // // serviceError.code === Status.INTERNAL &&
+        //  // serviceError.details === PubsubClient.RST_STREAM_NO_ERROR_MESSAGE;
+        true;
       const momentoError = new TopicSubscribe.Error(
         this.getCacheServiceErrorMapper().convertError(serviceError)
       );
-      this.handleSubscribeError(options, momentoError, isRstStreamNoError);
+      this.handleSubscribeError(
+        options,
+        momentoError,
+        shouldReconnectSubscription
+      );
     };
   }
 


### PR DESCRIPTION
At some point in time a refactor seems to have made the TopicClient less resilient to network interruptions. It may have happened when we made changes to disable keepalives by default (due to lambda issues), or during some refactor work to add topics support to the web SDK.

This commit does the following:

* Add configuration options for grpc keepalives and enable them in the default topicclient config
* Adds a good deal of trace-level logging to help debug what is happening when subscriptions are interrupted
* Re-work the error-handling and "end of stream" logic a bit to improve connection resiliency.

I tested this on my laptop by disabling my wifi after the subscription was created. Prior to these changes, the network issues were not detected and the connection was left in a broken state. After these changes, the issues are detected and the connection is re-established successfully.