### PR TITLE
fix: force resolve to release path in nativeNodeModulesPlugina and include that in esbuild config

### DIFF
--- a/examples/nodejs/aws/lambda-examples/advanced-compression/esbuild.ts
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/esbuild.ts
@@ -9,10 +9,15 @@ const nativeNodeModulesPlugin: Plugin = {
     setup(build) {
         // If a ".node" file is imported within a module in the "file" namespace, resolve
         // it to an absolute path and put it into the "node-file" virtual namespace.
-        build.onResolve({ filter: /\.node$/, namespace: 'file' }, args => ({
-            path: require.resolve(args.path, { paths: [args.resolveDir] }),
-            namespace: 'node-file',
-        }))
+      build.onResolve({ filter: /\.node$/, namespace: 'file' }, (args) => {
+        const releasePath = args.path.replace(/\/build\/(Debug|Release)\/zstd.node/, '/build/Release/zstd.node'); // Force Release
+        // Ensure this path is absolute and checked
+        const resolvedPath = require.resolve(releasePath, { paths: [args.resolveDir] });
+        return {
+          path: resolvedPath,
+          namespace: 'node-file',
+        };
+      });
 
         // Files in the "node-file" virtual namespace call "require()" on the
         // path from esbuild of the ".node" file in the output directory.
@@ -53,4 +58,5 @@ build({
     loader: {
         '.node': 'copy',
     },
+  plugins: [nativeNodeModulesPlugin],
 }).catch(() => process.exit(1));

--- a/examples/nodejs/aws/lambda-examples/advanced-compression/package-lock.json
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "hasInstallScript": true,
       "dependencies": {
         "@gomomento/sdk": "^1.108.0",
         "@gomomento/sdk-nodejs-compression-zstd": "^0.108.0",

--- a/examples/nodejs/aws/lambda-examples/advanced-compression/package.json
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/package.json
@@ -15,7 +15,6 @@
     "esbuild": "^0.20.2"
   },
   "scripts": {
-    "postinstall": "mkdir -p node_modules/@mongodb-js/zstd/build/Debug && cp node_modules/@mongodb-js/zstd/build/Release/zstd.node node_modules/@mongodb-js/zstd/build/Debug",
     "prebuild": "rm -rf dist",
     "install:dev": "rm -rf node_modules && npm install",
     "install:aws": "rm -rf node_modules && npm install --platform=linux --arch=x64",


### PR DESCRIPTION
## PR Description:
- Removes `postInstall` script from `package.json`
- Updates the `nativeNodeModulesPlugin` in esbuild to force resolve path
- Add plugin to esbuild config