### PR TITLE
chore: add getItemTtl to sortedSetPutElement failing test

### DIFF
--- a/packages/common-integration-tests/src/cache/dictionary.ts
+++ b/packages/common-integration-tests/src/cache/dictionary.ts
@@ -152,7 +152,7 @@ export function runDictionaryTests(
           ttl: CollectionTtl.of(timeout * 10).withNoRefreshTtlOnUpdates(),
         });
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
-        await sleep(timeout * 1000);
+        await sleep(timeout * 1000 + 1);
 
         const getResponse = await cacheClient.dictionaryGetField(
           integrationTestCacheName,

--- a/packages/common-integration-tests/src/cache/sorted-set.ts
+++ b/packages/common-integration-tests/src/cache/sorted-set.ts
@@ -2391,7 +2391,6 @@ export function runSortedSetTests(
       };
 
       const changeResponder = (props: ValidateSortedSetChangerProps) => {
-        console.log('props.ttl', props.ttl);
         return cacheClient.sortedSetPutElements(
           props.cacheName,
           props.sortedSetName,

--- a/packages/common-integration-tests/src/cache/sorted-set.ts
+++ b/packages/common-integration-tests/src/cache/sorted-set.ts
@@ -1,7 +1,6 @@
 import {v4} from 'uuid';
 import {
   CacheDelete,
-  CacheItemGetTtl,
   CacheSortedSetFetch,
   CacheSortedSetGetRank,
   CacheSortedSetGetScore,
@@ -109,15 +108,7 @@ export function runSortedSetTests(
           ttl: CollectionTtl.of(timeout * 10).withNoRefreshTtlOnUpdates(),
         });
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
-        await sleep(timeout * 1000);
-        const getItemTTLResponse = await cacheClient.itemGetTtl(
-          integrationTestCacheName,
-          sortedSetName
-        );
-        expectWithMessage(() => {
-          expect(getItemTTLResponse).toBeInstanceOf(CacheItemGetTtl.Miss);
-        }, `expected MISS but got ${getItemTTLResponse.toString()}`);
-
+        await sleep(timeout * 1000 + 1);
         const getResponse = await cacheClient.sortedSetFetchByRank(
           integrationTestCacheName,
           sortedSetName
@@ -2400,6 +2391,7 @@ export function runSortedSetTests(
       };
 
       const changeResponder = (props: ValidateSortedSetChangerProps) => {
+        console.log('props.ttl', props.ttl);
         return cacheClient.sortedSetPutElements(
           props.cacheName,
           props.sortedSetName,

--- a/packages/common-integration-tests/src/cache/sorted-set.ts
+++ b/packages/common-integration-tests/src/cache/sorted-set.ts
@@ -1,6 +1,7 @@
 import {v4} from 'uuid';
 import {
   CacheDelete,
+  CacheItemGetTtl,
   CacheSortedSetFetch,
   CacheSortedSetGetRank,
   CacheSortedSetGetScore,
@@ -109,6 +110,13 @@ export function runSortedSetTests(
         });
         expect((changeResponse as IResponseSuccess).is_success).toBeTrue();
         await sleep(timeout * 1000);
+        const getItemTTLResponse = await cacheClient.itemGetTtl(
+          integrationTestCacheName,
+          sortedSetName
+        );
+        expectWithMessage(() => {
+          expect(getItemTTLResponse).toBeInstanceOf(CacheItemGetTtl.Miss);
+        }, `expected MISS but got ${getItemTTLResponse.toString()}`);
 
         const getResponse = await cacheClient.sortedSetFetchByRank(
           integrationTestCacheName,


### PR DESCRIPTION
## PR Description:
The nodejs test for `sortedSetPutElements` fails on:
```
    ✘ Integration tests for sorted set operations > #sortedSetPutElements > does not refresh with no refresh ttl '(2119 ms)
     expected MISS but got Hit: valueArrayStringElements: 131ed5dd-b2da-4524-b635-be36df04f2b9: 42
     Error: expect(received).toBeInstanceOf(expected)
```

I suspect the reason is the sleep for 1 sec is not suffiient for the test. Adding 1ms to sleep timeout to avoid this from happening.

As of 09/11/24, same error occurred for dictionary tests [(dashboard link)](https://momento.chronosphere.io/dashboards/canaries?start=1h). 

```
● Integration tests for dictionary operations › #dictionarySetField › does not refresh with no refresh ttl
expected MISS but got Hit: value2
Error: expect(received).toBeInstanceOf(expected)
```

Adding 1ms to sleep timeout for dictionary tests too.