### PR TITLE
refactor: rename `signal` cancellation property to `abortSignal`

### DIFF
--- a/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
+++ b/packages/client-sdk-nodejs/src/internal/cache-data-client.ts
@@ -529,7 +529,7 @@ export class CacheDataClient implements IDataClient {
         encodedKey,
         encodedValue,
         ttlToUse,
-        options?.signal
+        options?.abortSignal
       );
     });
   }
@@ -2176,7 +2176,7 @@ export class CacheDataClient implements IDataClient {
         metadata,
         {
           interceptors: this.createInterceptorsWithCancellation(
-            options?.signal
+            options?.abortSignal
           ),
         },
         (err, resp) => {
@@ -2236,7 +2236,7 @@ export class CacheDataClient implements IDataClient {
           }
         }
       );
-      this.setupAbortSignalHandler(options?.signal, getGrpcCall, 'get');
+      this.setupAbortSignalHandler(options?.abortSignal, getGrpcCall, 'get');
     });
   }
 

--- a/packages/client-sdk-nodejs/test/integration/cache/abort-signal.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache/abort-signal.test.ts
@@ -21,13 +21,13 @@ describe('AbortSignal', () => {
   describe('cache client WITHOUT retry strategy', () => {
     it('should cancel a set call', async () => {
       const testSet = async () => {
-        const signal = AbortSignal.timeout(1);
+        const abortSignal = AbortSignal.timeout(1);
         const setResponse = await cacheClientWithoutRetryStrategy.set(
           integrationTestCacheName,
           v4(),
           'value',
           {
-            signal,
+            abortSignal,
           }
         );
         if (
@@ -46,12 +46,12 @@ describe('AbortSignal', () => {
 
     it('should cancel a get call', async () => {
       const testGet = async () => {
-        const signal = AbortSignal.timeout(1);
+        const abortSignal = AbortSignal.timeout(1);
         const getResponse = await cacheClientWithoutRetryStrategy.get(
           integrationTestCacheName,
           v4(),
           {
-            signal,
+            abortSignal,
           }
         );
         if (
@@ -72,13 +72,13 @@ describe('AbortSignal', () => {
   describe('cache client WITH default retry strategy', () => {
     it('should cancel a set call', async () => {
       const testSet = async () => {
-        const signal = AbortSignal.timeout(1);
+        const abortSignal = AbortSignal.timeout(1);
         const setResponse = await cacheClient.set(
           integrationTestCacheName,
           v4(),
           'value',
           {
-            signal,
+            abortSignal,
           }
         );
         if (
@@ -97,12 +97,12 @@ describe('AbortSignal', () => {
 
     it('should cancel a get call', async () => {
       const testGet = async () => {
-        const signal = AbortSignal.timeout(1);
+        const abortSignal = AbortSignal.timeout(1);
         const getResponse = await cacheClient.get(
           integrationTestCacheName,
           v4(),
           {
-            signal,
+            abortSignal,
           }
         );
         if (

--- a/packages/core/src/utils/cache-call-options.ts
+++ b/packages/core/src/utils/cache-call-options.ts
@@ -24,7 +24,7 @@ export interface CancellationCallOptions {
   /**
    * The signal to cancel the operation.
    */
-  signal?: AbortSignal;
+  abortSignal?: AbortSignal;
 }
 
 export interface SetCallOptions


### PR DESCRIPTION
For clarity rename the signal property to cancel and RPC from `signal`
to `abortSignal`.
