### PR TITLE
ci: check permissions of triggering actor before running PR checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-user-permissions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
   verify:
     runs-on: ubuntu-24.04
     steps:
@@ -359,6 +378,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cache-tests:
+    needs: verify-user-permissions
     strategy:
       matrix:
         node: [18]
@@ -372,6 +392,8 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -384,6 +406,7 @@ jobs:
           ./scripts/build-and-test-all-packages-consistent-reads.sh
 
   test-examples:
+    needs: verify-user-permissions
     strategy:
       matrix:
         node: [16, 18, 20]
@@ -398,6 +421,8 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -500,6 +525,7 @@ jobs:
         run: exit 1
 
   test-web-examples:
+    needs: verify-user-permissions
     strategy:
       matrix:
         node: [ 16, 18 ]
@@ -514,6 +540,8 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -550,20 +578,19 @@ jobs:
         run: exit 1
 
   test-deno-examples:
+    needs: verify-user-permissions
     strategy:
       matrix:
         node: [ 16, 18 ]
       fail-fast: true
     name: Test Deno examples on node ${{ matrix.node }}
     runs-on: ubuntu-24.04
-    env:
-      # TODO: remove token stored as secret in favor of using a
-      # momento-local instance that can be spun up for testing
-      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           require: write
           username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check User Permission
         if: steps.checkAccess.outputs.require-result == 'false'
         run: |
@@ -392,8 +390,6 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -421,8 +417,6 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -540,8 +534,6 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -589,8 +581,6 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without the first access check
 
       - name: Install Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -674,33 +674,3 @@ jobs:
             npm i
             npm run build
           popd
-  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
-  # dependabot-auto-merge:
-  #   name: Dependabot Auto Merge
-  #   permissions:
-  #     contents: write
-  #     pull-requests: write
-  #   runs-on: ubuntu-latest
-  #   # make sure we run all tests/examples and they pass before we try and auto approve/merge the dependabot prs
-  #   needs: [test-deno-examples, test-web-examples, test-examples, test, verify]
-  #   if: ${{ github.actor == 'dependabot[bot]' }}
-  #   steps:
-  #     - name: Dependabot metadata
-  #       id: metadata
-  #       uses: dependabot/fetch-metadata@v1
-  #       with:
-  #         github-token: "${{ secrets.GITHUB_TOKEN }}"
-  #     - name: Approve a PR
-  #       run: gh pr review --approve "$PR_URL"
-  #       env:
-  #         PR_URL: ${{github.event.pull_request.html_url}}
-  #         # need to have an approver first before dependabot can merge the pr, here we are using the shared
-  #         # momento github actions bot user
-  #         GH_TOKEN: ${{secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN}}
-  #     - name: Enable auto-merge for Dependabot PRs
-  #       if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-  #       run: gh pr merge --squash "$PR_URL"
-  #       env:
-  #         PR_URL: ${{github.event.pull_request.html_url}}
-  #         GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-


### PR DESCRIPTION
Addresses https://github.com/momentohq/dev-eco-issue-tracker/issues/1096

For PR checks that need an auth token to run successfully, we first check that the github actor that triggered the workflow has write permissions to the repo before sharing the secrets and running the tests.

This should allow us the ability to approve workflows on PRs that come in via forked branches, making it easier to accept open-source contributions.

**Intended behavior**

1. PR from fork comes in, requires workflow approval from a maintainer
2. Maintainer approves, starts workflow, becomes the "triggering actor"
3. GitHub Actions workflow checks triggering actor's permissions, proceeds if they have at least "write" access to the repo
4. PR checks run with access to secrets due to usage of `on: pull_request_target`

PRs from a maintainer should run the PR checks as usual because they are the ones that trigger the workflow. Workflow approval can be configured to be required on all PRs from forks.

[Reference article for the workflow](https://michaelheap.com/access-secrets-from-forks/#check-collaborator-permissions)

[Reference article for `on: pull_request` vs `on: pull_request_target`](https://runs-on.com/github-actions/pull-request-vs-pull-request-target/)
