### PR TITLE
fix: fixed timeout retry strategy should overwrite deadline only after first request fails

### DIFF
--- a/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
@@ -6,7 +6,7 @@ import {EligibilityStrategy} from './eligibility-strategy';
 import {MomentoLoggerFactory, MomentoLogger} from '../..';
 import {DefaultStorageEligibilityStrategy} from './storage-default-eligibility-strategy';
 import {Status} from '@grpc/grpc-js/build/src/constants';
-import {getCurrentTimeAsDateObject} from '../../internal/utils';
+import {hasExceededDeadlineRelativeToNow} from '../../internal/utils';
 
 export interface FixedTimeoutRetryStrategyProps {
   loggerFactory: MomentoLoggerFactory;
@@ -47,7 +47,7 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     if (
       props.attemptNumber > 0 &&
       props.grpcStatus.code === Status.DEADLINE_EXCEEDED &&
-      props.overallDeadline >= getCurrentTimeAsDateObject()
+      hasExceededDeadlineRelativeToNow(props.overallDeadline)
     ) {
       this.logger.debug(
         `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`

--- a/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
@@ -47,7 +47,7 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     if (
       props.attemptNumber > 0 &&
       props.grpcStatus.code === Status.DEADLINE_EXCEEDED &&
-      props.overallDeadline > getCurrentTimeAsDateObject()
+      props.overallDeadline >= getCurrentTimeAsDateObject()
     ) {
       this.logger.debug(
         `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`

--- a/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
@@ -5,6 +5,7 @@ import {
 import {EligibilityStrategy} from './eligibility-strategy';
 import {MomentoLoggerFactory, MomentoLogger} from '../..';
 import {DefaultStorageEligibilityStrategy} from './storage-default-eligibility-strategy';
+import {Status} from '@grpc/grpc-js/build/src/constants';
 
 export interface FixedTimeoutRetryStrategyProps {
   loggerFactory: MomentoLoggerFactory;
@@ -39,6 +40,20 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     this.logger.debug(
       `Determining whether request is eligible for retry; status code: ${props.grpcStatus.code}, request type: ${props.grpcRequest.path}, attemptNumber: ${props.attemptNumber}`
     );
+
+    // If a retry attempt's timeout has passed but the client's overall timeout has not yet passed,
+    // we should reset the deadline and retry.
+    if (
+      props.attemptNumber > 0 &&
+      props.grpcStatus.code === Status.DEADLINE_EXCEEDED &&
+      props.overallDeadline > new Date(Date.now())
+    ) {
+      this.logger.debug(
+        `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`
+      );
+      return addJitter(this.retryDelayIntervalMillis);
+    }
+
     if (!this.eligibilityStrategy.isEligibleForRetry(props)) {
       // null means do not retry
       return null;
@@ -47,7 +62,6 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     this.logger.debug(
       `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`
     );
-    // retry after a fixed time interval has passed (+/- some jitter)
     return addJitter(this.retryDelayIntervalMillis);
   }
 }

--- a/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
@@ -47,7 +47,7 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     if (
       props.attemptNumber > 0 &&
       props.grpcStatus.code === Status.DEADLINE_EXCEEDED &&
-      hasExceededDeadlineRelativeToNow(props.overallDeadline)
+      !hasExceededDeadlineRelativeToNow(props.overallDeadline)
     ) {
       this.logger.debug(
         `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`

--- a/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/fixed-timeout-retry-strategy.ts
@@ -6,6 +6,7 @@ import {EligibilityStrategy} from './eligibility-strategy';
 import {MomentoLoggerFactory, MomentoLogger} from '../..';
 import {DefaultStorageEligibilityStrategy} from './storage-default-eligibility-strategy';
 import {Status} from '@grpc/grpc-js/build/src/constants';
+import {getCurrentTimeAsDateObject} from '../../internal/utils';
 
 export interface FixedTimeoutRetryStrategyProps {
   loggerFactory: MomentoLoggerFactory;
@@ -46,7 +47,7 @@ export class FixedTimeoutRetryStrategy implements RetryStrategy {
     if (
       props.attemptNumber > 0 &&
       props.grpcStatus.code === Status.DEADLINE_EXCEEDED &&
-      props.overallDeadline > new Date(Date.now())
+      props.overallDeadline > getCurrentTimeAsDateObject()
     ) {
       this.logger.debug(
         `Request is eligible for retry (attempt ${props.attemptNumber}), retrying after ${this.retryDelayIntervalMillis} ms +/- jitter.`

--- a/packages/client-sdk-nodejs/src/config/retry/retry-strategy.ts
+++ b/packages/client-sdk-nodejs/src/config/retry/retry-strategy.ts
@@ -6,6 +6,7 @@ export interface DeterminewhenToRetryRequestProps {
   grpcRequest: ClientMethodDefinition<unknown, unknown>;
   attemptNumber: number;
   requestMetadata: Metadata;
+  overallDeadline: Date;
 }
 
 export interface RetryStrategy {

--- a/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
@@ -16,6 +16,10 @@ import {RetryStrategy} from '../../config/retry/retry-strategy';
 import {Status} from '@grpc/grpc-js/build/src/constants';
 import {MomentoLoggerFactory} from '../../';
 import {NoRetryStrategy} from '../../config/retry/no-retry-strategy';
+import {
+  createDateObjectFromUnixMillisTimestamp,
+  getCurrentTimeAsDateObject,
+} from '../utils';
 
 export interface RetryInterceptorProps {
   clientName: string;
@@ -118,7 +122,7 @@ export class RetryInterceptor {
                 //
                 // We also need this check in case DEADLINE_EXCEEDED is marked as a retryable status code
                 // as it is in the default storage eligibility strategy.
-                if (new Date(Date.now()) >= overallDeadline) {
+                if (getCurrentTimeAsDateObject() >= overallDeadline) {
                   logger.debug(
                     `Request not eligible for retry: path: ${
                       options.method_definition.path
@@ -233,8 +237,9 @@ export class RetryInterceptor {
 }
 
 function calculateDeadline(offsetMillis: number, maxDeadline?: Date): Date {
-  const deadline = new Date(Date.now());
-  deadline.setMilliseconds(deadline.getMilliseconds() + offsetMillis);
+  const deadline = createDateObjectFromUnixMillisTimestamp(
+    getCurrentTimeAsDateObject().getTime() + offsetMillis
+  );
   if (maxDeadline !== undefined && deadline > maxDeadline) {
     return maxDeadline;
   }

--- a/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
@@ -19,6 +19,7 @@ import {NoRetryStrategy} from '../../config/retry/no-retry-strategy';
 import {
   createDateObjectFromUnixMillisTimestamp,
   getCurrentTimeAsDateObject,
+  hasExceededDeadlineRelativeToNow,
 } from '../utils';
 
 export interface RetryInterceptorProps {
@@ -122,7 +123,7 @@ export class RetryInterceptor {
                 //
                 // We also need this check in case DEADLINE_EXCEEDED is marked as a retryable status code
                 // as it is in the default storage eligibility strategy.
-                if (getCurrentTimeAsDateObject() >= overallDeadline) {
+                if (hasExceededDeadlineRelativeToNow(overallDeadline)) {
                   logger.debug(
                     `Request not eligible for retry: path: ${
                       options.method_definition.path

--- a/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
+++ b/packages/client-sdk-nodejs/src/internal/grpc/retry-interceptor.ts
@@ -240,7 +240,7 @@ function calculateDeadline(offsetMillis: number, maxDeadline?: Date): Date {
   const deadline = createDateObjectFromUnixMillisTimestamp(
     getCurrentTimeAsDateObject().getTime() + offsetMillis
   );
-  if (maxDeadline !== undefined && deadline > maxDeadline) {
+  if (maxDeadline !== undefined && deadline >= maxDeadline) {
     return maxDeadline;
   }
   return deadline;

--- a/packages/client-sdk-nodejs/src/internal/utils.ts
+++ b/packages/client-sdk-nodejs/src/internal/utils.ts
@@ -14,3 +14,7 @@ export function createDateObjectFromUnixMillisTimestamp(
 ): Date {
   return new Date(unixMillisTimestamp);
 }
+
+export function hasExceededDeadlineRelativeToNow(overallDeadline: Date) {
+  return getCurrentTimeAsDateObject() >= overallDeadline;
+}

--- a/packages/client-sdk-nodejs/src/internal/utils.ts
+++ b/packages/client-sdk-nodejs/src/internal/utils.ts
@@ -4,3 +4,13 @@ export function convert(v: string | Uint8Array): Uint8Array {
   }
   return v;
 }
+
+export function getCurrentTimeAsDateObject(): Date {
+  return new Date();
+}
+
+export function createDateObjectFromUnixMillisTimestamp(
+  unixMillisTimestamp: number
+): Date {
+  return new Date(unixMillisTimestamp);
+}

--- a/packages/client-sdk-nodejs/test/integration/retry/exponential-backoff-retry-strategy.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/retry/exponential-backoff-retry-strategy.test.ts
@@ -55,7 +55,9 @@ describe('ExponentialBackoffRetryStrategy integration tests', () => {
           const getResponse = await cacheClient.get(cacheName, 'key');
           expect(getResponse.type).toEqual(CacheGetResponse.Error);
           if (getResponse.type === CacheGetResponse.Error) {
-            expect(getResponse.errorCode()).toEqual('SERVER_UNAVAILABLE');
+            expect(getResponse.errorCode()).toEqual(
+              MomentoErrorCode.TIMEOUT_ERROR
+            );
           }
 
           // Evaluate how many retries were attempted.


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1214 

The JS fixed timeout retry strategy was overwriting the grpc deadline from the initial request when it should update the deadline only after the initial request fails. Once the initial request fails, the retry deadline (responseDataReceivedTimeoutMillis) should be used.

Updates the tests to ensure this logic is exercised. 