### PR TITLE
chore: clarify limit exceeded in resource exhausted errors

### DIFF
--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -117,7 +117,7 @@ export class CacheServiceErrorMapper
       case Status.UNAUTHENTICATED:
         return new AuthenticationError(...errParams);
       case Status.RESOURCE_EXHAUSTED: {
-        const errCause = errParams[2]?.get('err')?.[0].toString();
+        const errCause = errParams[2]?.get('err')?.[0]?.toString();
         return new LimitExceededError(...errParams, errCause);
       }
       case Status.ALREADY_EXISTS: {

--- a/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-nodejs/src/errors/cache-service-error-mapper.ts
@@ -116,8 +116,10 @@ export class CacheServiceErrorMapper
         return new TimeoutError(...errParams);
       case Status.UNAUTHENTICATED:
         return new AuthenticationError(...errParams);
-      case Status.RESOURCE_EXHAUSTED:
-        return new LimitExceededError(...errParams);
+      case Status.RESOURCE_EXHAUSTED: {
+        const errCause = errParams[2]?.get('err')?.[0].toString();
+        return new LimitExceededError(...errParams, errCause);
+      }
       case Status.ALREADY_EXISTS: {
         let errCause = errParams[2]?.get('err')?.[0];
         // TODO: Remove this once the error message is standardized on the server side

--- a/packages/client-sdk-nodejs/test/integration/cache/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache/large-messages.test.ts
@@ -43,4 +43,22 @@ describe('CacheClient', () => {
       expect(responseValue).toEqual(value);
     }, `expected 5mb retrieved string to match 5mb value that was set for key ${key}`);
   });
+
+  it('should fail with RESOURCE_EXHAUSTED_ERROR when setting a value greater than 5mb', async () => {
+    const cacheKey = v4();
+    const cacheValue = 'x'.repeat(5_300_000);
+    const setResponse = await cacheClient.set(
+      integrationTestCacheName,
+      cacheKey,
+      cacheValue
+    );
+    const stringifiedSetResponse = setResponse.toString();
+    expectWithMessage(() => {
+      expect(setResponse).toBeInstanceOf(CacheSet.Error);
+    }, `expected ERROR but got ${stringifiedSetResponse}`);
+    expect(stringifiedSetResponse).toInclude('RESOURCE_EXHAUSTED');
+    expect(stringifiedSetResponse).toInclude(
+      'Request size limit exceeded for this account'
+    );
+  });
 });

--- a/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
+++ b/packages/client-sdk-web/src/errors/cache-service-error-mapper.ts
@@ -112,8 +112,11 @@ export class CacheServiceErrorMapper
         return new TimeoutError(...errParams);
       case StatusCode.UNAUTHENTICATED:
         return new AuthenticationError(...errParams);
-      case StatusCode.RESOURCE_EXHAUSTED:
-        return new LimitExceededError(...errParams);
+      case StatusCode.RESOURCE_EXHAUSTED: {
+        const meta = errParams[2] ?? {};
+        const errCause = meta['err'];
+        return new LimitExceededError(...errParams, errCause);
+      }
       case StatusCode.ALREADY_EXISTS: {
         let errCause = '';
         // TODO: Remove this once the error message is standardized on the server side


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/982

Removes the confusing preamble from the RESOURCE_EXHAUSTED error message. Makes more clear which limit was exceeded if that information is available in the grpc error details or `err` metadata field. 

Using the `err` metadata is preferred so that we don't rely on basic string matching if possible as error details can change any time in the future.

If all else fails, we return a generic error message: `'Limit exceeded for this account'`