### PR TITLE
feat: support topics sequence page

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.113.0",
+        "@gomomento/generated-types": "0.119.2",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.10.9",
         "@types/google-protobuf": "3.15.10",
@@ -43,6 +43,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -75,6 +76,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -810,9 +812,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.113.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.113.0.tgz",
-      "integrity": "sha512-7DJdcNWzCT5dpp1W+Vb77RZfamCt/SbtvoOcDtSDVU/wAsK7y7Yeo88DkgqiD2sCHv/u5X3wgLye51dlCsbgDw==",
+      "version": "0.119.2",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.119.2.tgz",
+      "integrity": "sha512-pt/yBiz1CdLPWQnBt/Liv2dzT2XGW3kHswVxrFdd2EUhy0uh+mfUM4AmWkSq3/cvip7novkvZ0JzWeow42RauA==",
       "dependencies": {
         "@grpc/grpc-js": "1.10.9",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -58,7 +58,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.113.0",
+    "@gomomento/generated-types": "0.119.2",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.10.9",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.113.0",
+        "@gomomento/generated-types-webtext": "0.119.2",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -45,6 +45,7 @@
       }
     },
     "../common-integration-tests": {
+      "name": "@gomomento/common-integration-tests",
       "version": "0.0.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -77,6 +78,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -812,9 +814,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.113.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.113.0.tgz",
-      "integrity": "sha512-+g7WyDyaakP9T+5nw0pYNQ5INuLGNmr0uzdX9bEeEpwFd2pDrPxFP6HBfvSOD1HJ+4tuUhc2mAA3/kQ5el7xhA==",
+      "version": "0.119.2",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.119.2.tgz",
+      "integrity": "sha512-Sxq1/JqnVe3IwOEhUTtXLtIoGV8tkAgVrNgHQJRu0F6h+ZZpvTfuB0kW+xq0uRVLSeZfDCQiH3bJsaezLVg+ug==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -63,7 +63,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.113.0",
+    "@gomomento/generated-types-webtext": "0.119.2",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",

--- a/packages/client-sdk-web/src/index.ts
+++ b/packages/client-sdk-web/src/index.ts
@@ -76,6 +76,7 @@ import * as CacheSetBatch from '@gomomento/sdk-core/dist/src/messages/responses/
 import * as TopicPublish from '@gomomento/sdk-core/dist/src/messages/responses/topic-publish';
 import * as TopicSubscribe from '@gomomento/sdk-core/dist/src/messages/responses/topic-subscribe';
 import {TopicItem} from '@gomomento/sdk-core/dist/src/messages/responses/topic-item';
+import {TopicDiscontinuity} from '@gomomento/sdk-core/dist/src/messages/responses/topic-discontinuity';
 
 // AuthClient Response Types
 import * as GenerateApiKey from '@gomomento/sdk-core/dist/src/messages/responses/generate-api-key';
@@ -284,6 +285,7 @@ export {
   TopicClientConfiguration,
   TopicClient,
   TopicItem,
+  TopicDiscontinuity,
   TopicPublish,
   TopicSubscribe,
   SubscribeCallOptions,

--- a/packages/core/src/internal/subscription-state.ts
+++ b/packages/core/src/internal/subscription-state.ts
@@ -17,6 +17,10 @@ export class SubscriptionState {
     return (this.lastTopicSequenceNumber ?? -1) + 1;
   }
 
+  public get resumeAtTopicSequencePage(): number {
+    return this.lastTopicSequencePage ?? 0;
+  }
+
   public setSubscribed(): void {
     this._isSubscribed = true;
   }

--- a/packages/core/src/internal/subscription-state.ts
+++ b/packages/core/src/internal/subscription-state.ts
@@ -4,6 +4,7 @@
 export class SubscriptionState {
   private _unsubscribeFn: () => void;
   public lastTopicSequenceNumber?: number;
+  public lastTopicSequencePage?: number;
   private _isSubscribed: boolean;
   constructor() {
     this._unsubscribeFn = () => {
@@ -43,6 +44,7 @@ export class SubscriptionState {
     return JSON.stringify(
       {
         lastTopicSequenceNumber: this.lastTopicSequenceNumber,
+        lastTopicSequencePage: this.lastTopicSequencePage,
         isSubscribed: this._isSubscribed,
       },
       null,

--- a/packages/core/src/messages/responses/topic-discontinuity.ts
+++ b/packages/core/src/messages/responses/topic-discontinuity.ts
@@ -43,7 +43,7 @@ export class TopicDiscontinuity {
   }
 
   public toString(): string {
-    const displayValue = `Last Sequence Number: ${this._lastSequenceNumber}; New Sequence Number: ${this._newSequenceNumber}`;
+    const displayValue = `Last Sequence Number: ${this._lastSequenceNumber}; New Sequence Number: ${this._newSequenceNumber}; New Sequence Page: ${this._newSequencePage}`;
     return `${this.constructor.name}: ${displayValue}`;
   }
 }

--- a/packages/core/src/messages/responses/topic-discontinuity.ts
+++ b/packages/core/src/messages/responses/topic-discontinuity.ts
@@ -6,10 +6,16 @@
 export class TopicDiscontinuity {
   private readonly _lastSequenceNumber: number;
   private readonly _newSequenceNumber: number;
+  private readonly _newSequencePage: number;
 
-  constructor(_lastSequenceNumber: number, _newSequenceNumber: number) {
+  constructor(
+    _lastSequenceNumber: number,
+    _newSequenceNumber: number,
+    _newSequencePage: number
+  ) {
     this._lastSequenceNumber = _lastSequenceNumber;
     this._newSequenceNumber = _newSequenceNumber;
+    this._newSequencePage = _newSequencePage;
   }
 
   /**
@@ -26,6 +32,14 @@ export class TopicDiscontinuity {
    */
   public newSequenceNumber(): number {
     return this._newSequenceNumber;
+  }
+
+  /**
+   * Returns the new sequence page after the discontinuity.
+   * @returns number
+   */
+  public newSequencePage(): number {
+    return this._newSequencePage;
   }
 
   public toString(): string {


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1059

Updates the topic subscription to take the sequence page into account:

- Keeps track of last known sequence page in addition to sequence number in `SubscriptionState` so we can reconnect gracefully
- Includes sequence page detail for `TopicDiscontinuity` objects

As part of this change, had to update the client-protos dependency version as well.

Tested locally to verify both node and web clients gracefully reconnect when wifi is toggled and sequence page is used to resume from the next expected sequence number.
Also tested locally and confirmed that subscribing with an initial (arbitrary) sequence page will cause a discontinuity before getting assigned a new sequence page.

Also had forgotten to export `TopicDiscontinuity` in the web sdk in a previous PR, so that was added here as well.