### PR TITLE
chore: change cancelled error message to remove the word server

### DIFF
--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -138,7 +138,7 @@ export class BadRequestError extends SdkError {
 export class CancelledError extends SdkError {
   override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
   override _messageWrapper =
-    'The request was cancelled; please contact us at support@momentohq.com';
+    'The request was cancelled; please contact us if this was unexpected at support@momentohq.com';
 }
 
 /**

--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -138,7 +138,7 @@ export class BadRequestError extends SdkError {
 export class CancelledError extends SdkError {
   override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
   override _messageWrapper =
-    'The request was cancelled, typically by the caller; please contact us at support@momentohq.com ';
+    'The request was cancelled; please contact us at support@momentohq.com ';
 }
 
 /**

--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -138,7 +138,7 @@ export class BadRequestError extends SdkError {
 export class CancelledError extends SdkError {
   override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
   override _messageWrapper =
-    'The request was cancelled by the server; please contact us at support@momentohq.com';
+    'The request was cancelled; please contact us at support@momentohq.com';
 }
 
 /**

--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -138,7 +138,7 @@ export class BadRequestError extends SdkError {
 export class CancelledError extends SdkError {
   override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
   override _messageWrapper =
-    'The request was cancelled; please contact us at support@momentohq.com ';
+    'The request was cancelled; please contact us at support@momentohq.com';
 }
 
 /**

--- a/packages/core/src/errors/errors.ts
+++ b/packages/core/src/errors/errors.ts
@@ -138,7 +138,7 @@ export class BadRequestError extends SdkError {
 export class CancelledError extends SdkError {
   override _errorCode = MomentoErrorCode.CANCELLED_ERROR;
   override _messageWrapper =
-    'The request was cancelled; please contact us at support@momentohq.com';
+    'The request was cancelled, typically by the caller; please contact us at support@momentohq.com ';
 }
 
 /**


### PR DESCRIPTION
Changing cancelled error messages. Went back and forth on the message, and made it simple to say was `cancelled` without assigning the "blame" to anyone. Although gRPC [status code](https://grpc.io/docs/guides/status-codes/) says `The operation was cancelled, typically by the caller.`