### PR TITLE
fix: upgrade to open pull request v7 for correct attribution

### DIFF
--- a/.github/workflows/update-example-deps.yml
+++ b/.github/workflows/update-example-deps.yml
@@ -31,7 +31,7 @@
             git status
 
         - name: Open PR
-          uses: peter-evans/create-pull-request@v5
+          uses: peter-evans/create-pull-request@v7
           with:
             token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
             commit-message: "chore: update momento dependency in examples\n\nAutomated commit created by update-example-deps workflow"


### PR DESCRIPTION
The commit attribution is wrong when we run the update-dependencies
workflow. While it should only be committing using the bot account, an
individual developer is also tagged on the commit. This is incorrect.

The create-pull-request GitHub action fixed the attribution for the
commits in v6. We upgrade to v7 for the latest.
