### PR TITLE
refactor: build aws/compression lambda zip in docker

### DIFF
--- a/examples/nodejs/aws/lambda-examples/advanced-compression/.gitignore
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/.gitignore
@@ -1,2 +1,3 @@
 function.zip
 .aws-sam
+output

--- a/examples/nodejs/aws/lambda-examples/advanced-compression/Dockerfile
+++ b/examples/nodejs/aws/lambda-examples/advanced-compression/Dockerfile
@@ -1,0 +1,17 @@
+FROM amazonlinux:2023
+
+# Install build dependencies
+RUN yum install -y zip && \
+  curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
+  yum install -y nodejs && \
+  npm install -g node-gyp
+
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.json esbuild.ts postbuild.ts ./
+COPY src ./src
+
+RUN npm install --platform=linux --arch=x64
+RUN npm run build
+
+CMD ["cp", "function.zip", "/output/"]


### PR DESCRIPTION
Because the latest `@mongodb-js/zstd` dependency is packaged as
prebuilds for different platforms/architectures, we provide a
Dockerfile to build for linux/x64.
