### PR TITLE
chore: bump generated-types on nodejs

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.119.2",
+        "@gomomento/generated-types": "0.124.0",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.10.9",
         "@types/google-protobuf": "3.15.10",
@@ -812,9 +812,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.119.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.119.2.tgz",
-      "integrity": "sha512-pt/yBiz1CdLPWQnBt/Liv2dzT2XGW3kHswVxrFdd2EUhy0uh+mfUM4AmWkSq3/cvip7novkvZ0JzWeow42RauA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.124.0.tgz",
+      "integrity": "sha512-eSARccnsZ9MtdHfPhsxFWcOTSWZNemKtHE6nVlLEsFgDUEnZMV9dnVM8ECmo8XMGTpEutaYFCwUppdPshpwlHQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.10.9",
         "google-protobuf": "3.21.2",

--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gomomento/generated-types": "0.119.2",
         "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.10.9",
+        "@grpc/grpc-js": "1.13.1",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
@@ -822,14 +822,26 @@
         "protoc-gen-ts": "^0.8.6"
       }
     },
+    "node_modules/@gomomento/generated-types/node_modules/@grpc/grpc-js": {
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
     "node_modules/@gomomento/sdk-core": {
       "resolved": "../core",
       "link": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
+      "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"

--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@gomomento/generated-types": "0.119.2",
         "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.13.1",
+        "@grpc/grpc-js": "1.10.9",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
@@ -822,26 +822,14 @@
         "protoc-gen-ts": "^0.8.6"
       }
     },
-    "node_modules/@gomomento/generated-types/node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
-        "@js-sdsl/ordered-map": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=12.10.0"
-      }
-    },
     "node_modules/@gomomento/sdk-core": {
       "resolved": "../core",
       "link": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
-      "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
+      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@gomomento/generated-types": "0.119.2",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.13.1",
+    "@grpc/grpc-js": "1.10.9",
     "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@gomomento/generated-types": "0.119.2",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.10.9",
+    "@grpc/grpc-js": "1.13.1",
     "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -60,7 +60,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.119.2",
+    "@gomomento/generated-types": "0.124.0",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.10.9",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-nodejs/src/config/middleware/cache-request-logging.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/cache-request-logging.ts
@@ -856,6 +856,17 @@ const convertSortedSetLengthByScoreRequest: RequestToLogInterfaceConverterFn<
   };
 };
 
+// TODO elaborate on all the fields here. This is a stub.
+const convertSortedSetUnionStoreRequest: RequestToLogInterfaceConverterFn<
+  cache.cache_client._SortedSetUnionStoreRequest,
+  SortedSetRequestLog
+> = (request: cache.cache_client._SortedSetUnionStoreRequest) => {
+  return {
+    requestType: 'sortedSetUnionStore',
+    sortedSetName: convertBytesToString(request.set_name),
+  };
+};
+
 export const CacheRequestToLogInterfaceConverter = new Map<
   string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -907,4 +918,5 @@ export const CacheRequestToLogInterfaceConverter = new Map<
   ['_SortedSetGetRankRequest', convertSortedSetGetRankRequest],
   ['_SortedSetLengthRequest', convertSortedSetLengthRequest],
   ['_SortedSetLengthByScoreRequest', convertSortedSetLengthByScoreRequest],
+  ['_SortedSetUnionStoreRequest', convertSortedSetUnionStoreRequest],
 ]);

--- a/packages/client-sdk-nodejs/src/config/middleware/cache-request-logging.ts
+++ b/packages/client-sdk-nodejs/src/config/middleware/cache-request-logging.ts
@@ -61,6 +61,13 @@ const convertGetBatchRequest: RequestToLogInterfaceConverterFn<
   };
 };
 
+const convertGetWithHashRequest: RequestToLogInterfaceConverterFn<
+  cache.cache_client._GetWithHashRequest,
+  RequestSingleKeyLog
+> = (request: cache.cache_client._GetWithHashRequest) => {
+  return convertSingleKeyRequest('getWithHash', request.cache_key);
+};
+
 const convertDeleteRequest: RequestToLogInterfaceConverterFn<
   cache.cache_client._DeleteRequest,
   RequestSingleKeyLog
