### PR TITLE
feat: add test-admin keepAlive tests

### DIFF
--- a/.github/workflows/retry-tests.yml
+++ b/.github/workflows/retry-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-          docker run --cap-add=NET_ADMIN --rm -p 8080:8080 -p 9090:9090 -e LOG_LEVEL=debug gomomento/momento-local --enable-test-admin
+          docker run --cap-add=NET_ADMIN --rm -d -p 8080:8080 -p 9090:9090 -e LOG_LEVEL=debug gomomento/momento-local --enable-test-admin
 
       - name: Set script permissions
         run: chmod +x ./scripts/build-and-test-package-retry-tests.sh

--- a/.github/workflows/retry-tests.yml
+++ b/.github/workflows/retry-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-          docker run -d -p 8080:8080 gomomento/momento-local
+          docker run --cap-add=NET_ADMIN --rm -p 8080:8080 -p 9090:9090 -e LOG_LEVEL=debug gomomento/momento-local --enable-test-admin
 
       - name: Set script permissions
         run: chmod +x ./scripts/build-and-test-package-retry-tests.sh
@@ -26,6 +26,7 @@ jobs:
       - name: Build and test with Momento Local
         env:
           MOMENTO_PORT: 8080
+          MOMENTO_ADMIN_PORT: 9090
         run: |
           node -v
           ./scripts/build-and-test-package-retry-tests.sh

--- a/.github/workflows/retry-tests.yml
+++ b/.github/workflows/retry-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Start Momento Local
         run: |
-          docker run --cap-add=NET_ADMIN --rm -d -p 8080:8080 -p 9090:9090 -e LOG_LEVEL=debug gomomento/momento-local --enable-test-admin
+          docker run --cap-add=NET_ADMIN --rm -d -p 8080:8080 -p 9090:9090 gomomento/momento-local --enable-test-admin
 
       - name: Set script permissions
         run: chmod +x ./scripts/build-and-test-package-retry-tests.sh

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -113,6 +113,33 @@ export async function WithCacheAndTopicClient(
   await testCallback(topicClient, cacheName);
 }
 
+export class TestAdminClient {
+  private readonly endpoint: string;
+
+  constructor() {
+    const host = process.env.TEST_ADMIN_ENDPOINT || '127.0.0.1';
+    const port = process.env.TEST_ADMIN_PORT || '9090';
+    this.endpoint = `${host}:${port}`;
+  }
+
+  public async blockPort(): Promise<void> {
+    await this.sendRequest('/block', 'Failed to block port');
+  }
+
+  public async unblockPort(): Promise<void> {
+    await this.sendRequest('/unblock', 'Failed to unblock port');
+  }
+
+  private async sendRequest(path: string, errorMessage: string): Promise<void> {
+    try {
+      await fetch(`http://${this.endpoint}${path}`);
+    } catch (error) {
+      console.error(`${errorMessage}:`, error);
+      throw error;
+    }
+  }
+}
+
 let _credsProvider: CredentialProvider | undefined = undefined;
 export function credsProvider(): CredentialProvider {
   if (_credsProvider === undefined) {

--- a/packages/client-sdk-nodejs/test/integration/retry/topic-client-retry.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/topic-client-retry.test.ts
@@ -218,7 +218,6 @@ describe('Topic client retry tests', () => {
           expect(initialHeartbeatCount).toBeGreaterThan(0);
 
           // Block the admin port
-          momentoLogger.info('Blocking admin port');
           await testAdminClient.blockPort();
 
           // Wait for connection lost
@@ -227,7 +226,6 @@ describe('Topic client retry tests', () => {
           expect(heartbeatCounter).toBe(initialHeartbeatCount); // Ensure no new heartbeats during the block
 
           // Unblock the admin port
-          momentoLogger.info('Unblocking admin port');
           await testAdminClient.unblockPort();
 
           // Wait for heartbeat to resume after unblocking


### PR DESCRIPTION
## PR Description:  
- Add keep-alive tests for test-admin:  
  - Introduce `TestAdminClient` in `integration-setup` to handle port blocking/unblocking.  
  - Test flow:  
    1. Start a subscription and verify heartbeats.  
    2. Block the admin port and confirm heartbeats stop.  
    3. Unblock the port and ensure heartbeats resume.

## Issue
closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1186