### PR TITLE
chore(nodejs): bump generated types and grpc-js to latest version

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.124.0",
+        "@gomomento/generated-types": "0.124.1",
         "@gomomento/sdk-core": "file:../core",
-        "@grpc/grpc-js": "1.10.9",
+        "@grpc/grpc-js": "1.13.1",
         "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
@@ -812,11 +812,11 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.124.0.tgz",
-      "integrity": "sha512-eSARccnsZ9MtdHfPhsxFWcOTSWZNemKtHE6nVlLEsFgDUEnZMV9dnVM8ECmo8XMGTpEutaYFCwUppdPshpwlHQ==",
+      "version": "0.124.1",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.124.1.tgz",
+      "integrity": "sha512-r+YZVV8G/Eaf9YNWYUWK5aTzEYV5BXSBhZvkhA1jaRbvDet22KbfDXr8SB2j/08NdKFuDLU6ARRypd3QsL94kg==",
       "dependencies": {
-        "@grpc/grpc-js": "1.10.9",
+        "@grpc/grpc-js": "1.13.1",
         "google-protobuf": "3.21.2",
         "grpc-tools": "^1.12.4",
         "protoc-gen-ts": "^0.8.6"
@@ -827,9 +827,9 @@
       "link": true
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
+      "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -5560,9 +5560,9 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+      "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6215,9 +6215,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
-      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -60,9 +60,9 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.124.0",
+    "@gomomento/generated-types": "0.124.1",
     "@gomomento/sdk-core": "file:../core",
-    "@grpc/grpc-js": "1.10.9",
+    "@grpc/grpc-js": "1.13.1",
     "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"


### PR DESCRIPTION
Bumps the generated types dependency to the latest version, which also
bumps grpc-js to v1.13.1. We also bump the grpc-js dependency to match
that.
