### PR TITLE
chore: increase topics reconnect delay to 500ms

### DIFF
--- a/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
+++ b/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
@@ -260,7 +260,7 @@ export abstract class AbstractPubsubClient<TGrpcError>
     // transparently restart the stream instead of propagating an error.
     if (shouldReconnectSubscription) {
       options.restartedDueToError = true;
-      const reconnectDelayMillis = 5000;
+      const reconnectDelayMillis = 500;
       this.logger.trace(
         'Error occurred on subscription, possibly a network interruption. Will attempt to restart stream in %s ms.',
         reconnectDelayMillis

--- a/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
+++ b/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts
@@ -260,7 +260,7 @@ export abstract class AbstractPubsubClient<TGrpcError>
     // transparently restart the stream instead of propagating an error.
     if (shouldReconnectSubscription) {
       options.restartedDueToError = true;
-      const reconnectDelayMillis = 100;
+      const reconnectDelayMillis = 5000;
       this.logger.trace(
         'Error occurred on subscription, possibly a network interruption. Will attempt to restart stream in %s ms.',
         reconnectDelayMillis


### PR DESCRIPTION
~~Previously, discontinuities were never shown. Increases the delay for attempting to reconnect to 5 seconds to match the go sdk, which did show discontinuities after resubscribing.~~

~~I think increasing the delay gives the server a little more breathing room to figure out that a reconnect had occurred and to send a discontinuity message to indicate the stream may have been interrupted.~~

Just increases delay for resubscribing to 500ms.
Discontinuities will be seen for network interruptions longer than the server message buffer (currently 5s).
