### PR TITLE
chore: bump client message size limits

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
@@ -1,9 +1,9 @@
 import {GrpcConfiguration} from '../..';
 import {ChannelOptions} from '@grpc/grpc-js';
 
-// The default value for max_send_message_length is 4mb.  We need to increase this to 5mb in order to
-// support cases where users have requested a limit increase up to our maximum item size of 5mb.
-const DEFAULT_MAX_REQUEST_SIZE = 5_243_000;
+// The default value for max_send_message_length is 4MiB.  We increase this to ~10MiB to support
+// customers that have requested a limit increase above the default 5MiB.
+const DEFAULT_MAX_REQUEST_SIZE = 10_486_000;
 
 export function grpcChannelOptionsFromGrpcConfig(
   grpcConfig: GrpcConfiguration


### PR DESCRIPTION
The current default Node.js message size limits are 5MiB for inbound
and outbound messages. Because the service limits may be slightly higher
for certain customers, we double the limits to provide a nice tradeoff
between user experience (not having to override the limits),
performance, and protective guardrails.
