### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/grpc-channel-options.ts
@@ -35,5 +35,8 @@ export function grpcChannelOptionsFromGrpcConfig(
       grpcConfig.getKeepAlivePermitWithoutCalls(),
     'grpc.keepalive_time_ms': grpcConfig.getKeepAliveTimeMS(),
     'grpc.keepalive_timeout_ms': grpcConfig.getKeepAliveTimeoutMS(),
+
+    // This flag disables service config resolution, which is not needed for our use case.
+    'grpc.service_config_disable_resolution': 1,
   };
 }


### PR DESCRIPTION
## PR Description:
- Adds a flag to disable the dynamic DNS service config

## Testing
- Enabled gRPC logging with `GRPC_VERBOSITY=DEBUG GRPC_TRACE=all npm run example`, but couldn't reproduce the `ENODATA` error.  
- Tried spoofing a TXT record using `/etc/hosts`, but it only supports IP address mappings, not TXT records.  
- Used `tcpdump` to capture DNS queries:  
  ```sh
  sudo tcpdump -i any -vvv port 53 | grep -i cache.cell-alpha-dev.preprod.a.momentohq.com
  ```  
  - Without the SDK flag, observed TXT record lookups.  
  - With the `grpc-service-config-flag` enabled (as in the recent commit), no TXT lookups occurred.  

This confirmed that enabling the flag prevents unnecessary TXT record lookups and avoids the `ENODATA` error.


### tcpdump Before Disabling
<details>
  <summary>Click to expand</summary>

  ```sh
 tcpdump: data link type PKTAP
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    10.0.0.249.56411 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 13609+ TXT? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    10.0.0.249.61870 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 34190+ A? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    10.0.0.249.49960 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 45608+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.56411: [udp sum ok] 13609 q: TXT? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.49960: [udp sum ok] 45608 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.61870: [udp sum ok] 34190 q: A? cache.cell-alpha-dev.preprod.a.momentohq.com. 1/0/0 cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (78)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.58794: [udp sum ok] 33023 q: TXT? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.59999: [udp sum ok] 6710 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.62425: [udp sum ok] 16580 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
  ```
</details>

### tcpdump After Disabling
<details>
  <summary>Click to expand</summary>

  ```sh
  tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    10.0.0.249.55259 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 44005+ A? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.55259: [udp sum ok] 44005 q: A? cache.cell-alpha-dev.preprod.a.momentohq.com. 1/0/0 cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (78)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.50463: [udp sum ok] 13609 q: TXT? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [3m21s] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [13m21s] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
  ```
</details>


Note: The logs indicate that the control-cache client is not applying the gRPC channel options during initialization. I will investigate this separately.

## Issue
https://gomomento.slack.com/archives/C01AC7JT370/p1740500594723289