### PR TITLE
chore: centralize default ttl and milliseconds conversion

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-control-client.ts
@@ -23,6 +23,7 @@ import {
   TopicLimits,
 } from '@gomomento/sdk-core/dist/src/messages/cache-info';
 import {RetryInterceptor} from './grpc/retry-interceptor';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export interface ControlClientProps {
   configuration: Configuration;
@@ -32,7 +33,8 @@ export interface ControlClientProps {
 export class CacheControlClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcControl.ScsControlClient>;
   private readonly interceptors: Interceptor[];
-  private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
+  private static readonly REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(60);
   private readonly logger: MomentoLogger;
   private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
 

--- a/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/internal-auth-client.ts
@@ -59,9 +59,11 @@ import {
 import {RetryInterceptor} from './grpc/retry-interceptor';
 import {AuthClientConfigurations} from '../index';
 import {AuthClientAllProps} from './auth-client-all-props';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export class InternalAuthClient implements IAuthClient {
-  private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
+  private static readonly REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(60);
 
   private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
   private readonly creds: CredentialProvider;

--- a/packages/client-sdk-nodejs/src/internal/ping-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/ping-client.ts
@@ -8,6 +8,7 @@ import {GrpcClientWrapper} from './grpc/grpc-client-wrapper';
 import {Configuration} from '../config/configuration';
 import {CredentialProvider, MomentoLogger} from '../';
 import {RetryInterceptor} from './grpc/retry-interceptor';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export interface PingClientProps {
   configuration: Configuration;
@@ -18,7 +19,8 @@ export interface PingClientProps {
 export class InternalNodeGrpcPingClient {
   private readonly clientWrapper: GrpcClientWrapper<grpcPing.PingClient>;
   private readonly interceptors: Interceptor[];
-  private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
+  private static readonly REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(60);
   private readonly logger: MomentoLogger;
 
   /**

--- a/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/pubsub-client.ts
@@ -27,12 +27,14 @@ import {TopicConfiguration} from '../config/topic-configuration';
 import {TopicClientAllProps} from './topic-client-all-props';
 import {grpcChannelOptionsFromGrpcConfig} from './grpc/grpc-channel-options';
 import {RetryInterceptor} from './grpc/retry-interceptor';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export class PubsubClient extends AbstractPubsubClient<ServiceError> {
   private readonly client: grpcPubsub.PubsubClient;
   protected readonly credentialProvider: CredentialProvider;
   private readonly unaryRequestTimeoutMs: number;
-  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
+  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(5);
   private static readonly DEFAULT_MAX_SESSION_MEMORY_MB: number = 256;
   private readonly unaryInterceptors: Interceptor[];
   private readonly streamingInterceptors: Interceptor[];

--- a/packages/client-sdk-nodejs/src/internal/storage-control-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/storage-control-client.ts
@@ -9,11 +9,13 @@ import {validateStoreName} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {CreateStore, DeleteStore} from '@gomomento/sdk-core';
 import {RetryInterceptor} from './grpc/retry-interceptor';
 import {StorageClientAllProps} from './storage-client-all-props';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export class StorageControlClient {
   private readonly clientWrapper: grpcControl.ScsControlClient;
   private readonly interceptors: Interceptor[];
-  private static readonly REQUEST_TIMEOUT_MS: number = 60 * 1000;
+  private static readonly REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(60);
   private readonly logger: MomentoLogger;
   private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
 

--- a/packages/client-sdk-nodejs/src/internal/webhook-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/webhook-client.ts
@@ -24,13 +24,15 @@ import {
 } from '@gomomento/sdk-core/dist/src/internal/utils';
 import {RetryInterceptor} from './grpc/retry-interceptor';
 import {TopicClientAllProps} from './topic-client-all-props';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export class WebhookClient implements IWebhookClient {
   private readonly webhookClient: grpcWebhook.WebhookClient;
   protected readonly credentialProvider: CredentialProvider;
   private readonly logger: MomentoLogger;
   private readonly cacheServiceErrorMapper: CacheServiceErrorMapper;
-  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
+  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(5);
   private readonly unaryInterceptors: Interceptor[];
 
   /**

--- a/packages/client-sdk-web/src/internal/pubsub-client.ts
+++ b/packages/client-sdk-web/src/internal/pubsub-client.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils/web-client-utils';
 import {ClientMetadataProvider} from './client-metadata-provider';
 import {TopicClientAllProps} from './topic-client-all-props';
+import {secondsToMilliseconds} from '@gomomento/sdk-core/dist/src/utils';
 
 export class PubsubClient<
   REQ extends Request<REQ, RESP>,
@@ -31,7 +32,8 @@ export class PubsubClient<
   private readonly client: pubsub.PubsubClient;
   private readonly credentialProvider: CredentialProvider;
   private readonly requestTimeoutMs: number;
-  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number = 5 * 1000;
+  private static readonly DEFAULT_REQUEST_TIMEOUT_MS: number =
+    secondsToMilliseconds(5);
   private readonly clientMetadataProvider: ClientMetadataProvider;
 
   private static readonly RST_STREAM_NO_ERROR_MESSAGE =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,8 @@ import {
   SetBatchItem,
 } from './utils';
 
+export * as utils from './utils';
+
 import {
   CredentialProvider,
   StringMomentoTokenProvider,

--- a/packages/core/src/utils/collection-ttl.ts
+++ b/packages/core/src/utils/collection-ttl.ts
@@ -1,4 +1,5 @@
 import {validateTtlSeconds} from '../internal/utils';
+import {secondsToMilliseconds} from './time';
 
 /** Represents the desired behavior for managing the TTL on collection
  *  objects (dictionaries, lists, sets) in your cache.
@@ -46,7 +47,9 @@ export class CollectionTtl {
    * @returns {number | null}
    */
   public ttlMilliseconds(): number | null {
-    return this._ttlSeconds === null ? null : this._ttlSeconds * 1000;
+    return this._ttlSeconds === null
+      ? null
+      : secondsToMilliseconds(this._ttlSeconds);
   }
 
   /** Whether or not to refresh a collection's TTL when it's modified.

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './expiration';
 export * from './itemType';
 export * from './webhook-destination';
 export * from './set-batch-item';
+export * from './time';

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -1,0 +1,8 @@
+/**
+ * Converts seconds to milliseconds.
+ * @param seconds - The number of seconds to convert.
+ * @returns The equivalent number of milliseconds.
+ */
+export function secondsToMilliseconds(seconds: number): number {
+  return seconds * 1000;
+}


### PR DESCRIPTION
Previously the code had lots of ad hoc conversion:
- deciding to use the provided ttl vs default
- converting to milliseconds by multiplying by 1000

We centralize these calculations for maintainability and to reduce
errors.

closes #1255 