### PR TITLE
fix: set the repo url to the current url

### DIFF
--- a/examples/fastly-compute/package.json
+++ b/examples/fastly-compute/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fastly/compute-starter-kit-typescript.git"
+    "url": "https://github.com/momentohq/client-sdk-javascript"
   },
   "author": "oss@fastly.com",
   "license": "MIT",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -10,7 +10,7 @@
   "types": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/momentohq/client-sdk-nodejs"
+    "url": "https://github.com/momentohq/client-sdk-javascript"
   },
   "scripts": {
     "prebuild": "eslint . --ext .ts",

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -10,7 +10,7 @@
   "types": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/momentohq/client-sdk-nodejs"
+    "url": "https://github.com/momentohq/client-sdk-javascript"
   },
   "scripts": {
     "prebuild": "eslint . --ext .ts",

--- a/packages/common-integration-tests/package-lock.json
+++ b/packages/common-integration-tests/package-lock.json
@@ -37,6 +37,7 @@
       }
     },
     "../core": {
+      "name": "@gomomento/sdk-core",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/common-integration-tests/package.json
+++ b/packages/common-integration-tests/package.json
@@ -10,7 +10,7 @@
   "types": "dist/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/momentohq/client-sdk-nodejs"
+    "url": "https://github.com/momentohq/client-sdk-javascript"
   },
   "scripts": {
     "prebuild": "eslint . --ext .ts",


### PR DESCRIPTION
Sets the package metadata repo url to the
current (github.com/momentohq/client-sdk-javascript).

Also corrects the repo url for the fastly example.
