### PR TITLE
fix: add webhook request details log

### DIFF
--- a/packages/common-integration-tests/src/webhooks/webhooks.ts
+++ b/packages/common-integration-tests/src/webhooks/webhooks.ts
@@ -20,6 +20,7 @@ import {
   ITopicClient,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import {delay} from '../auth/auth-client';
+import {log} from 'console';
 
 export function runWebhookTests(
   topicClient: ITopicClient,
@@ -132,6 +133,7 @@ export function runWebhookTests(
         const details = await getWebhookRequestDetails(
           webhook.destination.url()
         );
+        log('webhook request details:', details);
         expect(details.invocationCount).toBe(1);
       });
     });


### PR DESCRIPTION
## PR Description:
The nodejs canaries failed on webhook test. It appears to be an intermittent issue. Adding log statement for debugging it more before we increase the timeout on get the webhook details. 

<img width="1168" alt="Screenshot 2024-09-12 at 12 57 17 PM" src="https://github.com/user-attachments/assets/68ff15b8-ee27-4c2e-8dad-8453b60504ce">
