### PR TITLE
feat: configure topic client to use separate publish and subscribe grpc channels

### DIFF
--- a/packages/client-sdk-nodejs/src/config/topic-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configuration.ts
@@ -42,6 +42,7 @@ export interface TopicConfiguration {
   getTransportStrategy(): TopicTransportStrategy;
 
   /**
+   * @deprecated Use `withNumStreamConnections()` and `withNumUnaryConnections()` instead.
    * Shorthand copy constructor for overriding TransportStrategy.GrpcStrategy.NumClients. This will
    * allow you to control the number of TCP connections that the client will open to the server. Usually
    * you should stick with the default value from your pre-built configuration, but it can be valuable
@@ -51,6 +52,28 @@ export interface TopicConfiguration {
    * @returns {Configuration} a new Configuration object with the updated TransportStrategy
    */
   withNumConnections(numConnections: number): TopicConfiguration;
+
+  /**
+   * Shorthand copy constructor for overriding TransportStrategy.GrpcStrategy.NumStreamClients. This will
+   * allow you to control the number of TCP connections that the client will open to the server for streaming
+   * requests. Usually you should stick with the default value from your pre-built configuration, but it can be valuable
+   * to increase this value in order to ensure more evenly distributed load on Momento servers.
+   *
+   * @param {number} numConnections
+   * @returns {Configuration} a new Configuration object with the updated TransportStrategy
+   */
+  withNumStreamConnections(numConnections: number): TopicConfiguration;
+
+  /**
+   * Shorthand copy constructor for overriding TransportStrategy.GrpcStrategy.NumUnaryClients. This will
+   * allow you to control the number of TCP connections that the client will open to the server for unary
+   * requests. Usually you should stick with the default value from your pre-built configuration, but it can be valuable
+   * to increase this value in order to ensure more evenly distributed load on Momento servers.
+   *
+   * @param {number} numConnections
+   * @returns {Configuration} a new Configuration object with the updated TransportStrategy
+   */
+  withNumUnaryConnections(numConnections: number): TopicConfiguration;
 
   /**
    * @returns {boolean} Configures whether the client should return a Momento Error object or throw an exception when an
@@ -131,6 +154,26 @@ export class TopicClientConfiguration implements TopicConfiguration {
         this.getTransportStrategy()
           .getGrpcConfig()
           .withNumClients(numConnections)
+      )
+    );
+  }
+
+  withNumStreamConnections(numConnections: number): TopicConfiguration {
+    return this.withTransportStrategy(
+      this.getTransportStrategy().withGrpcConfig(
+        this.getTransportStrategy()
+          .getGrpcConfig()
+          .withNumStreamClients(numConnections)
+      )
+    );
+  }
+
+  withNumUnaryConnections(numConnections: number): TopicConfiguration {
+    return this.withTransportStrategy(
+      this.getTransportStrategy().withGrpcConfig(
+        this.getTransportStrategy()
+          .getGrpcConfig()
+          .withNumUnaryClients(numConnections)
       )
     );
   }

--- a/packages/client-sdk-nodejs/src/config/topic-configurations.ts
+++ b/packages/client-sdk-nodejs/src/config/topic-configurations.ts
@@ -33,7 +33,8 @@ export class Default extends TopicClientConfiguration {
       loggerFactory: loggerFactory,
       transportStrategy: new StaticTopicTransportStrategy({
         grpcConfiguration: new StaticTopicGrpcConfiguration({
-          numClients: 1,
+          numStreamClients: 1,
+          numUnaryClients: 1,
           keepAlivePermitWithoutCalls: 1,
           keepAliveTimeMs: 5000,
           keepAliveTimeoutMs: 1000,
@@ -63,7 +64,8 @@ export class Lambda extends TopicClientConfiguration {
     loggerFactory: MomentoLoggerFactory = defaultLoggerFactory
   ): TopicClientConfiguration {
     const grpcConfig = new StaticTopicGrpcConfiguration({
-      numClients: 1,
+      numStreamClients: 1,
+      numUnaryClients: 1,
       deadlineMillis: 5000,
     });
     const transportStrategy = new StaticTopicTransportStrategy({

--- a/packages/client-sdk-nodejs/src/config/transport/topics/grpc-configuration.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/topics/grpc-configuration.ts
@@ -1,9 +1,22 @@
 export interface TopicGrpcConfigurationProps {
   /**
-   * The number of internal clients a topic client will create to communicate with Momento. More of them allows
-   * more concurrent requests, at the cost of more open connections and the latency of setting up each client.
+   * @deprecated Use `numStreamClients` and `numUnaryClients` instead.
+   * The number of internal clients a topic client will create to communicate with Momento.
+   * More of them allows more concurrent requests, at the cost of more open connections and the latency of setting up each client.
    */
   numClients?: number;
+
+  /**
+   * The number of internal clients a topic client will create to communicate with Momento for streaming requests (e.g. subscribe).
+   * More of them allows more concurrent requests, at the cost of more open connections and the latency of setting up each client.
+   */
+  numStreamClients?: number;
+
+  /**
+   * The number of internal clients a topic client will create to communicate with Momento for unary requests (e.g. publish).
+   * More of them allows more concurrent requests, at the cost of more open connections and the latency of setting up each client.
+   */
+  numUnaryClients?: number;
 
   /**
    * Indicates if it permissible to send keepalive pings from the client without any outstanding streams.
@@ -53,17 +66,52 @@ export interface TopicGrpcConfigurationProps {
  */
 export interface TopicGrpcConfiguration {
   /**
+   * @deprecated Use `getNumStreamClients()` and `getNumUnaryClients()` instead.
    * @returns {number} the number of internal clients a topic client will create to communicate with Momento. More of
    * them will allow for more concurrent requests.
    */
   getNumClients(): number;
 
   /**
-   * Copy constructor for overriding the number of clients to create
-   * @param {number} numClients the number of internal clients to create
-   * @returns {GrpcConfiguration} a new GrpcConfiguration with the specified number of clients
+   * @deprecated Use `withNumStreamClients()` and `withNumUnaryClients()` instead.
+   * Copy constructor for overriding the number of clients to create.
+   *
+   * @param {number} numClients - @deprecated Use `withNumStreamClients()` and `withNumUnaryClients()` instead.
+   * The number of internal clients to create.
+   *
+   * @returns {GrpcConfiguration} A new GrpcConfiguration with the specified number of clients.
    */
   withNumClients(numClients: number): TopicGrpcConfiguration;
+
+  /**
+   * @returns {number} the number of internal clients a topic client will create to communicate with Momento for streaming requests (e.g. subscribe). More of
+   * them will allow for more concurrent requests.
+   */
+  getNumStreamClients(): number;
+
+  /**
+   * Copy constructor for overriding the number of stream clients to create.
+   *
+   * @param {number} numStreamClients - The number of internal clients to create for streaming requests.
+   *
+   * @returns {TopicGrpcConfiguration} A new GrpcConfiguration with the specified number of stream clients.
+   */
+  withNumStreamClients(numStreamClients: number): TopicGrpcConfiguration;
+
+  /**
+   * @returns {number} the number of internal clients a topic client will create to communicate with Momento for unary requests (e.g. publish). More of
+   * them will allow for more concurrent requests.
+   */
+  getNumUnaryClients(): number;
+
+  /**
+   * Copy constructor for overriding the number of unary clients to create.
+   *
+   * @param {number} numUnaryClients - The number of internal clients to create for unary requests.
+   *
+   * @returns {TopicGrpcConfiguration} A new GrpcConfiguration with the specified number of unary clients.
+   */
+  withNumUnaryClients(numUnaryClients: number): TopicGrpcConfiguration;
 
   /**
    * NOTE: keep-alives are very important for long-lived server environments where there may be periods of time

--- a/packages/client-sdk-nodejs/src/config/transport/topics/transport-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/transport/topics/transport-strategy.ts
@@ -35,16 +35,27 @@ export interface TopicTransportStrategyProps {
 
 export class StaticTopicGrpcConfiguration implements TopicGrpcConfiguration {
   private readonly numClients: number;
+  private readonly numStreamClients: number;
+  private readonly numUnaryClients: number;
   private readonly keepAlivePermitWithoutCalls?: number;
   private readonly keepAliveTimeoutMs?: number;
   private readonly keepAliveTimeMs?: number;
   private readonly deadlineMillis: number;
 
   constructor(props: TopicGrpcConfigurationProps) {
-    if (props.numClients !== undefined && props.numClients !== null) {
-      this.numClients = props.numClients;
+    if (
+      props.numStreamClients !== undefined &&
+      props.numStreamClients !== null
+    ) {
+      this.numStreamClients = props.numStreamClients;
     } else {
-      this.numClients = 1;
+      this.numStreamClients = 1;
+    }
+
+    if (props.numUnaryClients !== undefined && props.numUnaryClients !== null) {
+      this.numUnaryClients = props.numUnaryClients;
+    } else {
+      this.numUnaryClients = 1;
     }
 
     this.keepAliveTimeMs = props.keepAliveTimeMs;
@@ -57,10 +68,32 @@ export class StaticTopicGrpcConfiguration implements TopicGrpcConfiguration {
     return this.numClients;
   }
 
+  getNumStreamClients(): number {
+    return this.numStreamClients;
+  }
+
+  getNumUnaryClients(): number {
+    return this.numUnaryClients;
+  }
+
   withNumClients(numClients: number): TopicGrpcConfiguration {
     return new StaticTopicGrpcConfiguration({
       ...this,
       numClients,
+    });
+  }
+
+  withNumStreamClients(numStreamClients: number): TopicGrpcConfiguration {
+    return new StaticTopicGrpcConfiguration({
+      ...this,
+      numStreamClients,
+    });
+  }
+
+  withNumUnaryClients(numUnaryClients: number): TopicGrpcConfiguration {
+    return new StaticTopicGrpcConfiguration({
+      ...this,
+      numUnaryClients,
     });
   }
 

--- a/packages/client-sdk-nodejs/src/topic-client.ts
+++ b/packages/client-sdk-nodejs/src/topic-client.ts
@@ -24,14 +24,23 @@ export class TopicClient extends AbstractTopicClient {
         props?.configuration ?? getDefaultTopicClientConfiguration(),
     };
 
-    const numClients = allProps.configuration
+    const grpcConfig = allProps.configuration
       .getTransportStrategy()
-      .getGrpcConfig()
-      .getNumClients();
+      .getGrpcConfig();
+
+    if (grpcConfig.getNumClients()) {
+      throw new Error(
+        'Deprecated: Use withNumStreamClients() and withNumUnaryClients() instead.'
+      );
+    }
+
+    const numStreamClients = grpcConfig.getNumStreamClients();
+    const numUnaryClients = grpcConfig.getNumUnaryClients();
 
     super(
       allProps.configuration.getLoggerFactory().getLogger(TopicClient.name),
-      range(numClients).map(_ => new PubsubClient(allProps)),
+      range(numStreamClients).map(_ => new PubsubClient(allProps)),
+      range(numUnaryClients).map(_ => new PubsubClient(allProps)),
       new WebhookClient(allProps)
     );
 

--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -32,6 +32,7 @@ import {
   MomentoLocalMiddlewareArgs,
 } from '../momento-local-middleware';
 import {MomentoLocalProviderProps} from '@gomomento/sdk-core/dist/src/auth';
+import {TopicClientAllProps} from '../../src/internal/topic-client-all-props';
 
 export const deleteCacheIfExists = async (
   momento: CacheClient,
@@ -209,6 +210,19 @@ export function integrationTestCacheClientProps(): CacheClientAllProps {
   };
 }
 
+export function integrationTestTopicClientProps(): TopicClientAllProps {
+  let credentialProvider = credsProvider();
+  if (testAgainstMomentoLocal()) {
+    credentialProvider = new MomentoLocalProvider();
+  }
+
+  return {
+    configuration:
+      TopicConfigurations.Default.latest().withClientTimeoutMillis(90000),
+    credentialProvider,
+  };
+}
+
 function momentoClientForTesting(): CacheClient {
   return new CacheClient(integrationTestCacheClientProps());
 }
@@ -246,8 +260,8 @@ function momentoCacheClientForTestingWithMgaAccountSessionToken(): CacheClient {
 
 function momentoTopicClientForTesting(): TopicClient {
   return new TopicClient({
-    configuration: integrationTestCacheClientProps().configuration,
-    credentialProvider: integrationTestCacheClientProps().credentialProvider,
+    configuration: integrationTestTopicClientProps().configuration,
+    credentialProvider: integrationTestTopicClientProps().credentialProvider,
   });
 }
 
@@ -261,14 +275,14 @@ function momentoStorageClientForTesting(): PreviewStorageClient {
 function momentoTopicClientWithThrowOnErrorsForTesting(): TopicClient {
   return new TopicClient({
     configuration:
-      integrationTestCacheClientProps().configuration.withThrowOnErrors(true),
-    credentialProvider: integrationTestCacheClientProps().credentialProvider,
+      integrationTestTopicClientProps().configuration.withThrowOnErrors(true),
+    credentialProvider: integrationTestTopicClientProps().credentialProvider,
   });
 }
 
 function momentoTopicClientForTestingWithMgaAccountSessionToken(): TopicClient {
   return new TopicClient({
-    configuration: integrationTestCacheClientProps().configuration,
+    configuration: integrationTestTopicClientProps().configuration,
     credentialProvider: mgaAccountSessionTokenCredsProvider(),
   });
 }
@@ -452,7 +466,7 @@ export function SetupAuthClientIntegrationTest(): {
         credentialProvider: CredentialProvider.fromString({
           authToken: authToken,
         }),
-        configuration: Configurations.Laptop.latest(),
+        configuration: TopicConfigurations.Default.latest(),
       }),
     cacheName: cacheName,
   };

--- a/packages/client-sdk-web/src/topic-client.ts
+++ b/packages/client-sdk-web/src/topic-client.ts
@@ -27,6 +27,7 @@ export class TopicClient extends AbstractTopicClient {
     super(
       configuration.getLoggerFactory().getLogger(TopicClient.name),
       [new PubsubClient(allProps)],
+      [new PubsubClient(allProps)],
       new WebhookClient(allProps)
     );
     this.logger.debug('Instantiated Momento TopicClient');


### PR DESCRIPTION
## PR Description

- Introduces separate gRPC channels for streaming (`subscribe`) and unary (`publish`) operations in both the Node.js and Web SDKs.
- Deprecates the use of `numClients` in favor of separate configuration options for `numStreamClients` and `numUnaryClients`.

## Notes

- **Node.js SDK:** Previously, we defaulted to `numClients = 1`. To maintain behavior, we now default both `numStreamClients` and `numUnaryClients` to `1`.  
  _(For comparison, the Go SDK uses a default of `4` clients.)_
  
- **Web SDK:** We were previously creating a single topic client. This has been preserved, but now we create two separate gRPC channels: one for publishing and one for subscribing [[code ref]](https://github.com/momentohq/client-sdk-javascript/blob/main/packages/client-sdk-web/src/topic-client.ts#L28-L30)
