### PR TITLE
feat: adds order opt to sortedset getRank

### DIFF
--- a/examples/nodejs/cache/basic.ts
+++ b/examples/nodejs/cache/basic.ts
@@ -1,10 +1,12 @@
 import {
   CacheClient,
-  Configurations,
-  CredentialProvider,
-  CreateCacheResponse,
-  CacheSetResponse,
   CacheGetResponse,
+  CacheSetResponse,
+  CacheSortedSetFetchResponse,
+  Configurations,
+  CreateCacheResponse,
+  CredentialProvider,
+  SortedSetOrder,
 } from '@gomomento/sdk';
 
 async function main() {
@@ -52,6 +54,26 @@ async function main() {
       break;
     case CacheGetResponse.Error:
       console.log(`Error: ${getResponse.message()}`);
+      break;
+  }
+
+  await momento.sortedSetGetRank('my-cache', 'my-sorted-set', 'my-element', {
+    order: SortedSetOrder.Descending,
+  });
+
+  const getRankRsp = await momento.sortedSetFetchByRank('myCache', 'mySortedSet', {
+    order: SortedSetOrder.Ascending,
+    // order: SortedSetOrder.Descending,
+  });
+  switch (getRankRsp.type) {
+    case CacheSortedSetFetchResponse.Hit:
+      console.log(JSON.stringify(getRankRsp.valueArray()));
+      break;
+    case CacheSortedSetFetchResponse.Miss:
+      console.log('sorted set not found');
+      break;
+    case CacheSortedSetFetchResponse.Error:
+      console.error(getRankRsp);
       break;
   }
 }

--- a/examples/nodejs/cache/basic.ts
+++ b/examples/nodejs/cache/basic.ts
@@ -2,11 +2,9 @@ import {
   CacheClient,
   CacheGetResponse,
   CacheSetResponse,
-  CacheSortedSetFetchResponse,
   Configurations,
   CreateCacheResponse,
   CredentialProvider,
-  SortedSetOrder,
 } from '@gomomento/sdk';
 
 async function main() {
@@ -54,26 +52,6 @@ async function main() {
       break;
     case CacheGetResponse.Error:
       console.log(`Error: ${getResponse.message()}`);
-      break;
-  }
-
-  await momento.sortedSetGetRank('my-cache', 'my-sorted-set', 'my-element', {
-    order: SortedSetOrder.Descending,
-  });
-
-  const getRankRsp = await momento.sortedSetFetchByRank('myCache', 'mySortedSet', {
-    order: SortedSetOrder.Ascending,
-    // order: SortedSetOrder.Descending,
-  });
-  switch (getRankRsp.type) {
-    case CacheSortedSetFetchResponse.Hit:
-      console.log(JSON.stringify(getRankRsp.valueArray()));
-      break;
-    case CacheSortedSetFetchResponse.Miss:
-      console.log('sorted set not found');
-      break;
-    case CacheSortedSetFetchResponse.Error:
-      console.error(getRankRsp);
       break;
   }
 }

