### PR TITLE
feat: add momento local tests for topics

### DIFF
--- a/packages/client-sdk-nodejs/src/config/retry/momento-rpc-method.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/momento-rpc-method.ts
@@ -43,6 +43,8 @@ enum MomentoRPCMethod {
   SortedSetGetRank = '_SortedSetGetRankRequest',
   SortedSetLength = '_SortedSetLengthRequest',
   SortedSetLengthByScore = '_SortedSetLengthByScoreRequest',
+  TopicPublish = '_PublishRequest',
+  TopicSubscribe = '_SubscriptionRequest',
 }
 
 class MomentoRPCMethodMetadataConverter {
@@ -96,6 +98,9 @@ class MomentoRPCMethodMetadataConverter {
     [MomentoRPCMethod.SortedSetGetRank]: 'sorted-set-get-rank',
     [MomentoRPCMethod.SortedSetLength]: 'sorted-set-length',
     [MomentoRPCMethod.SortedSetLengthByScore]: 'sorted-set-length-by-score',
+
+    [MomentoRPCMethod.TopicPublish]: 'topic-publish',
+    [MomentoRPCMethod.TopicSubscribe]: 'topic-subscribe',
   };
 
   /**

--- a/packages/client-sdk-nodejs/src/config/topic-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configuration.ts
@@ -1,5 +1,6 @@
 import {MomentoLoggerFactory} from '@gomomento/sdk-core';
 import {TopicTransportStrategy} from './transport/topics';
+import {Middleware} from './middleware/middleware';
 
 export interface TopicConfigurationProps {
   /**
@@ -16,6 +17,11 @@ export interface TopicConfigurationProps {
    * Configures whether the client should return a Momento Error object or throw an exception when an error occurs.
    */
   throwOnErrors: boolean;
+
+  /**
+   * Configures middleware functions that will wrap each request
+   */
+  middlewares: Middleware[];
 }
 
 /**
@@ -61,17 +67,38 @@ export interface TopicConfiguration {
    * @returns {Configuration} a new Configuration object with the specified throwOnErrors setting
    */
   withThrowOnErrors(throwOnErrors: boolean): TopicConfiguration;
