### PR TITLE
chore: remove logs from tests

### DIFF
--- a/packages/common-integration-tests/src/cache/dictionary.ts
+++ b/packages/common-integration-tests/src/cache/dictionary.ts
@@ -31,7 +31,6 @@ import {
 } from '@gomomento/sdk-core/dist/src/messages/responses/response-base';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients/cache';
-import {log} from 'console';
 
 export function runDictionaryTests(
   cacheClient: ICacheClient,
@@ -160,12 +159,6 @@ export function runDictionaryTests(
           dictionaryName
         );
         expect(itemGetTtlResponse).toBeInstanceOf(CacheItemGetTtl.Hit);
-        log(
-          `Received CacheItemGetTtl Hit. Remaining TTL for the item: ${(
-            itemGetTtlResponse as CacheItemGetTtl.Hit
-          ).remainingTtlMillis()} milliseconds.`
-        );
-
         await sleep(timeout * 1000 + 1);
 
         const getResponse = await cacheClient.dictionaryGetField(

--- a/packages/common-integration-tests/src/cache/sorted-set.ts
+++ b/packages/common-integration-tests/src/cache/sorted-set.ts
@@ -33,7 +33,6 @@ import {
 } from '@gomomento/sdk-core/dist/src/messages/responses/response-base';
 import {sleep} from '@gomomento/sdk-core/dist/src/internal/utils';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/internal/clients';
-import {log} from 'console';
 
 export function runSortedSetTests(
   cacheClient: ICacheClient,
@@ -115,12 +114,6 @@ export function runSortedSetTests(
           sortedSetName
         );
         expect(itemGetTtlResponse).toBeInstanceOf(CacheItemGetTtl.Hit);
-        log(
-          `Received CacheItemGetTtl Hit. Remaining TTL for the item: ${(
-            itemGetTtlResponse as CacheItemGetTtl.Hit
-          ).remainingTtlMillis()} milliseconds.`
-        );
-
         await sleep(timeout * 1000 + 1);
         const getResponse = await cacheClient.sortedSetFetchByRank(
           integrationTestCacheName,

--- a/packages/common-integration-tests/src/webhooks/webhooks.ts
+++ b/packages/common-integration-tests/src/webhooks/webhooks.ts
@@ -20,7 +20,6 @@ import {
   ITopicClient,
 } from '@gomomento/sdk-core/dist/src/internal/clients';
 import {delay} from '../auth/auth-client';
-import {log} from 'console';
 
 export function runWebhookTests(
   topicClient: ITopicClient,
@@ -133,7 +132,6 @@ export function runWebhookTests(
         const details = await getWebhookRequestDetails(
           webhook.destination.url()
         );
-        log('webhook request details:', details);
         expect(details.invocationCount).toBe(1);
       });
     });


### PR DESCRIPTION
## PR Description:
- Removing logs from tests that were added to debug the canaries. Since now we use consistent reads inside canaries, we can get rid of the logs that were added. 
