### PR TITLE
test: add negative test to detect replication failures

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/shared/cache/replica-reads.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/shared/cache/replica-reads.test.ts
@@ -1,0 +1,10 @@
+import {runReplicaReadTests} from '@gomomento/common-integration-tests';
+import {SetupIntegrationTest} from '../../integration-setup';
+
+const {cacheClientWithBalancedReadConcern, integrationTestCacheName} =
+  SetupIntegrationTest();
+
+runReplicaReadTests(
+  cacheClientWithBalancedReadConcern,
+  integrationTestCacheName
+);

--- a/packages/client-sdk-web/test/integration/shared/cache/replica-reads.test.ts
+++ b/packages/client-sdk-web/test/integration/shared/cache/replica-reads.test.ts
@@ -1,0 +1,10 @@
+import {runReplicaReadTests} from '@gomomento/common-integration-tests';
+import {SetupIntegrationTest} from '../../integration-setup';
+
+const {cacheClientWithBalancedReadConcern, integrationTestCacheName} =
+  SetupIntegrationTest();
+
+runReplicaReadTests(
+  cacheClientWithBalancedReadConcern,
+  integrationTestCacheName
+);

--- a/packages/common-integration-tests/src/cache/replica-reads.ts
+++ b/packages/common-integration-tests/src/cache/replica-reads.ts
@@ -15,43 +15,44 @@ export function runReplicaReadTests(
       const replicationDelayMs = 1000;
       const trials = [];
 
+      const trialFn = async (trialNumber: number) => {
+        // Start this trial at it's own time plus a random delay
+        const startDelay =
+          trialNumber * delayBetweenTrials + (Math.random() - 0.5) * 10;
+        await new Promise(resolve => setTimeout(resolve, startDelay));
+
+        const cacheKey = v4();
+        const cacheValue = v4();
+
+        // Perform a set operation
+        const setResponse = await client.set(
+          integrationTestCacheName,
+          cacheKey,
+          cacheValue
+        );
+        expectWithMessage(() => {
+          expect(setResponse).toBeInstanceOf(CacheSet.Success);
+        }, `expected SUCCESS but got ${setResponse.toString()}`);
+
+        // Wait for replication to complete
+        await new Promise(resolve => setTimeout(resolve, replicationDelayMs));
+
+        // Verify that the value can be read
+        const getResponse = await client.get(
+          integrationTestCacheName,
+          cacheKey
+        );
+        expectWithMessage(() => {
+          expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+        }, `expected HIT but got ${getResponse.toString()}`);
+
+        expectWithMessage(() => {
+          expect(getResponse.value()).toEqual(cacheValue);
+        }, `expected ${cacheValue} but got ${getResponse.value() ?? 'undefined'}`);
+      };
+
       for (let i = 0; i < numTrials; i++) {
-        const trialPromise = (async () => {
-          // Start this trial at it's own time plus a random delay
-          const startDelay =
-            i * delayBetweenTrials + (Math.random() - 0.5) * 10;
-          await new Promise(resolve => setTimeout(resolve, startDelay));
-
-          const cacheKey = v4();
-          const cacheValue = v4();
-
-          // Perform a set operation
-          const setResponse = await client.set(
-            integrationTestCacheName,
-            cacheKey,
-            cacheValue
-          );
-          expectWithMessage(() => {
-            expect(setResponse).toBeInstanceOf(CacheSet.Success);
-          }, `expected SUCCESS but got ${setResponse.toString()}`);
-
-          // Wait for replication to complete
-          await new Promise(resolve => setTimeout(resolve, replicationDelayMs));
-
-          // Verify that the value can be read
-          const getResponse = await client.get(
-            integrationTestCacheName,
-            cacheKey
-          );
-          expectWithMessage(() => {
-            expect(getResponse).toBeInstanceOf(CacheGet.Hit);
-          }, `expected HIT but got ${getResponse.toString()}`);
-
-          expectWithMessage(() => {
-            expect(getResponse.value()).toEqual(cacheValue);
-          }, `expected ${cacheValue} but got ${getResponse.value() ?? 'undefined'}`);
-        })();
-        trials.push(trialPromise);
+        trials.push(trialFn(i));
       }
 
       await Promise.all(trials);

--- a/packages/common-integration-tests/src/cache/replica-reads.ts
+++ b/packages/common-integration-tests/src/cache/replica-reads.ts
@@ -47,11 +47,9 @@ export function runReplicaReadTests(
             expect(getResponse).toBeInstanceOf(CacheGet.Hit);
           }, `expected HIT but got ${getResponse.toString()}`);
 
