### PR TITLE
feat: add retry tests for RpcDelayer

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
@@ -72,7 +72,7 @@ describe('Automated retry with full network outage', () => {
           'key',
           1
         );
-        expect(incrementResponse.type).toEqual(CacheIncrementResponse.Success);
+        expect(incrementResponse.type).toEqual(CacheIncrementResponse.Error);
         const noOfRetries = testMetricsCollector.getTotalRetryCount(
           cacheName,
           MomentoRPCMethod.Increment
@@ -155,7 +155,7 @@ describe('Automated retry with full network outage', () => {
           'key',
           1
         );
-        expect(incrementResponse.type).toEqual(CacheIncrementResponse.Success);
+        expect(incrementResponse.type).toEqual(CacheIncrementResponse.Error);
         const noOfRetries = testMetricsCollector.getTotalRetryCount(
           cacheName,
           MomentoRPCMethod.Increment

--- a/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
@@ -251,18 +251,19 @@ describe('Automated retry with temporary network outage', () => {
 describe('Automated retry with delay ms on fixed timeout strategy', () => {
   let testMetricsCollector: TestRetryMetricsCollector;
   let momentoLogger: MomentoLogger;
+  let loggerFactory: DefaultMomentoLoggerFactory;
+  const RETRY_DELAY_MILLIS = 1000;
+  const CLIENT_TIMEOUT_MILLIS = 5000;
 
   beforeAll(() => {
     testMetricsCollector = new TestRetryMetricsCollector();
     momentoLogger = new DefaultMomentoLoggerFactory().getLogger(
       'TestRetryMetricsMiddleware'
     );
+    loggerFactory = new DefaultMomentoLoggerFactory();
   });
 
   it('should get hit/miss response with no retries for fixed timeout strategy if delayMs < responseDataReceivedTimeoutMillis', async () => {
-    const RETRY_DELAY_MILLIS = 1000;
-    const CLIENT_TIMEOUT_MILLIS = 5000;
-    const loggerFactory = new DefaultMomentoLoggerFactory();
     const retryStrategy = new FixedTimeoutRetryStrategy({
       loggerFactory: loggerFactory,
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,
@@ -295,9 +296,6 @@ describe('Automated retry with delay ms on fixed timeout strategy', () => {
   });
 
   it('should TIMEOUT_ERROR error with no retries for fixed timeout strategy if delayMs > responseDataReceivedTimeoutMillis', async () => {
-    const RETRY_DELAY_MILLIS = 1000;
-    const CLIENT_TIMEOUT_MILLIS = 5000;
-    const loggerFactory = new DefaultMomentoLoggerFactory();
     const retryStrategy = new FixedTimeoutRetryStrategy({
       loggerFactory: loggerFactory,
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,
@@ -333,9 +331,6 @@ describe('Automated retry with delay ms on fixed timeout strategy', () => {
   });
 
   it('should get hit/miss response with retries for fixed timeout strategy if delayMs < responseDataReceivedTimeoutMillis', async () => {
-    const RETRY_DELAY_MILLIS = 1000;
-    const CLIENT_TIMEOUT_MILLIS = 5000;
-    const loggerFactory = new DefaultMomentoLoggerFactory();
     const retryStrategy = new FixedTimeoutRetryStrategy({
       loggerFactory: loggerFactory,
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,

--- a/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/automated-retry-tests.test.ts
@@ -7,7 +7,10 @@ import {
   MomentoLogger,
 } from '../../../src';
 import {TestRetryMetricsCollector} from '../../test-retry-metrics-collector';
-import {MomentoRPCMethod} from '../../momento-rpc-method';
+import {
+  MomentoRPCMethod,
+  MomentoRPCMethodConverter,
+} from '../../momento-rpc-method';
 import {WithCacheAndCacheClient} from '../integration-setup';
 import {TestRetryMetricsMiddlewareArgs} from '../../test-retry-metrics-middleware';
 import {v4} from 'uuid';
@@ -29,7 +32,7 @@ describe('Automated retry with full network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
     };
 
     await WithCacheAndCacheClient(
@@ -56,7 +59,9 @@ describe('Automated retry with full network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [
+        MomentoRPCMethodConverter.convert(MomentoRPCMethod.Increment),
+      ],
     };
     await WithCacheAndCacheClient(
       config => config,
@@ -72,7 +77,7 @@ describe('Automated retry with full network outage', () => {
           cacheName,
           MomentoRPCMethod.Increment
         );
-        expect(noOfRetries).toBe(0);
+        expect(noOfRetries).toBe(0); // Increment is not eligible for retry
       }
     );
   });
@@ -91,7 +96,7 @@ describe('Automated retry with full network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
     };
 
     await WithCacheAndCacheClient(
@@ -133,7 +138,9 @@ describe('Automated retry with full network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [
+        MomentoRPCMethodConverter.convert(MomentoRPCMethod.Increment),
+      ],
     };
 
     await WithCacheAndCacheClient(
@@ -153,7 +160,7 @@ describe('Automated retry with full network outage', () => {
           cacheName,
           MomentoRPCMethod.Increment
         );
-        expect(noOfRetries).toBe(0);
+        expect(noOfRetries).toBe(0); // Increment is not eligible for retry
       }
     );
   });
@@ -176,7 +183,7 @@ describe('Automated retry with temporary network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       errorCount: 2,
     };
     await WithCacheAndCacheClient(
@@ -209,7 +216,7 @@ describe('Automated retry with temporary network outage', () => {
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
       returnError: 'unavailable',
-      errorRpcList: ['get'],
+      errorRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       errorCount: 2,
     };
 
@@ -274,7 +281,7 @@ describe('Automated retry with delay ms on fixed timeout strategy', () => {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
-      delayRpcList: ['get'],
+      delayRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       delayMillis: 500,
     };
     await WithCacheAndCacheClient(
@@ -306,7 +313,7 @@ describe('Automated retry with delay ms on fixed timeout strategy', () => {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
-      delayRpcList: ['get'],
+      delayRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       delayMillis: 1500,
     };
     await WithCacheAndCacheClient(
@@ -341,10 +348,10 @@ describe('Automated retry with delay ms on fixed timeout strategy', () => {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
-      errorRpcList: ['get'],
+      errorRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       returnError: 'unavailable',
       errorCount: 2,
-      delayRpcList: ['get'],
+      delayRpcList: [MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)],
       delayMillis: 500,
       delayCount: 2,
     };

--- a/packages/client-sdk-nodejs/test/momento-rpc-method.ts
+++ b/packages/client-sdk-nodejs/test/momento-rpc-method.ts
@@ -51,8 +51,9 @@ class MomentoRPCMethodConverter {
       Object.values(MomentoRPCMethod).map(method => [
         method,
         method
-          .replace(/^_/, '')
-          .replace(/Request$/, '')
+          .replace(/^_/, '') // Remove leading underscore
+          .replace(/Request$/, '') // Remove trailing "Request"
+          .replace(/([a-z])([A-Z])/g, '$1-$2') // Insert hyphen between lowercase and uppercase
           .toLowerCase(),
       ])
     );

--- a/packages/client-sdk-nodejs/test/momento-rpc-method.ts
+++ b/packages/client-sdk-nodejs/test/momento-rpc-method.ts
@@ -1,4 +1,4 @@
-export enum MomentoRPCMethod {
+enum MomentoRPCMethod {
   Get = '_GetRequest',
   Set = '_SetRequest',
   Delete = '_DeleteRequest',
@@ -44,3 +44,31 @@ export enum MomentoRPCMethod {
   SortedSetLength = '_SortedSetLengthRequest',
   SortedSetLengthByScore = '_SortedSetLengthByScoreRequest',
 }
+
+class MomentoRPCMethodConverter {
+  private static readonly rpcMethodToMetadataMap: Record<string, string> =
+    Object.fromEntries(
+      Object.values(MomentoRPCMethod).map(method => [
+        method,
+        method
+          .replace(/^_/, '')
+          .replace(/Request$/, '')
+          .toLowerCase(),
+      ])
+    );
+
+  /**
+   * Converts a MomentoRPCMethod enum value to its corresponding metadata type.
+   * @param rpcMethod - The MomentoRPCMethod enum value.
+   * @returns The corresponding metadata type.
+   */
+  public static convert(rpcMethod: MomentoRPCMethod): string {
+    const metadataType = this.rpcMethodToMetadataMap[rpcMethod];
+    if (!metadataType) {
+      throw new Error(`Unsupported MomentoRPCMethod: ${rpcMethod}`);
+    }
+    return metadataType;
+  }
+}
+
+export {MomentoRPCMethod, MomentoRPCMethodConverter};

--- a/packages/client-sdk-nodejs/test/unit/momento-rpc-method.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/momento-rpc-method.test.ts
@@ -1,0 +1,34 @@
+import {
+  MomentoRPCMethod,
+  MomentoRPCMethodConverter,
+} from '../momento-rpc-method';
+
+describe('MomentoRPCMethodConverter', () => {
+  it('should convert basic methods correctly', () => {
+    expect(MomentoRPCMethodConverter.convert(MomentoRPCMethod.Get)).toBe('get');
+    expect(MomentoRPCMethodConverter.convert(MomentoRPCMethod.Set)).toBe('set');
+    expect(MomentoRPCMethodConverter.convert(MomentoRPCMethod.Delete)).toBe(
+      'delete'
+    );
+  });
+
+  it('should convert methods with long names to kebab-case', () => {
+    expect(
+      MomentoRPCMethodConverter.convert(MomentoRPCMethod.SortedSetLength)
+    ).toBe('sorted-set-length');
+    expect(
+      MomentoRPCMethodConverter.convert(MomentoRPCMethod.DictionaryFetch)
+    ).toBe('dictionary-fetch');
+    expect(
+      MomentoRPCMethodConverter.convert(MomentoRPCMethod.ListConcatenateFront)
+    ).toBe('list-concatenate-front');
+  });
+
+  it('should throw an error for unsupported methods', () => {
+    expect(() =>
+      MomentoRPCMethodConverter.convert(
+        '_UnsupportedRequest' as MomentoRPCMethod
+      )
+    ).toThrow('Unsupported MomentoRPCMethod: _UnsupportedRequest');
+  });
+});


### PR DESCRIPTION
## PR description:
- Add more retry tests for RPCDelayer
- Add a MomentoRPCMethodConverter class that helps convert the MomentoRPCMethod enum to its corresponding metadata type that momento local can parse. 
- Added unit test for MomentoRPCMethodConverter class

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1109