### PR TITLE
chore: document max message length units

### DIFF
--- a/packages/client-sdk-nodejs/src/config/configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/configuration.ts
@@ -87,7 +87,7 @@ export interface Configuration {
    * allow you to adjust the maximum message length the client can send and receive from the server.
    *
    * This is only relevant if you have requested a service limit increase beyond the default value.
-   * @param {number} maxMessageLength
+   * @param {number} maxMessageLength - the max message length (in bytes) the client can send and receive
    * @returns {Configuration} a new Configuration object with the updated TransportStrategy
    */
   withMaxMessageLength(maxMessageLength: number): Configuration;

--- a/packages/client-sdk-nodejs/src/config/transport/cache/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/cache/grpc-configuration.ts
@@ -144,7 +144,7 @@ export interface GrpcConfiguration {
 
   /**
    * Copy constructor for overriding the max send message length.
-   * @param maxSendMessageLength the desired maximum message length the client can send to the server.
+   * @param maxSendMessageLength the desired maximum message length (in bytes) the client can send to the server.
    */
   withMaxSendMessageLength(maxSendMessageLength: number): GrpcConfiguration;
 
@@ -156,7 +156,7 @@ export interface GrpcConfiguration {
 
   /**
    * Copy constructor for overriding the max receive message length.
-   * @param maxReceiveMessageLength the desired maximum message length the client can receive from the server.
+   * @param maxReceiveMessageLength the desired maximum message length (in bytes) the client can receive from the server.
    */
   withMaxReceiveMessageLength(
     maxReceiveMessageLength: number


### PR DESCRIPTION
Previously we did not indicate that max message length was in
bytes. We adjust that here.