-          if (getResponse instanceof CacheGet.Hit) {
-            expectWithMessage(() => {
-              expect(getResponse.valueString()).toEqual(cacheValue);
-            }, `expected ${cacheValue} but got ${getResponse.valueString()}`);
-          }
+          expectWithMessage(() => {
+            expect(getResponse.value()).toEqual(cacheValue);
+          }, `expected ${cacheValue} but got ${getResponse.value() ?? 'undefined'}`);
         })();
         trials.push(trialPromise);
       }

--- a/packages/common-integration-tests/src/cache/replica-reads.ts
+++ b/packages/common-integration-tests/src/cache/replica-reads.ts
@@ -1,0 +1,62 @@
+import {v4} from 'uuid';
+import {CacheGet, CacheSet} from '@gomomento/sdk-core';
+import {expectWithMessage} from '../common-int-test-utils';
+import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
+
+export function runReplicaReadTests(
+  cacheClientWithBalancedReadConcern: ICacheClient,
+  integrationTestCacheName: string
+) {
+  describe('Replica Read Tests', () => {
+    it('should read the latest value after replication delay using balanced read concern', async () => {
+      const client = cacheClientWithBalancedReadConcern;
+      const numTrials = 10;
+      const delayBetweenTrials = 100;
+      const replicationDelayMs = 1000;
+      const trials = [];
+
+      for (let i = 0; i < numTrials; i++) {
+        const trialPromise = (async () => {
+          // Start this trial at it's own time plus a random delay
+          const startDelay =
+            i * delayBetweenTrials + (Math.random() - 0.5) * 10;
+          await new Promise(resolve => setTimeout(resolve, startDelay));
+
+          const cacheKey = v4();
+          const cacheValue = v4();
+
+          // Perform a set operation
+          const setResponse = await client.set(
+            integrationTestCacheName,
+            cacheKey,
+            cacheValue
+          );
+          expectWithMessage(() => {
+            expect(setResponse).toBeInstanceOf(CacheSet.Success);
+          }, `expected SUCCESS but got ${setResponse.toString()}`);
+
+          // Wait for the replication SLA period to exceed
+          await new Promise(resolve => setTimeout(resolve, replicationDelayMs));
+
+          // Perform a get operation
+          const getResponse = await client.get(
+            integrationTestCacheName,
+            cacheKey
+          );
+          expectWithMessage(() => {
+            expect(getResponse).toBeInstanceOf(CacheGet.Hit);
+          }, `expected HIT but got ${getResponse.toString()}`);
+
+          if (getResponse instanceof CacheGet.Hit) {
+            expectWithMessage(() => {
+              expect(getResponse.valueString()).toEqual(cacheValue);
+            }, `expected ${cacheValue} but got ${getResponse.valueString()}`);
+          }
+        })();
+        trials.push(trialPromise);
+      }
+
+      await Promise.all(trials);
+    });
+  });
+}

--- a/packages/common-integration-tests/src/cache/replica-reads.ts
+++ b/packages/common-integration-tests/src/cache/replica-reads.ts
@@ -35,10 +35,10 @@ export function runReplicaReadTests(
             expect(setResponse).toBeInstanceOf(CacheSet.Success);
           }, `expected SUCCESS but got ${setResponse.toString()}`);
 
-          // Wait for the replication SLA period to exceed
+          // Wait for replication to complete
           await new Promise(resolve => setTimeout(resolve, replicationDelayMs));
 
-          // Perform a get operation
+          // Verify that the value can be read
           const getResponse = await client.get(
             integrationTestCacheName,
             cacheKey

--- a/packages/common-integration-tests/src/index.ts
+++ b/packages/common-integration-tests/src/index.ts
@@ -14,4 +14,5 @@ export * from './cache/update-ttl';
 export * from './leaderboard/leaderboard-client';
 export * from './webhooks/webhooks';
 export * from './cache/batch-get-set';
+export * from './cache/replica-reads';
 export * from './storage/storage';


### PR DESCRIPTION
Previously, our integration tests were written assuming consistent
reads. To avoid false positives caused by stale reads in low-latency
environments, we enforced consistent reads by setting the consistent
read header. While this reduced noise from false positives, it also
meant we lacked test coverage for replica reads and replication behavior.

To address this gap, we've added a negative test that detects
replication failures by verifying that no stale reads occur after the
expected replication delay.

The new test suite `replica-reads` implements a test that runs 10
trials in parallel. Each trial performs the following steps:
- Set: Writes a random key-value pair to the cache
- Wait: 1 second for reads to propagate
- Get: Reads the value for the key using `cacheClientWithBalancedReadConcern`.
- Assert: Confirms that the retrieved value matches the value set
earlier.

Trials are started with slight delays between them to distribute
load (delayBetweenTrials and a small random offset).