@@ -153,6 +160,31 @@ const convertSetIfNotExistsRequest: RequestToLogInterfaceConverterFn<
     key: convertBytesToString(request.cache_key),
     value: convertBytesToString(request.cache_body),
     ttlMillis: request.ttl_milliseconds,
+  };
+};
+
+const convertSetIfHashRequest: RequestToLogInterfaceConverterFn<
+  cache.cache_client._SetIfHashRequest,
+  SetRequestLog
+> = (request: cache.cache_client._SetIfHashRequest) => {
+  return {
+    requestType: 'setIfHash',
+    key: convertBytesToString(request.cache_key),
+    value: convertBytesToString(request.cache_body),
+    ttlMillis: request.ttl_milliseconds,
+    presentAndNotHashEqual: request.present_and_not_hash_equal
+      ? convertBytesToString(request.present_and_not_hash_equal.hash_to_check)
+      : undefined,
+    presentAndHashEqual: request.present_and_hash_equal
+      ? convertBytesToString(request.present_and_hash_equal.hash_to_check)
+      : undefined,
+    absentOrHashEqual: request.absent_or_hash_equal
+      ? convertBytesToString(request.absent_or_hash_equal.hash_to_check)
+      : undefined,
+    absentOrNotHashEqual: request.absent_or_not_hash_equal
+      ? convertBytesToString(request.absent_or_not_hash_equal.hash_to_check)
+      : undefined,
+    unconditional: request.unconditional ? true : undefined,
   };
 };
 
@@ -830,10 +862,12 @@ export const CacheRequestToLogInterfaceConverter = new Map<
   RequestToLogInterfaceConverterFn<any, RequestLog>
 >([
   ['_GetRequest', convertGetRequest],
+  ['_GetWithHashRequest', convertGetWithHashRequest],
   ['_GetBatchRequest', convertGetBatchRequest],
   ['_DeleteRequest', convertDeleteRequest],
   ['_SetRequest', convertSetRequest],
   ['_SetBatchRequest', convertSetBatchRequest],
+  ['_SetIfHashRequest', convertSetIfHashRequest],
   ['_SetIfRequest', convertSetIfRequest],
   ['_SetIfNotExistsRequest', convertSetIfNotExistsRequest],
   ['_KeysExistRequest', convertKeysExistRequest],

--- a/packages/client-sdk-nodejs/src/config/retry/momento-rpc-method.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/momento-rpc-method.ts
@@ -1,9 +1,11 @@
 enum MomentoRPCMethod {
   Get = '_GetRequest',
+  GetWithHash = '_GetWithHashRequest',
   Set = '_SetRequest',
   Delete = '_DeleteRequest',
   Increment = '_IncrementRequest',
   SetIf = '_SetIfRequest',
+  SetIfHash = '_SetIfHashRequest',
   SetIfNotExists = '_SetIfNotExistsRequest',
   GetBatch = '_GetBatchRequest',
   SetBatch = '_SetBatchRequest',
@@ -50,7 +52,9 @@ enum MomentoRPCMethod {
 class MomentoRPCMethodMetadataConverter {
   private static readonly rpcMethodToMetadataMap: Record<string, string> = {
     [MomentoRPCMethod.Get]: 'get',
+    [MomentoRPCMethod.GetWithHash]: 'get-with-hash',
     [MomentoRPCMethod.Set]: 'set',
+    [MomentoRPCMethod.SetIfHash]: 'set-if-hash',
     [MomentoRPCMethod.Delete]: 'delete',
     [MomentoRPCMethod.Increment]: 'increment',
     [MomentoRPCMethod.SetIf]: 'set-if',

--- a/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/leaderboard-data-client.ts
@@ -202,7 +202,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     elements: Record<number, number> | Map<number, number>
   ): Promise<LeaderboardUpsert.Response> {
     const request = new leaderboard._UpsertElementsRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
       elements: this.convertMapOrRecordToElementsList(elements),
     });
@@ -297,7 +296,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     }
 
     const request = new leaderboard._GetByScoreRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
       score_range: protoBufScoreRange,
       order: protoBufOrder,
@@ -376,7 +374,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     });
 
     const request = new leaderboard._GetByRankRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
       rank_range: protoBufRankRange,
       order: protoBufOrder,
@@ -434,7 +431,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
         : leaderboard._Order.ASCENDING;
 
     const request = new leaderboard._GetRankRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
       ids: ids,
       order: protoBufOrder,
@@ -480,7 +476,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     leaderboardName: string
   ): Promise<LeaderboardLength.Response> {
     const request = new leaderboard._GetLeaderboardLengthRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
     });
     const metadata = this.createMetadata(cacheName);