+
+  /**
+   * @returns {Middleware[]} the middleware functions that will wrap each request
+   */
+  getMiddlewares(): Middleware[];
+
+  /**
+   * Copy constructor for configuring middleware functions that will wrap each request
+   * @param {Middleware[]} middleware
+   * @returns {TopicConfiguration} a new TopicConfiguration object with the specified middleware
+   */
+  withMiddlewares(middleware: Middleware[]): TopicConfiguration;
+
+  /**
+   * Copy constructor that adds a single middleware to the existing middlewares
+   * @param {Middleware} middleware
+   * @returns {TopicConfiguration} a new TopicConfiguration object with the specified Middleware appended to the list of existing Middlewares
+   */
+  addMiddleware(middleware: Middleware): TopicConfiguration;
 }
 
 export class TopicClientConfiguration implements TopicConfiguration {
   private readonly loggerFactory: MomentoLoggerFactory;
   private readonly transportStrategy: TopicTransportStrategy;
   private readonly throwOnErrors: boolean;
+  private readonly middlewares: Middleware[];
 
   constructor(props: TopicConfigurationProps) {
     this.loggerFactory = props.loggerFactory;
     this.transportStrategy = props.transportStrategy;
     this.throwOnErrors = props.throwOnErrors;
+    this.middlewares = props.middlewares;
   }
 
   getLoggerFactory(): MomentoLoggerFactory {
@@ -109,6 +136,24 @@ export class TopicClientConfiguration implements TopicConfiguration {
     return new TopicClientConfiguration({
       ...this,
       throwOnErrors,
+    });
+  }
+
+  getMiddlewares(): Middleware[] {
+    return this.middlewares;
+  }
+
+  withMiddlewares(middlewares: Middleware[]): TopicConfiguration {
+    return new TopicClientConfiguration({
+      ...this,
+      middlewares,
+    });
+  }
+
+  addMiddleware(middleware: Middleware): TopicConfiguration {
+    return new TopicClientConfiguration({
+      ...this,
+      middlewares: [middleware, ...this.middlewares],
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -8,9 +8,11 @@ import {
   StaticTopicGrpcConfiguration,
   StaticTopicTransportStrategy,
 } from './transport/topics';
+import {Middleware} from './middleware/middleware';
 
 const defaultLoggerFactory: MomentoLoggerFactory =
   new DefaultMomentoLoggerFactory();
+const defaultMiddlewares: Middleware[] = [];
 
 /**
  * Default config provides defaults suitable for most environments; prioritizes success of publishing and receiving messages.
@@ -38,6 +40,7 @@ export class Default extends TopicClientConfiguration {
         }),
       }),
       throwOnErrors: false,
+      middlewares: defaultMiddlewares,
     });
   }
 }
@@ -68,6 +71,7 @@ export class Lambda extends TopicClientConfiguration {
       loggerFactory: loggerFactory,
       transportStrategy: transportStrategy,
       throwOnErrors: false,
+      middlewares: defaultMiddlewares,
     });
   }
 }

--- a/packages/client-sdk-nodejs/src/topic-client.ts
+++ b/packages/client-sdk-nodejs/src/topic-client.ts
@@ -36,6 +36,12 @@ export class TopicClient extends AbstractTopicClient {
     );
 
     this.logger.debug('Instantiated Momento TopicClient');
+
+    allProps.configuration.getMiddlewares().forEach(m => {
+      if (m.init) {
+        m.init();
+      }
+    });
   }
 }
 

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -21,14 +21,16 @@ import {
   ReadConcern,
   StorageConfigurations,
   TopicClient,
+  TopicConfiguration,
+  TopicConfigurations,
 } from '../../src';
 import {ICacheClient} from '@gomomento/sdk-core/dist/src/clients/ICacheClient';
 import {ITopicClient} from '@gomomento/sdk-core/dist/src/clients/ITopicClient';
 import {CacheClientAllProps} from '../../src/internal/cache-client-all-props';
 import {
-  TestRetryMetricsMiddleware,
-  TestRetryMetricsMiddlewareArgs,
-} from '../test-retry-metrics-middleware';
+  MomentoLocalMiddleware,
+  MomentoLocalMiddlewareArgs,
+} from '../momento-local-middleware';
 import {MomentoLocalProviderProps} from '@gomomento/sdk-core/dist/src/auth';
 
 export const deleteCacheIfExists = async (
@@ -59,7 +61,7 @@ export async function WithCache(
 
 export async function WithCacheAndCacheClient(
   configFn: (config: Configuration) => Configuration,
-  testMetricsMiddlewareArgs: TestRetryMetricsMiddlewareArgs,
+  momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs,
   testCallback: (cacheClient: CacheClient, cacheName: string) => Promise<void>
 ) {
   const cacheName = testCacheName();
@@ -70,9 +72,7 @@ export async function WithCacheAndCacheClient(
   const momentoLocalProvider = new MomentoLocalProvider(
     momentoLocalProviderProps
   );
-  const testMiddleware = new TestRetryMetricsMiddleware(
-    testMetricsMiddlewareArgs
-  );
+  const testMiddleware = new MomentoLocalMiddleware(momentoLocalMiddlewareArgs);
   const cacheClient = await CacheClient.create({
     configuration: configFn(
       Configurations.Laptop.v1().withMiddlewares([testMiddleware])
@@ -82,6 +82,35 @@ export async function WithCacheAndCacheClient(
   });
   await cacheClient.createCache(cacheName);
   await testCallback(cacheClient, cacheName);
+}
+
+export async function WithCacheAndTopicClient(
+  configFn: (config: TopicConfiguration) => TopicConfiguration,
+  momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs,
+  testCallback: (topicClient: TopicClient, cacheName: string) => Promise<void>
+) {
+  const cacheName = testCacheName();
+  const momentoLocalProviderProps: MomentoLocalProviderProps = {
+    hostname: process.env.MOMENTO_HOSTNAME || '127.0.0.1',
+    port: parseInt(process.env.MOMENTO_PORT || '8080'),
+  };
+  const momentoLocalProvider = new MomentoLocalProvider(
+    momentoLocalProviderProps
+  );
+  const testMiddleware = new MomentoLocalMiddleware(momentoLocalMiddlewareArgs);
+  const cacheClient = await CacheClient.create({
+    configuration: Configurations.Laptop.v1(),
+    credentialProvider: momentoLocalProvider,
+    defaultTtlSeconds: 60,
+  });
+  const topicClient = new TopicClient({
+    configuration: configFn(
+      TopicConfigurations.Default.latest().withMiddlewares([testMiddleware])
+    ),
+    credentialProvider: momentoLocalProvider,
+  });
+  await cacheClient.createCache(cacheName);
+  await testCallback(topicClient, cacheName);
 }
 
 let _credsProvider: CredentialProvider | undefined = undefined;

--- a/packages/client-sdk-nodejs/test/integration/retry/exponential-backoff-retry-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/exponential-backoff-retry-strategy.test.ts
@@ -9,7 +9,7 @@ import {
 import {TestRetryMetricsCollector} from '../../test-retry-metrics-collector';
 import {MomentoRPCMethod} from '../../../src/config/retry/momento-rpc-method';
 import {WithCacheAndCacheClient} from '../integration-setup';
-import {TestRetryMetricsMiddlewareArgs} from '../../test-retry-metrics-middleware';
+import {MomentoLocalMiddlewareArgs} from '../../momento-local-middleware';
 import {v4} from 'uuid';
 
 describe('ExponentialBackoffRetryStrategy integration tests', () => {
@@ -37,7 +37,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
         });
 
       // Simulate server UNAVAILABLE for all attempts
-      const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
         logger: momentoLogger,
         testMetricsCollector,
         requestId: v4(),
@@ -50,7 +50,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
           config
             .withRetryStrategy(exponentialBackoffRetryStrategy)
             .withClientTimeoutMillis(CLIENT_TIMEOUT_MILLIS),
-        testMiddlewareArgs,
+        momentoLocalMiddlewareArgs,
         async (cacheClient, cacheName) => {
           const getResponse = await cacheClient.get(cacheName, 'key');
           expect(getResponse.type).toEqual(CacheGetResponse.Error);
@@ -79,7 +79,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
           loggerFactory,
         });
 
-      const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
         logger: momentoLogger,
         testMetricsCollector,
         requestId: v4(),
@@ -89,7 +89,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
 
       await WithCacheAndCacheClient(
         config => config.withRetryStrategy(exponentialBackoffRetryStrategy),
-        testMiddlewareArgs,
+        momentoLocalMiddlewareArgs,
         async (cacheClient, cacheName) => {
           const incrementResponse = await cacheClient.increment(
             cacheName,
@@ -118,7 +118,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
         });
 
       // Return "unavailable" for first 2 calls, then succeed
-      const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
         logger: momentoLogger,
         testMetricsCollector,
         requestId: v4(),
@@ -132,7 +132,7 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
           config
             .withRetryStrategy(exponentialBackoffRetryStrategy)
             .withClientTimeoutMillis(CLIENT_TIMEOUT_MILLIS),
-        testMiddlewareArgs,
+        momentoLocalMiddlewareArgs,
         async (cacheClient, cacheName) => {
           const getResponse = await cacheClient.get(cacheName, 'key');
           // Because we never actually set the key, it should be a Miss

--- a/packages/client-sdk-nodejs/test/integration/retry/fixed-count-retry-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/fixed-count-retry-strategy.test.ts
@@ -8,7 +8,7 @@ import {
 import {TestRetryMetricsCollector} from '../../test-retry-metrics-collector';
 import {MomentoRPCMethod} from '../../../src/config/retry/momento-rpc-method';
 import {WithCacheAndCacheClient} from '../integration-setup';
-import {TestRetryMetricsMiddlewareArgs} from '../../test-retry-metrics-middleware';
+import {MomentoLocalMiddlewareArgs} from '../../momento-local-middleware';
 import {v4} from 'uuid';
 
 describe('Fixed count retry strategy with full network outage', () => {
@@ -23,7 +23,7 @@ describe('Fixed count retry strategy with full network outage', () => {
   });
 
   it('should make max 3 attempts for retry eligible api', async () => {
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -50,7 +50,7 @@ describe('Fixed count retry strategy with full network outage', () => {
   });
 
   it('should make 0 attempts for retry non-eligible api', async () => {
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -89,7 +89,7 @@ describe('Fixed count retry strategy with temporary network outage', () => {
   });
 
   it('should make less than max number of allowed retry attempts', async () => {
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),

--- a/packages/client-sdk-nodejs/test/integration/retry/fixed-timeout-retry-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/fixed-timeout-retry-strategy.test.ts
@@ -9,9 +9,9 @@ import {
 } from '../../../src';
 import {TestRetryMetricsCollector} from '../../test-retry-metrics-collector';
 import {WithCacheAndCacheClient} from '../integration-setup';
-import {TestRetryMetricsMiddlewareArgs} from '../../test-retry-metrics-middleware';
 import {v4} from 'uuid';
 import {MomentoRPCMethod} from '../../../src/config/retry/momento-rpc-method';
+import {MomentoLocalMiddlewareArgs} from '../../momento-local-middleware';
 
 describe('Fixed timeout retry strategy with full network outage', () => {
   let testMetricsCollector: TestRetryMetricsCollector;
@@ -33,7 +33,7 @@ describe('Fixed timeout retry strategy with full network outage', () => {
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -77,7 +77,7 @@ describe('Fixed timeout retry strategy with full network outage', () => {
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -128,7 +128,7 @@ describe('Fixed timeout retry strategy with temporary network outage', () => {
       retryDelayIntervalMillis: RETRY_DELAY_MILLIS,
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -194,7 +194,7 @@ describe('Fixed timeout retry strategy with delay ms', () => {
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
       responseDataReceivedTimeoutMillis: 1000,
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -226,7 +226,7 @@ describe('Fixed timeout retry strategy with delay ms', () => {
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
       responseDataReceivedTimeoutMillis: 1000,
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),
@@ -263,7 +263,7 @@ describe('Fixed timeout retry strategy with delay ms', () => {
       eligibilityStrategy: new DefaultEligibilityStrategy(loggerFactory),
       responseDataReceivedTimeoutMillis: 2000,
     });
-    const testMiddlewareArgs: TestRetryMetricsMiddlewareArgs = {
+    const testMiddlewareArgs: MomentoLocalMiddlewareArgs = {
       logger: momentoLogger,
       testMetricsCollector: testMetricsCollector,
       requestId: v4(),

--- a/packages/client-sdk-nodejs/test/integration/retry/topic-client-retry.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/topic-client-retry.test.ts
@@ -1,0 +1,165 @@
+import {
+  DefaultMomentoLoggerFactory,
+  MomentoErrorCode,
+  MomentoLogger,
+  SubscribeCallOptions,
+} from '../../../src';
+import {TestRetryMetricsCollector} from '../../test-retry-metrics-collector';
+import {WithCacheAndTopicClient} from '../integration-setup';
+import {MomentoLocalMiddlewareArgs} from '../../momento-local-middleware';
+import {v4} from 'uuid';
+import {Semaphore} from '@gomomento/sdk-core/dist/src/internal/utils';
+import {TopicPublish, TopicSubscribe} from '@gomomento/sdk-core';
+import {MomentoRPCMethod} from '../../../src/config/retry/momento-rpc-method';
+
+describe('Topic client retry tests', () => {
+  let testMetricsCollector: TestRetryMetricsCollector;
+  let momentoLogger: MomentoLogger;
+
+  beforeAll(() => {
+    testMetricsCollector = new TestRetryMetricsCollector();
+    momentoLogger = new DefaultMomentoLoggerFactory().getLogger(
+      'TopicClientRetryTests'
+    );
+  });
+
+  describe('subscribe', () => {
+    it('should retry on recoverable error and restore connection', async () => {
+      const streamMessageLimit = 3;
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
+        logger: momentoLogger,
+        testMetricsCollector: testMetricsCollector,
+        requestId: v4(),
+        streamError: MomentoErrorCode.SERVER_UNAVAILABLE,
+        streamErrorRpcList: [MomentoRPCMethod.TopicSubscribe],
+        streamErrorMessageLimit: streamMessageLimit,
+      };
+      let subscription: TopicSubscribe.Subscription | null = null;
+      const semaphore = new Semaphore(0); // Semaphore starts at 0 (not acquired)
+      let retryCounter = 0;
+      let errorCounter = 0;
+
+      const subscribeOptions: SubscribeCallOptions = {
+        onItem(item) {
+          momentoLogger.info(`Received item: ${item.valueString()}`);
+        },
+        onError() {
+          errorCounter++;
+        },
+        onConnectionLost() {
+          retryCounter++;
+          semaphore.release(); // release the semaphore to allow the test to continue
+        },
+      };
+
+      await WithCacheAndTopicClient(
+        config => config,
+        momentoLocalMiddlewareArgs,
+        async (topicClient, cacheName) => {
+          const topicName = 'topic';
+
+          // Subscribe to the topic
+          const subscribeResponse = await topicClient.subscribe(
+            cacheName,
+            topicName,
+            subscribeOptions
+          );
+          expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
+          subscription = subscribeResponse as TopicSubscribe.Subscription;
+
+          expect(retryCounter).toBe(0);
+
+          // Wait for connection lost
+          await semaphore.acquire(); // Wait until the semaphore is released
+
+          expect(retryCounter).toBe(1);
+          expect(errorCounter).toBe(0);
+
+          // Unsubscribe after test completes
+          if (subscription) {
+            subscription.unsubscribe();
+          }
+        }
+      );
+    });
+
+    it('should not retry on an unrecoverable error', async () => {
+      const streamMessageLimit = 3;
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
+        logger: momentoLogger,
+        testMetricsCollector: testMetricsCollector,
+        requestId: v4(),
+        // Currently, CACHE_NOT_FOUND_ERROR is the only unrecoverable error that is not retried.
+        streamError: MomentoErrorCode.CACHE_NOT_FOUND_ERROR,
+        streamErrorRpcList: [MomentoRPCMethod.TopicSubscribe],
+        streamErrorMessageLimit: streamMessageLimit,
+      };
+      const semaphore = new Semaphore(0); // Semaphore starts at 0 (not acquired)
+      let connectionLostCounter = 0;
+      let errorCounter = 0;
+
+      const subscribeOptions: SubscribeCallOptions = {
+        onItem(item) {
+          momentoLogger.info(`Received item: ${item.valueString()}`);
+        },
+        onError() {
+          errorCounter++;
+        },
+        onConnectionLost() {
+          connectionLostCounter++;
+          semaphore.release(); // release the semaphore to allow the test to continue
+        },
+      };
+
+      await WithCacheAndTopicClient(
+        config => config,
+        momentoLocalMiddlewareArgs,
+        async (topicClient, cacheName) => {
+          const topicName = 'topic';
+
+          // Subscribe to the topic
+          const subscribeResponse = await topicClient.subscribe(
+            cacheName,
+            topicName,
+            subscribeOptions
+          );
+          expect(subscribeResponse).toBeInstanceOf(TopicSubscribe.Subscription);
+
+          // Wait for connection lost
+          await semaphore.acquire(); // wait for error to be received
+
+          expect(errorCounter).toBe(1);
+          expect(connectionLostCounter).toBe(1);
+        }
+      );
+    });
+  });
+
+  describe('publish', () => {
+    it('should error on deadline exceeded', async () => {
+      const momentoLocalMiddlewareArgs: MomentoLocalMiddlewareArgs = {
+        logger: momentoLogger,
+        testMetricsCollector: testMetricsCollector,
+        requestId: v4(),
+        delayRpcList: [MomentoRPCMethod.TopicPublish],
+        delayMillis: 6000, // Default deadline is 5 seconds
+      };
+
+      await WithCacheAndTopicClient(
+        config => config,
+        momentoLocalMiddlewareArgs,
+        async (topicClient, cacheName) => {
+          const publishResponse = await topicClient.publish(
+            cacheName,
+            'topic',
+            'message'
+          );
+          expect(publishResponse).toBeInstanceOf(TopicPublish.Error);
+          expect((publishResponse as TopicPublish.Error).errorCode()).toEqual(
+            MomentoErrorCode.TIMEOUT_ERROR
+          );
+        }
+      );
+    });
+  });
+});

--- a/packages/client-sdk-nodejs/test/unit/test-retry-metrics-middleware.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/test-retry-metrics-middleware.test.ts
@@ -1,7 +1,7 @@
 import {
-  TestMetricsMiddlewareRequestHandler,
-  TestRetryMetricsMiddleware,
-} from '../test-retry-metrics-middleware';
+  MomentoLocalMiddlewareRequestHandler,
+  MomentoLocalMiddleware,
+} from '../momento-local-middleware';
 import {TestRetryMetricsCollector} from '../test-retry-metrics-collector';
 import {
   CredentialProvider,
@@ -23,7 +23,7 @@ import {MiddlewareMetadata} from '../../src/config/middleware/middleware';
 import {MomentoErrorCodeMetadataConverter} from '../../src/config/retry/momento-error-code-metadata-converter';
 
 describe('TestRetryMetricsMiddleware', () => {
-  let middleware: TestRetryMetricsMiddleware;
+  let middleware: MomentoLocalMiddleware;
   let cacheClient: CacheClient;
   let testMetricsCollector: TestRetryMetricsCollector;
   let momentoLogger: MomentoLogger;
@@ -33,7 +33,7 @@ describe('TestRetryMetricsMiddleware', () => {
     momentoLogger = new DefaultMomentoLoggerFactory().getLogger(
       'TestRetryMetricsMiddleware'
     );
-    middleware = new TestRetryMetricsMiddleware({
+    middleware = new MomentoLocalMiddleware({
       logger: momentoLogger,
       testMetricsCollector,
       requestId: v4(),
@@ -120,7 +120,7 @@ describe('TestRetryMetricsMiddleware', () => {
       delayCount,
     };
 
-    const handler = new TestMetricsMiddlewareRequestHandler(
+    const handler = new MomentoLocalMiddlewareRequestHandler(
       testRetryMetricsMiddlewareArgs
     );
     await handler.onRequestMetadata(middlewareMetadata);

--- a/packages/core/src/utils/topic-call-options.ts
+++ b/packages/core/src/utils/topic-call-options.ts
@@ -40,4 +40,9 @@ export interface SubscribeCallOptions {
    * @param heartbeat The heartbeat received from the topic subscription.
    */
   onHeartbeat?: (heartbeat: TopicHeartbeat) => void;
+
+  /**
+   * The callback to invoke when the connection is lost.
+   */
+  onConnectionLost?: () => void;
 }


### PR DESCRIPTION
## PR Description  
This commit introduces several improvements and fixes related to the topic client, including:  

- Adding middleware support for the topic client.  
- Renaming `TestMetricsMiddleware` to `MomentoLocalMiddleware` and refactoring the relevant code.  
- Adding momento local tests for topics using middleware.  
- Fixing the reconnect logic for subscriptions when an error occurs (details below).  

## Fixes  

### **Improved Retry Logic in [`handleSubscribeError`](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts#L217)**
- The [`shouldReconnectSubscription` flag is always set to `true`](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/client-sdk-nodejs/src/internal/pubsub-client.ts#L298), causing the client to always attempt a reconnect when an error occurs.  
- The [`sleep(reconnectDelayMillis)` function](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts#L268) introduces a delayed retry, which may still execute even after `unsubscribeFn` has been invoked.  

### **Race Condition Between Unsubscribe and Retry**  
- If an error occurs, [the retry logic schedules a `sendSubscribe` call after a 500ms delay.](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/core/src/internal/clients/pubsub/AbstractPubsubClient.ts#L263-L272)  
- However, if `unsubscribeFn` is called just before the retry executes, the subscription state might not be correctly checked, leading to unintended retries.  

### **Missing `subscriptionState.isSubscribed` Check in `handleSubscribeError`**  
- The [`prepareErrorCallback` function correctly verifies](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/client-sdk-nodejs/src/internal/pubsub-client.ts#L290-L292) whether the subscription has already been unsubscribed before handling the error.  
- However, `handleSubscribeError` does not perform this check before retrying, which can result in an unnecessary or unintended reconnect attempt.  

### **Fix**  
To prevent unintended retries, a validation check has been added in `handleSubscribeError` to ensure that `unsubscribeFn` has not already been called before attempting a reconnect.