### PR TITLE
chore: let the old grpc client drain after configured timeout

### DIFF
--- a/packages/client-sdk-nodejs/test/unit/grpc/idle-grpc-client-wrapper.test.ts
+++ b/packages/client-sdk-nodejs/test/unit/grpc/idle-grpc-client-wrapper.test.ts
@@ -73,6 +73,8 @@ describe('IdleGrpcClientWrapper', () => {
     wrapper.getClient();
     // factory should be called twice (initial + reconnection)
     expect(factory).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1000); // Advance time to ensure the client is closed
     // the first client should be closed
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(badClient.close).toHaveBeenCalledTimes(1);
@@ -107,6 +109,8 @@ describe('IdleGrpcClientWrapper', () => {
     const c2 = wrapper.getClient();
     expect(c2).toBe(newClient);
     expect(factory).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1000); // Advance time to ensure the client is closed
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(initialClient.close).toHaveBeenCalledTimes(1);
   });
@@ -140,6 +144,8 @@ describe('IdleGrpcClientWrapper', () => {
     const c2 = wrapper.getClient();
     expect(c2).toBe(newClient);
     expect(factory).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1000); // Advance time to ensure the client is closed
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(initialClient.close).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## PR Description
This PR enhances the `IdleGrpcClientWrapper` to more gracefully handle gRPC client reconnections by introducing a new `ClientReaper` utility. This addresses scenarios where `.close()` was being called immediately on clients that may still have in-flight requests — potentially causing disruptions like `DEADLINE_EXCEEDED` errors.

