### PR TITLE
feat: add retry test metrics collector

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
+++ b/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
@@ -1,3 +1,35 @@
+export enum MomentoRPCMethod {
+  Get = 'get',
+  Set = 'set',
+  Delete = 'delete',
+  GetBatch = 'getBatch',
+  SetBatch = 'setBatch',
+  KeysExist = 'keysExist',
+  ItemGetTtl = 'itemGetTtl',
+  ItemGetType = 'itemGetType',
+  DictionaryGet = 'dictionaryGet',
+  DictionaryFetch = 'dictionaryFetch',
+  DictionarySet = 'dictionarySet',
+  DictionaryDelete = 'dictionaryDelete',
+  DictionaryLength = 'dictionaryLength',
+  SetFetch = 'setFetch',
+  SetSample = 'setSample',
+  SetUnion = 'setUnion',
+  SetDifference = 'setDifference',
+  SetContains = 'setContains',
+  SetLength = 'setLength',
+  ListRemove = 'listRemove',
+  ListFetch = 'listFetch',
+  ListLength = 'listLength',
+  sortedSetPut = 'sortedSetPut',
+  sortedSetFetch = 'sortedSetFetch',
+  sortedSetGetScore = 'sortedSetGetScore',
+  sortedSetRemove = 'sortedSetRemove',
+  sortedSetGetRank = 'sortedSetGetRank',
+  sortedSetLength = 'sortedSetLength',
+  sortedSetLengthByScore = 'sortedSetLengthByScore',
+}
+
 export class TestRetryMetricsCollector {
   // Data structure to store timestamps: cacheName -> requestName -> [timestamps]
   private readonly data: Record<string, Record<string, number[]>>;
@@ -9,12 +41,12 @@ export class TestRetryMetricsCollector {
   /**
    * Adds a timestamp for a specific request and cache.
    * @param cacheName - The name of the cache.
-   * @param requestName - The name of the request (could also be an enum like MomentoRpcs).
-   * @param timestamp - The timestamp to record (in milliseconds).
+   * @param requestName - The name of the request.
+   * @param timestamp - The timestamp to record in seconds since epoch.
    */
   addTimestamp(
     cacheName: string,
-    requestName: string,
+    requestName: MomentoRPCMethod,
     timestamp: number
   ): void {
     if (!this.data[cacheName]) {
@@ -41,7 +73,7 @@ export class TestRetryMetricsCollector {
    * Calculates the average time between retries for a specific cache and request.
    * @param cacheName - The name of the cache.
    * @param requestName - The name of the request.
-   * @returns The average time in milliseconds, or null if there are no retries.
+   * @returns The average time in seconds, or null if there are no retries.
    */
   getAverageTimeBetweenRetries(
     cacheName: string,

--- a/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
+++ b/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
@@ -21,13 +21,13 @@ export enum MomentoRPCMethod {
   ListRemove = 'listRemove',
   ListFetch = 'listFetch',
   ListLength = 'listLength',
-  sortedSetPut = 'sortedSetPut',
-  sortedSetFetch = 'sortedSetFetch',
-  sortedSetGetScore = 'sortedSetGetScore',
-  sortedSetRemove = 'sortedSetRemove',
-  sortedSetGetRank = 'sortedSetGetRank',
-  sortedSetLength = 'sortedSetLength',
-  sortedSetLengthByScore = 'sortedSetLengthByScore',
+  SortedSetPut = 'sortedSetPut',
+  SortedSetFetch = 'sortedSetFetch',
+  SortedSetGetScore = 'sortedSetGetScore',
+  SortedSetRemove = 'sortedSetRemove',
+  SortedSetGetRank = 'sortedSetGetRank',
+  SortedSetLength = 'sortedSetLength',
+  SortedSetLengthByScore = 'sortedSetLengthByScore',
 }
 
 export class TestRetryMetricsCollector {

--- a/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
+++ b/packages/client-sdk-nodejs/test/integration/test-retry-metrics-collector.ts
@@ -1,0 +1,73 @@
+export class TestRetryMetricsCollector {
+  // Data structure to store timestamps: cacheName -> requestName -> [timestamps]
+  private readonly data: Record<string, Record<string, number[]>>;
+
+  constructor() {
+    this.data = {};
+  }
+
+  /**
+   * Adds a timestamp for a specific request and cache.
+   * @param cacheName - The name of the cache.
+   * @param requestName - The name of the request (could also be an enum like MomentoRpcs).
+   * @param timestamp - The timestamp to record (in milliseconds).
+   */
+  addTimestamp(
+    cacheName: string,
+    requestName: string,
+    timestamp: number
+  ): void {
+    if (!this.data[cacheName]) {
+      this.data[cacheName] = {};
+    }
+    if (!this.data[cacheName][requestName]) {
+      this.data[cacheName][requestName] = [];
+    }
+    this.data[cacheName][requestName].push(timestamp);
+  }
+
+  /**
+   * Calculates the total retry count for a specific cache and request.
+   * @param cacheName - The name of the cache.
+   * @param requestName - The name of the request.
+   * @returns The total number of retries.
+   */
+  getTotalRetryCount(cacheName: string, requestName: string): number {
+    const timestamps = this.data[cacheName]?.[requestName] ?? [];
+    return timestamps.length;
+  }
+
+  /**
+   * Calculates the average time between retries for a specific cache and request.
+   * @param cacheName - The name of the cache.
+   * @param requestName - The name of the request.
+   * @returns The average time in milliseconds, or null if there are no retries.
+   */
+  getAverageTimeBetweenRetries(
+    cacheName: string,
+    requestName: string
+  ): number | null {
+    const timestamps = this.data[cacheName]?.[requestName] ?? [];
+    if (timestamps.length < 2) {
+      // No retries occurred.
+      return null;
+    }
+    const intervals = [];
+    for (let i = 1; i < timestamps.length; i++) {
+      intervals.push(timestamps[i] - timestamps[i - 1]);
+    }
+    const totalInterval = intervals.reduce(
+      (sum, interval) => sum + interval,
+      0
+    );
+    return totalInterval / intervals.length;
+  }
+
+  /**
+   * Retrieves all collected metrics for debugging or analysis.
+   * @returns The complete data structure with all recorded metrics.
+   */
+  getAllMetrics(): Record<string, Record<string, number[]>> {
+    return this.data;
+  }
+}

--- a/packages/client-sdk-nodejs/test/unit/test-retry-metrics-collector.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/test-retry-metrics-collector.test.ts
@@ -1,0 +1,101 @@
+import {TestRetryMetricsCollector} from '../integration/test-retry-metrics-collector';
+
+describe('TestRetryMetricsCollector', () => {
+  let metricsCollector: TestRetryMetricsCollector;
+
+  beforeEach(() => {
+    metricsCollector = new TestRetryMetricsCollector();
+  });
+
+  test('should initialize with an empty data structure', () => {
+    expect(metricsCollector.getAllMetrics()).toEqual({});
+  });
+
+  test('should add timestamps correctly', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+    metricsCollector.addTimestamp('cache1', 'request1', 200);
+
+    const metrics = metricsCollector.getAllMetrics();
+    expect(metrics['cache1']['request1']).toEqual([100, 200]);
+  });
+
+  test('should calculate total retry count correctly', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+    metricsCollector.addTimestamp('cache1', 'request1', 200);
+    metricsCollector.addTimestamp('cache1', 'request1', 300);
+
+    const totalRetryCount = metricsCollector.getTotalRetryCount(
+      'cache1',
+      'request1'
+    );
+    expect(totalRetryCount).toBe(3);
+  });
+
+  test('should return 0 retries for non-existent cache or request', () => {
+    const totalRetryCount = metricsCollector.getTotalRetryCount(
+      'cache1',
+      'nonExistentRequest'
+    );
+    expect(totalRetryCount).toBe(0);
+  });
+
+  test('should calculate average time between retries correctly', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+    metricsCollector.addTimestamp('cache1', 'request1', 300);
+    metricsCollector.addTimestamp('cache1', 'request1', 600);
+
+    const averageTime = metricsCollector.getAverageTimeBetweenRetries(
+      'cache1',
+      'request1'
+    );
+    expect(averageTime).toBe(250); // (300 - 100 + 600 - 300) / 2
+  });
+
+  test('should return null for average time if only one timestamp exists', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+
+    const averageTime = metricsCollector.getAverageTimeBetweenRetries(
+      'cache1',
+      'request1'
+    );
+    expect(averageTime).toBeNull();
+  });
+
+  test('should return null for average time for non-existent cache or request', () => {
+    const averageTime = metricsCollector.getAverageTimeBetweenRetries(
+      'cache1',
+      'nonExistentRequest'
+    );
+    expect(averageTime).toBeNull();
+  });
+
+  test('should handle multiple caches and requests correctly', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+    metricsCollector.addTimestamp('cache1', 'request1', 200);
+
+    metricsCollector.addTimestamp('cache2', 'request2', 300);
+    metricsCollector.addTimestamp('cache2', 'request2', 600);
+
+    expect(metricsCollector.getTotalRetryCount('cache1', 'request1')).toBe(2);
+    expect(
+      metricsCollector.getAverageTimeBetweenRetries('cache1', 'request1')
+    ).toBe(100);
+
+    expect(metricsCollector.getTotalRetryCount('cache2', 'request2')).toBe(2);
+    expect(
+      metricsCollector.getAverageTimeBetweenRetries('cache2', 'request2')
+    ).toBe(300);
+  });
+
+  test('should return the full metrics data structure', () => {
+    metricsCollector.addTimestamp('cache1', 'request1', 100);
+    metricsCollector.addTimestamp('cache1', 'request1', 200);
+
+    const allMetrics = metricsCollector.getAllMetrics();
+    expect(allMetrics).toEqual({
+      cache1: {
+        request1: [100, 200],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## PR Description:
- Add a retry test metrics collector class that allows us to collect data regarding no of retries, total number of retries and average time between the retries. 

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1091