### PR TITLE
chore: add http api tests to makefile

### DIFF
--- a/packages/client-sdk-nodejs/Makefile
+++ b/packages/client-sdk-nodejs/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service
+.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service test-http-service
 
 
 test-auth-service:
@@ -24,3 +24,7 @@ test-storage-service:
 test-topics-service:
 	@echo "Testing topics service..."
 	@npm run integration-test-topics
+
+test-http-service:
+	@echo "Testing http service..."
+	@npm run integration-test-http

--- a/packages/client-sdk-web/Makefile
+++ b/packages/client-sdk-web/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service
+.PHONY: test-auth-service test-cache-service test-leaderboard-service test-storage-service test-topics-service test-http-service
 
 
 test-auth-service:
@@ -24,3 +24,7 @@ test-storage-service:
 test-topics-service:
 	@echo "Testing topics service..."
 	@npm run integration-test-topics
+
+test-http-service:
+	@echo "Testing http service..."
+	@npm run integration-test-http


### PR DESCRIPTION
## PR Description:
To add http api tests to canaries, we use the make file base bath defined here: https://github.com/momentohq/canaries-kitchensink/blob/main/canaries/sdk-canary/index.ts#L79-L88. 

Therefore, this commit adds http-tests to makefile for both nodejs and web sdks

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1068