### PR TITLE
ci: checkout default ref on PRs if merge commit is unavailable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Verify README generation
         uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
@@ -393,7 +393,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -422,7 +422,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -541,7 +541,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -590,7 +590,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Install Deno
         uses: denoland/setup-deno@v1
@@ -635,7 +635,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Build all packages
         run: |


### PR DESCRIPTION
It appears that sometimes the `merge_commit_sha` we want to check out in combination with using `on: pull_request_target` does not always exist.

This PR ensures we checkout `merge_commit_sha || pull_request.head.sha` so that it has a fallback ref that will always exist. (The head.sha is the last commit on the PR, the merge_commit_sha is the test merge with main).

Note: The updated workflow will not run on this PR because `pull_request_target` runs in the context of the base branch (main), not the PR branch.