### PR TITLE
feat: optional config object for topic, auth, storage, leaderboard clients

### DIFF
--- a/packages/client-sdk-nodejs/src/auth-client.ts
+++ b/packages/client-sdk-nodejs/src/auth-client.ts
@@ -4,16 +4,28 @@ import {AbstractAuthClient} from '@gomomento/sdk-core/dist/src/internal/clients/
 import {AuthClientProps} from './auth-client-props';
 import {AuthClientAllProps} from './internal/auth-client-all-props';
 import {getDefaultCredentialProvider} from '@gomomento/sdk-core';
+import {AuthClientConfiguration, AuthClientConfigurations} from '.';
 
 export class AuthClient extends AbstractAuthClient implements IAuthClient {
-  constructor(props: AuthClientProps) {
+  constructor(props?: AuthClientProps) {
     const allProps: AuthClientAllProps = {
       ...props,
+      configuration:
+        props?.configuration ?? getDefaultAuthClientConfiguration(),
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
     const authClient = new InternalAuthClient(allProps);
 
     super({createAuthClient: () => authClient});
   }
+}
+
+function getDefaultAuthClientConfiguration(): AuthClientConfiguration {
+  const config = AuthClientConfigurations.Default.latest();
+  const logger = config.getLoggerFactory().getLogger('AuthClient');
+  logger.info(
+    'No configuration provided to AuthClient. Using latest "Default" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }

--- a/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-leaderboard-client.ts
@@ -25,13 +25,13 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
   private readonly dataClient: ILeaderboardDataClient;
   private readonly configuration: LeaderboardConfiguration;
 
-  constructor(props: LeaderboardClientProps) {
+  constructor(props?: LeaderboardClientProps) {
     const configuration =
-      props.configuration ?? getDefaultLeaderboardConfiguration();
+      props?.configuration ?? getDefaultLeaderboardConfiguration();
     const allProps: LeaderboardClientAllProps = {
       configuration: configuration,
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
     this.configuration = configuration;
 
@@ -70,5 +70,10 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
 }
 
 function getDefaultLeaderboardConfiguration(): LeaderboardConfiguration {
-  return LeaderboardConfigurations.Laptop.latest();
+  const config = LeaderboardConfigurations.Laptop.latest();
+  const logger = config.getLoggerFactory().getLogger('LeaderboardClient');
+  logger.info(
+    'No configuration provided to LeaderboardClient. Using default "Laptop" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }

--- a/packages/client-sdk-nodejs/src/preview-storage-client.ts
+++ b/packages/client-sdk-nodejs/src/preview-storage-client.ts
@@ -20,11 +20,12 @@ export class PreviewStorageClient
   extends AbstractStorageClient
   implements IStorageClient
 {
-  constructor(props: StorageClientProps) {
+  constructor(props?: StorageClientProps) {
     const allProps: StorageClientAllProps = {
-      configuration: props.configuration ?? getDefaultStorageConfiguration(),
+      configuration:
+        props?.configuration ?? getDefaultStorageClientConfiguration(),
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
 
     const controlClient: IStorageControlClient = createControlClient(allProps);
@@ -48,6 +49,11 @@ function createDataClient(props: StorageClientAllProps): IStorageDataClient {
   return new StorageDataClient(props);
 }
 
-function getDefaultStorageConfiguration(): StorageConfiguration {
-  return StorageConfigurations.Laptop.latest();
+function getDefaultStorageClientConfiguration(): StorageConfiguration {
+  const config = StorageConfigurations.Laptop.latest();
+  const logger = config.getLoggerFactory().getLogger('StorageClient');
+  logger.info(
+    'No configuration provided to StorageClient. Using default "Laptop" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }

--- a/packages/client-sdk-nodejs/src/topic-client.ts
+++ b/packages/client-sdk-nodejs/src/topic-client.ts
@@ -16,12 +16,12 @@ export class TopicClient extends AbstractTopicClient {
   /**
    * Creates an instance of TopicClient.
    */
-  constructor(props: TopicClientProps) {
+  constructor(props?: TopicClientProps) {
     const allProps: TopicClientAllProps = {
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
       configuration:
-        props.configuration ?? getDefaultTopicClientConfiguration(),
+        props?.configuration ?? getDefaultTopicClientConfiguration(),
     };
 
     const numClients = allProps.configuration
@@ -40,5 +40,10 @@ export class TopicClient extends AbstractTopicClient {
 }
 
 function getDefaultTopicClientConfiguration(): TopicConfiguration {
-  return TopicConfigurations.Default.latest();
+  const config = TopicConfigurations.Default.latest();
+  const logger = config.getLoggerFactory().getLogger('TopicClient');
+  logger.info(
+    'No configuration provided to TopicClient. Using latest "Default" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }

--- a/packages/client-sdk-web/src/auth-client.ts
+++ b/packages/client-sdk-web/src/auth-client.ts
@@ -8,12 +8,12 @@ import {AuthClientAllProps} from './internal/auth-client-all-props';
 import {getDefaultCredentialProvider} from '@gomomento/sdk-core';
 
 export class AuthClient extends AbstractAuthClient {
-  constructor(props: AuthClientProps) {
+  constructor(props?: AuthClientProps) {
     const createAuthClient = (): IAuthClient => {
       const allProps: AuthClientAllProps = {
         ...props,
         credentialProvider:
-          props.credentialProvider ?? getDefaultCredentialProvider(),
+          props?.credentialProvider ?? getDefaultCredentialProvider(),
       };
       return new InternalWebGrpcAuthClient(allProps);
     };

--- a/packages/client-sdk-web/src/preview-leaderboard-client.ts
+++ b/packages/client-sdk-web/src/preview-leaderboard-client.ts
@@ -23,12 +23,12 @@ import {LeaderboardClientAllProps} from './internal/leaderboard-client-all-props
 export class PreviewLeaderboardClient implements ILeaderboardClient {
   private dataClient: ILeaderboardDataClient;
 
-  constructor(props: LeaderboardClientProps) {
+  constructor(props?: LeaderboardClientProps) {
     const allProps: LeaderboardClientAllProps = {
       configuration:
-        props.configuration ?? getDefaultLeaderboardConfiguration(),
+        props?.configuration ?? getDefaultLeaderboardConfiguration(),
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
     this.dataClient = new LeaderboardDataClient(allProps);
   }
@@ -46,5 +46,10 @@ export class PreviewLeaderboardClient implements ILeaderboardClient {
 }
 
 function getDefaultLeaderboardConfiguration(): LeaderboardConfiguration {
-  return LeaderboardConfigurations.Laptop.latest();
+  const config = LeaderboardConfigurations.Laptop.latest();
+  const logger = config.getLoggerFactory().getLogger('LeaderboardClient');
+  logger.info(
+    'No configuration provided to LeaderboardClient. Using default "Laptop" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }

--- a/packages/client-sdk-web/src/preview-storage-client.ts
+++ b/packages/client-sdk-web/src/preview-storage-client.ts
@@ -20,12 +20,12 @@ export class PreviewStorageClient
 {
   private readonly _configuration: StorageConfiguration;
 
-  constructor(props: StorageClientProps) {
+  constructor(props?: StorageClientProps) {
     const allProps: StorageClientAllProps = {
       configuration:
-        props.configuration ?? getDefaultStorageClientConfiguration(),
+        props?.configuration ?? getDefaultStorageClientConfiguration(),
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
     const controlClient: IStorageControlClient = createControlClient(allProps);
     const dataClient: IStorageDataClient = createDataClient(allProps);
@@ -63,7 +63,7 @@ function getDefaultStorageClientConfiguration(): StorageConfiguration {
   const config = StorageConfigurations.Default.latest();
   const logger = config.getLoggerFactory().getLogger('StorageClient');
   logger.info(
-    'No configuration provided to StorageClient. Using default configuration. For production use, consider specifying an explicit configuration.'
+    'No configuration provided to StorageClient. Using latest "Default" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
   );
   return config;
 }

--- a/packages/client-sdk-web/src/topic-client.ts
+++ b/packages/client-sdk-web/src/topic-client.ts
@@ -15,13 +15,13 @@ export class TopicClient extends AbstractTopicClient {
   /**
    * Creates an instance of TopicClient.
    */
-  constructor(props: TopicClientProps) {
+  constructor(props?: TopicClientProps) {
     const configuration =
-      props.configuration ?? getDefaultTopicClientConfiguration();
+      props?.configuration ?? getDefaultTopicClientConfiguration();
     const allProps: TopicClientAllProps = {
       configuration: configuration,
       credentialProvider:
-        props.credentialProvider ?? getDefaultCredentialProvider(),
+        props?.credentialProvider ?? getDefaultCredentialProvider(),
     };
 
     super(
@@ -34,5 +34,10 @@ export class TopicClient extends AbstractTopicClient {
 }
 
 function getDefaultTopicClientConfiguration(): TopicConfiguration {
-  return TopicConfigurations.Default.latest();
+  const config = TopicConfigurations.Default.latest();
+  const logger = config.getLoggerFactory().getLogger('TopicClient');
+  logger.info(
+    'No configuration provided to TopicClient. Using latest "Default" configuration, suitable for development. For production use, consider specifying an explicit configuration.'
+  );
+  return config;
 }


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1035

Only the CacheClient requires a config value for default TTL. All other clients have optional config options, so the entire config object can be made optional.

```typescript
const topicClient = new TopicClient();

// instead of 

const topicClient = new TopicClient({});
```

Will follow up with updates to docs/examples