### PR TITLE
chore: bump generated types to 0.124.4

### DIFF
--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -12,12 +12,12 @@
         "@gomomento/generated-types": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.13.1",
-        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
+        "@types/google-protobuf": "3.15.10",
         "@types/jest": "27.5.2",
         "@types/node": "16.18.97",
         "@types/uuid": "8.3.4",
@@ -1508,7 +1508,8 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.10",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
-      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types": "0.124.3",
+        "@gomomento/generated-types": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.13.1",
         "@types/google-protobuf": "3.15.10",
@@ -812,14 +812,12 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types": {
-      "version": "0.124.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.124.3.tgz",
-      "integrity": "sha512-0a3o9EsxoStK868Ii4utAQRijMcIwIvCyMZ/mZn+wJmQCXJKxNWZ2fM6lFYWcTMJYHmBUQaJyvMJwIZYyxUV4w==",
-      "dependencies": {
-        "google-protobuf": "3.21.2"
-      },
+      "version": "0.124.4",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types/-/generated-types-0.124.4.tgz",
+      "integrity": "sha512-SohIuIBgFbsnQNiV1E/55J5u2leN0AOavIpy0DtludEiJIWctqOphsIY8rirNM8ygltt7SpvRiuR5ip9JZen3g==",
       "peerDependencies": {
-        "@grpc/grpc-js": "1.13.1"
+        "@grpc/grpc-js": "1.13.1",
+        "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@gomomento/sdk-core": {

--- a/packages/client-sdk-nodejs/package-lock.json
+++ b/packages/client-sdk-nodejs/package-lock.json
@@ -12,12 +12,12 @@
         "@gomomento/generated-types": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
         "@grpc/grpc-js": "1.13.1",
+        "@types/google-protobuf": "3.15.10",
         "google-protobuf": "3.21.2",
         "jwt-decode": "3.1.2"
       },
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
-        "@types/google-protobuf": "3.15.10",
         "@types/jest": "27.5.2",
         "@types/node": "16.18.97",
         "@types/uuid": "8.3.4",
@@ -1508,8 +1508,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.10",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.10.tgz",
-      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g==",
-      "dev": true
+      "integrity": "sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -60,7 +60,7 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "@gomomento/generated-types": "0.124.3",
+    "@gomomento/generated-types": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.13.1",
     "@types/google-protobuf": "3.15.10",

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
     "@types/jest": "27.5.2",
+    "@types/google-protobuf": "3.15.10",
     "@types/node": "16.18.97",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "5.62.0",
@@ -63,7 +64,6 @@
     "@gomomento/generated-types": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.13.1",
-    "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"
   },

--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
     "@types/jest": "27.5.2",
-    "@types/google-protobuf": "3.15.10",
     "@types/node": "16.18.97",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "5.62.0",
@@ -64,6 +63,7 @@
     "@gomomento/generated-types": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
     "@grpc/grpc-js": "1.13.1",
+    "@types/google-protobuf": "3.15.10",
     "google-protobuf": "3.21.2",
     "jwt-decode": "3.1.2"
   },

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
-        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -19,6 +18,7 @@
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
         "@happy-dom/jest-environment": "^16.8.1",
+        "@types/google-protobuf": "3.15.6",
         "@types/jest": "27.5.2",
         "@types/node": "16.18.97",
         "@types/uuid": "^9.0.7",
@@ -1393,7 +1393,8 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@gomomento/generated-types-webtext": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
+        "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "jwt-decode": "3.1.2"
@@ -18,7 +19,6 @@
       "devDependencies": {
         "@gomomento/common-integration-tests": "file:../common-integration-tests",
         "@happy-dom/jest-environment": "^16.8.1",
-        "@types/google-protobuf": "3.15.6",
         "@types/jest": "27.5.2",
         "@types/node": "16.18.97",
         "@types/uuid": "^9.0.7",
@@ -1393,8 +1393,7 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
-      "dev": true
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/packages/client-sdk-web/package-lock.json
+++ b/packages/client-sdk-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gomomento/generated-types-webtext": "0.124.3",
+        "@gomomento/generated-types-webtext": "0.124.4",
         "@gomomento/sdk-core": "file:../core",
         "@types/google-protobuf": "3.15.6",
         "google-protobuf": "3.21.2",
@@ -814,13 +814,11 @@
       "link": true
     },
     "node_modules/@gomomento/generated-types-webtext": {
-      "version": "0.124.3",
-      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.124.3.tgz",
-      "integrity": "sha512-VBwXxw7jGCy2WwGf7ScjJvgPz6JiE38dzLTrz751txpu1RBRUv5f/7UxbUXCHf7TTYrgacqGXGYqMMTrQIz48w==",
-      "dependencies": {
-        "google-protobuf": "3.21.2"
-      },
+      "version": "0.124.4",
+      "resolved": "https://registry.npmjs.org/@gomomento/generated-types-webtext/-/generated-types-webtext-0.124.4.tgz",
+      "integrity": "sha512-mLiX5vFx1rtQE7kHCV5lrtvBaOl+DTSGKYHxcxi4YXCwW0BvAMlCxP6+TXb1WPdiIfIdCZe9DJ4lP8VBOX25hw==",
       "peerDependencies": {
+        "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
     "@happy-dom/jest-environment": "^16.8.1",
-    "@types/google-protobuf": "3.15.6",
     "@types/jest": "27.5.2",
     "@types/node": "16.18.97",
     "@types/uuid": "^9.0.7",
@@ -67,6 +66,7 @@
   "dependencies": {
     "@gomomento/generated-types-webtext": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
+    "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",
     "jwt-decode": "3.1.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@gomomento/common-integration-tests": "file:../common-integration-tests",
     "@happy-dom/jest-environment": "^16.8.1",
+    "@types/google-protobuf": "3.15.6",
     "@types/jest": "27.5.2",
     "@types/node": "16.18.97",
     "@types/uuid": "^9.0.7",
@@ -66,7 +67,6 @@
   "dependencies": {
     "@gomomento/generated-types-webtext": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
-    "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",
     "jwt-decode": "3.1.2"

--- a/packages/client-sdk-web/package.json
+++ b/packages/client-sdk-web/package.json
@@ -64,7 +64,7 @@
     "xhr2": "0.2.1"
   },
   "dependencies": {
-    "@gomomento/generated-types-webtext": "0.124.3",
+    "@gomomento/generated-types-webtext": "0.124.4",
     "@gomomento/sdk-core": "file:../core",
     "@types/google-protobuf": "3.15.6",
     "google-protobuf": "3.21.2",


### PR DESCRIPTION
Similar to #1545, we update the generated types but this time with protobuf as a peer dependency. This protects application developers from the same dual package hazard we saw with grpc.