### PR TITLE
chore: add copy constructors for max send/recieve message length

### DIFF
--- a/packages/client-sdk-nodejs/src/config/transport/cache/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/cache/grpc-configuration.ts
@@ -143,10 +143,24 @@ export interface GrpcConfiguration {
   getMaxSendMessageLength(): number | undefined;
 
   /**
+   * Copy constructor for overriding the max send message length.
+   * @param maxSendMessageLength the desired maximum message length the client can send to the server.
+   */
+  withMaxSendMessageLength(maxSendMessageLength: number): GrpcConfiguration;
+
+  /**
    * The maximum message length the client can receive from the server.  If the server attempts to send a message larger than
    * this size, it will result in a RESOURCE_EXHAUSTED error.
    */
   getMaxReceiveMessageLength(): number | undefined;
+
+  /**
+   * Copy constructor for overriding the max receive message length.
+   * @param maxReceiveMessageLength the desired maximum message length the client can receive from the server.
+   */
+  withMaxReceiveMessageLength(
+    maxReceiveMessageLength: number
+  ): GrpcConfiguration;
 
   /**
    * @returns {number} the number of internal clients a cache client will create to communicate with Momento. More of

--- a/packages/client-sdk-nodejs/src/config/transport/cache/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/cache/transport-strategy.ts
@@ -153,8 +153,26 @@ export class StaticGrpcConfiguration implements GrpcConfiguration {
     return this.maxSendMessageLength;
   }
 
+  withMaxSendMessageLength(
+    maxSendMessageLength: number
+  ): StaticGrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      ...this,
+      maxSendMessageLength,
+    });
+  }
+
   getMaxReceiveMessageLength(): number | undefined {
     return this.maxReceiveMessageLength;
+  }
+
+  withMaxReceiveMessageLength(
+    maxReceiveMessageLength: number
+  ): StaticGrpcConfiguration {
+    return new StaticGrpcConfiguration({
+      ...this,
+      maxReceiveMessageLength,
+    });
   }
 
   getNumClients(): number {


### PR DESCRIPTION
Adds `GrpcConfiguration` copy constructors to set the max send/receive
message length.