--- a/examples/nodejs/cache/basic.ts
+++ b/examples/nodejs/cache/basic.ts
@@ -1,10 +1,10 @@
 import {
   CacheClient,
-  CacheGetResponse,
-  CacheSetResponse,
   Configurations,
-  CreateCacheResponse,
   CredentialProvider,
+  CreateCacheResponse,
+  CacheSetResponse,
+  CacheGetResponse,
 } from '@gomomento/sdk';
 
 async function main() {

--- a/packages/client-sdk-nodejs-compression/package-lock.json
+++ b/packages/client-sdk-nodejs-compression/package-lock.json
@@ -37,6 +37,7 @@
       }
     },
     "../client-sdk-nodejs": {
+      "name": "@gomomento/sdk",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -3611,7 +3611,8 @@ export class CacheDataClient implements IDataClient {
   public async sortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string | Uint8Array
+    value: string | Uint8Array,
+    order?: SortedSetOrder
   ): Promise<CacheSortedSetGetRank.Response> {
     try {
       validateCacheName(cacheName);
@@ -3627,7 +3628,8 @@ export class CacheDataClient implements IDataClient {
       return await this.sendSortedSetGetRank(
         cacheName,
         this.convert(sortedSetName),
-        this.convert(value)
+        this.convert(value),
+        order
       );
     });
   }
@@ -3635,11 +3637,18 @@ export class CacheDataClient implements IDataClient {
   private async sendSortedSetGetRank(
     cacheName: string,
     sortedSetName: Uint8Array,
-    value: Uint8Array
+    value: Uint8Array,
+    order?: SortedSetOrder
   ): Promise<CacheSortedSetGetRank.Response> {
+    const protoBufOrder =
+      order === SortedSetOrder.Descending
+        ? grpcCache._SortedSetGetRankRequest.Order.DESCENDING
+        : grpcCache._SortedSetGetRankRequest.Order.ASCENDING;
+
     const request = new grpcCache._SortedSetGetRankRequest({
       set_name: sortedSetName,
       value: value,
+      order: protoBufOrder,
     });
     const metadata = this.createMetadata(cacheName);
     return await new Promise((resolve, reject) => {

--- a/packages/client-sdk-web/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-web/src/internal/cache-data-client.ts
@@ -3657,7 +3657,8 @@ export class CacheDataClient<
   public async sortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string | Uint8Array
+    value: string | Uint8Array,
+    order?: SortedSetOrder
   ): Promise<CacheSortedSetGetRank.Response> {
     try {
       validateCacheName(cacheName);
@@ -3677,7 +3678,8 @@ export class CacheDataClient<
     const result = await this.sendSortedSetGetRank(
       cacheName,
       convertToB64String(sortedSetName),
-      convertToB64String(value)
+      convertToB64String(value),
+      order
     );
 
     this.logger.trace(
@@ -3690,11 +3692,18 @@ export class CacheDataClient<
   private async sendSortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string
+    value: string,
+    order?: SortedSetOrder
   ): Promise<CacheSortedSetGetRank.Response> {
+    const protoBufOrder =
+      order === SortedSetOrder.Descending
+        ? _SortedSetGetRankRequest.Order.DESCENDING
+        : _SortedSetGetRankRequest.Order.ASCENDING;
+
     const request = new _SortedSetGetRankRequest();
     request.setSetName(sortedSetName);
     request.setValue(value);
+    request.setOrder(protoBufOrder);
 
     return await new Promise((resolve, reject) => {
       this.clientWrapper.sortedSetGetRank(

--- a/packages/common-integration-tests/src/sorted-set.ts
+++ b/packages/common-integration-tests/src/sorted-set.ts
@@ -6,12 +6,12 @@ import {
   CacheSortedSetGetScore,
   CacheSortedSetGetScores,
   CacheSortedSetIncrementScore,
+  CacheSortedSetLength,
+  CacheSortedSetLengthByScore,
   CacheSortedSetPutElement,
   CacheSortedSetPutElements,
   CacheSortedSetRemoveElement,
   CacheSortedSetRemoveElements,
-  CacheSortedSetLength,
-  CacheSortedSetLengthByScore,
   CollectionTtl,
   MomentoErrorCode,
   SortedSetOrder,
@@ -1391,6 +1391,34 @@ export function runSortedSetTests(
           integrationTestCacheName,
           sortedSetName,
           'foo'
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        hitResult = result as CacheSortedSetGetRank.Hit;
+        expect(hitResult.rank()).toEqual(0);
+
+        result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
+          sortedSetName,
+          'foo',
+          {
+            order: SortedSetOrder.Descending,
+          }
+        );
+        expectWithMessage(() => {
+          expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);
+        }, `expected HIT but got ${result.toString()}`);
+        hitResult = result as CacheSortedSetGetRank.Hit;
+        expect(hitResult.rank()).toEqual(2);
+
+        result = await cacheClient.sortedSetGetRank(
+          integrationTestCacheName,
+          sortedSetName,
+          'foo',
+          {
+            order: SortedSetOrder.Ascending,
+          }
         );
         expectWithMessage(() => {
           expect(result).toBeInstanceOf(CacheSortedSetGetRank.Hit);

--- a/packages/core/src/clients/ICacheClient.ts
+++ b/packages/core/src/clients/ICacheClient.ts
@@ -70,6 +70,7 @@ import {
   SortedSetFetchByRankCallOptions,
   SortedSetFetchByScoreCallOptions,
   SortedSetLengthByScoreCallOptions,
+  SortedSetGetRankCallOptions,
   SetCallOptions,
   GetCallOptions,
   SetIfAbsentCallOptions,
@@ -104,6 +105,7 @@ export type SortedSetPutElementOptions = CollectionCallOptions;
 export type SortedSetPutElementsOptions = CollectionCallOptions;
 export type SortedSetFetchByRankOptions = SortedSetFetchByRankCallOptions;
 export type SortedSetFetchByScoreOptions = SortedSetFetchByScoreCallOptions;
+export type SortedSetGetRankOptions = SortedSetGetRankCallOptions;
 export type SortedSetIncrementOptions = CollectionCallOptions;
 export type SortedSetLengthByScoreOptions = SortedSetLengthByScoreCallOptions;
 
@@ -370,7 +372,8 @@ export interface ICacheClient extends IControlClient, IPingClient {
   sortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string | Uint8Array
+    value: string | Uint8Array,
+    options?: SortedSetGetRankOptions
   ): Promise<CacheSortedSetGetRank.Response>;
   sortedSetGetScore(
     cacheName: string,

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -1416,7 +1416,7 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} sortedSetName - The sorted set to fetch from.
    * @param {string | Uint8Array} value - The value of the element whose rank we are retrieving.
    * @param {SortedSetGetRankOptions} options
-   * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
+   * @param {SortedSetOrder} [options.order] - The order in which sorted set will be sorted to determine the rank.
    * Defaults to ascending.
    * @returns {Promise<CacheSortedSetGetRank.Response>}
    * {@link CacheSortedSetGetRank.Hit} containing the rank of the requested elements when found.

--- a/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
+++ b/packages/core/src/internal/clients/cache/AbstractCacheClient.ts
@@ -95,6 +95,7 @@ import {
   SortedSetPutElementOptions,
   SortedSetPutElementsOptions,
   SortedSetFetchByScoreOptions,
+  SortedSetGetRankOptions,
   SortedSetIncrementOptions,
   SortedSetLengthByScoreOptions,
   SetBatchOptions,
@@ -1414,6 +1415,9 @@ export abstract class AbstractCacheClient implements ICacheClient {
    * @param {string} cacheName - The cache containing the sorted set.
    * @param {string} sortedSetName - The sorted set to fetch from.
    * @param {string | Uint8Array} value - The value of the element whose rank we are retrieving.
+   * @param {SortedSetGetRankOptions} options
+   * @param {SortedSetOrder} [options.order] - The order to fetch the elements in.
+   * Defaults to ascending.
    * @returns {Promise<CacheSortedSetGetRank.Response>}
    * {@link CacheSortedSetGetRank.Hit} containing the rank of the requested elements when found.
    * {@link CacheSortedSetGetRank.Miss} when the element does not exist.
@@ -1422,10 +1426,16 @@ export abstract class AbstractCacheClient implements ICacheClient {
   public async sortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string | Uint8Array
+    value: string | Uint8Array,
+    options?: SortedSetGetRankOptions
   ): Promise<CacheSortedSetGetRank.Response> {
     const client = this.getNextDataClient();
-    return await client.sortedSetGetRank(cacheName, sortedSetName, value);
+    return await client.sortedSetGetRank(
+      cacheName,
+      sortedSetName,
+      value,
+      options?.order
+    );
   }
 
   /**

--- a/packages/core/src/internal/clients/cache/IDataClient.ts
+++ b/packages/core/src/internal/clients/cache/IDataClient.ts
@@ -330,7 +330,8 @@ export interface IDataClient {
   sortedSetGetRank(
     cacheName: string,
     sortedSetName: string,
-    value: string | Uint8Array
+    value: string | Uint8Array,
+    order?: SortedSetOrder
   ): Promise<CacheSortedSetGetRank.Response>;
   sortedSetGetScore(
     cacheName: string,

--- a/packages/core/src/utils/cache-call-options.ts
+++ b/packages/core/src/utils/cache-call-options.ts
@@ -123,6 +123,14 @@ export interface SortedSetFetchByScoreCallOptions {
   count?: number;
 }
 
+export interface SortedSetGetRankCallOptions {
+  /**
+   * The order in which sorted set will be sorted to determine the rank.
+   * If the order is not specified, then ascending order is used.
+   */
+  order?: SortedSetOrder;
+}
+
 export interface SortedSetLengthByScoreCallOptions {
   /**
    * The minimum score of the elements to include when counting number of items in the set, inclusive.


### PR DESCRIPTION
Currently for `sortedSetGetRank` we only support fetching in `Ascending` order.
```Typescript
await momento.sortedSetGetRank('my-cache', 'my-sorted-set', 'my-element');
```

This PR adds optional call options to `sortedSetGetRank` to sort the sorted set by `Descending` or `Ascending` order when determining the rank of the passed element.
So can call like this now:
```typescript
await momento.sortedSetGetRank('my-cache', 'my-sorted-set', 'my-element', {
    order: SortedSetOrder.Descending
});
```
