### PR TITLE
chore: use the pull request head sha to build the ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Verify README generation
         uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
@@ -393,7 +393,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -422,7 +422,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -541,7 +541,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v3
@@ -590,7 +590,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Deno
         uses: denoland/setup-deno@v1
@@ -635,7 +635,7 @@ jobs:
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build all packages
         run: |


### PR DESCRIPTION
## PR Description:

In the following pull request: [#1505](https://github.com/momentohq/client-sdk-javascript/pull/1505), it was observed that the CI process consistently builds against the previous commit instead of the head commit. 

You can verify this by reviewing the "Setup repo" step under the "Check Ref logs" section in CI Actions, which indicates the commit being tested.

To address this issue, this update ensures that the CI always tests against the pull request's head SHA rather than the merge commit SHA, improving accuracy and reliability in the testing process.