@@ -534,7 +529,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     ids: Array<number>
   ): Promise<LeaderboardRemoveElements.Response> {
     const request = new leaderboard._RemoveElementsRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
       ids: ids,
     });
@@ -578,7 +572,6 @@ export class LeaderboardDataClient implements ILeaderboardDataClient {
     leaderboardName: string
   ): Promise<LeaderboardDelete.Response> {
     const request = new leaderboard._DeleteLeaderboardRequest({
-      cache_name: cacheName,
       leaderboard: leaderboardName,
     });
     const metadata = this.createMetadata(cacheName);

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.119.2",
+        "@gomomento/generated-types-webtext": "0.124.0",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -814,9 +814,9 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.119.2",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.119.2.tgz",
-      "integrity": "sha512-Sxq1/JqnVe3IwOEhUTtXLtIoGV8tkAgVrNgHQJRu0F6h+ZZpvTfuB0kW+xq0uRVLSeZfDCQiH3bJsaezLVg+ug==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.124.0.tgz",
+      "integrity": "sha512-ZBSzCrfiz/b3XAtbv8FmHeMZ8RIQQEHiGfJddbcogorhVYs/JXawhTVnqwrJpqdJWMTjGfyhDXrDpWXurEzQ0w==",
       "dependencies": {
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -64,7 +64,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.119.2",
+    "@gomomento/generated-types-webtext": "0.124.0",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",

--- a/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
+++ b/packages/client-sdk-web/src/internal/leaderboard-data-client.ts
@@ -146,7 +146,6 @@ export class LeaderboardDataClient<
     elements: Record<number, number> | Map<number, number>
   ): Promise<LeaderboardUpsert.Response> {
     const request = new _UpsertElementsRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
     request.setElementsList(this.convertMapOrRecordToElementsList(elements));
 
@@ -223,7 +222,6 @@ export class LeaderboardDataClient<
     maxScore?: number
   ): Promise<LeaderboardFetch.Response> {
     const request = new _GetByScoreRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
     request.setOffset(offset);
     request.setLimitElements(count);
@@ -311,7 +309,6 @@ export class LeaderboardDataClient<
     order: LeaderboardOrder
   ): Promise<LeaderboardFetch.Response> {
     const request = new _GetByRankRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
 
     const protoBufOrder =
@@ -375,7 +372,6 @@ export class LeaderboardDataClient<
     order: LeaderboardOrder
   ): Promise<LeaderboardFetch.Response> {
     const request = new _GetRankRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
     request.setIdsList(ids);
 
@@ -428,7 +424,6 @@ export class LeaderboardDataClient<
     leaderboardName: string
   ): Promise<LeaderboardLength.Response> {
     const request = new _GetLeaderboardLengthRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
 
     return await new Promise((resolve, reject) => {
@@ -480,7 +475,6 @@ export class LeaderboardDataClient<
     ids: Array<number>
   ): Promise<LeaderboardRemoveElements.Response> {
     const request = new _RemoveElementsRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
     request.setIdsList(ids);
 
@@ -523,7 +517,6 @@ export class LeaderboardDataClient<
     leaderboardName: string
   ): Promise<LeaderboardDelete.Response> {
     const request = new _DeleteLeaderboardRequest();
-    request.setCacheName(cacheName);
     request.setLeaderboard(leaderboardName);
 
     return await new Promise((resolve, reject) => {


### PR DESCRIPTION
Bumps the generated-types dependency on the nodejs sdk to the latest
version (v `1.24.0`).
