### PR TITLE
chore: add web and nodejs sdk makefiles

### DIFF
--- a/packages/client-sdk-nodejs/Makefile
+++ b/packages/client-sdk-nodejs/Makefile
@@ -1,0 +1,26 @@
+.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service
+
+
+test-auth-service:
+	@echo "Testing auth service..."
+	@npm run integration-test-auth
+
+
+test-cache-service:
+	@echo "Testing cache service..."
+	@npm run integration-test-cache
+
+
+test-leaderboard-service:
+	@echo "Testing leaderboard service..."
+	@npm run integration-test-leaderboard
+
+
+test-storage-service:
+	@echo "Testing storage service..."
+	@npm run integration-test-storage
+
+
+test-topics-service:
+	@echo "Testing topics service..."
+	@npm run integration-test-topics

--- a/packages/client-sdk-web/Makefile
+++ b/packages/client-sdk-web/Makefile
@@ -1,0 +1,26 @@
+.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service
+
+
+test-auth-service:
+	@echo "Testing auth service..."
+	@npm run integration-test-auth
+
+
+test-cache-service:
+	@echo "Testing cache service..."
+	@npm run integration-test-cache
+
+
+test-leaderboard-service:
+	@echo "Testing leaderboard service..."
+	@npm run integration-test-leaderboard
+
+
+test-storage-service:
+	@echo "Testing storage service..."
+	@npm run integration-test-storage
+
+
+test-topics-service:
+	@echo "Testing topics service..."
+	@npm run integration-test-topics


### PR DESCRIPTION
In order to standardize testing from the canaries, we add makefiles
with the standard per-service target names.
