### PR TITLE
chore: exclude AbortSignal tests from canary npm target

### DIFF
--- a/packages/client-sdk-nodejs/package.json
+++ b/packages/client-sdk-nodejs/package.json
@@ -17,7 +17,7 @@
     "test": "jest --testPathIgnorePatterns=\"auth-client\\.test\\.ts|http-apis\\.test\\.ts\" --maxWorkers 1",
     "integration-test-auth": "jest auth/ --maxWorkers 1 -- useConsistentReads",
     "integration-test-http": "jest http/ --maxWorkers 1 -- useConsistentReads",
-    "integration-test-cache": "jest cache/ --maxWorkers 1 -- useConsistentReads",
+    "integration-test-cache": "jest cache/ --maxWorkers 1 --testPathIgnorePatterns=\"abort-signal\" -- useConsistentReads",
     "integration-test-control-cache-topics": "npm run integration-test-cache && npm run integration-test-topics",
     "integration-test-leaderboard": "jest leaderboard/ --maxWorkers 1 -- useConsistentReads",
     "integration-test-topics": "jest topics/ --maxWorkers 1 -- useConsistentReads",

--- a/packages/client-sdk-nodejs/test/integration/cache/abort-signal.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache/abort-signal.test.ts
@@ -1,6 +1,6 @@
 import {SetupIntegrationTest} from '../integration-setup';
 import {v4} from 'uuid';
-import {CacheSetResponse} from '@gomomento/sdk-core';
+import {CacheGetResponse, CacheSetResponse} from '@gomomento/sdk-core';
 
 const {cacheClient, cacheClientWithoutRetryStrategy, integrationTestCacheName} =
   SetupIntegrationTest();
@@ -44,29 +44,29 @@ describe('AbortSignal', () => {
       await testTrials(testSet());
     });
 
-    // it('should cancel a get call', async () => {
-    //   const testGet = async () => {
-    //     const abortSignal = AbortSignal.timeout(1);
-    //     const getResponse = await cacheClientWithoutRetryStrategy.get(
-    //       integrationTestCacheName,
-    //       v4(),
-    //       {
-    //         abortSignal,
-    //       }
-    //     );
-    //     if (
-    //       getResponse.type === CacheGetResponse.Error &&
-    //       getResponse.errorCode() === 'CANCELLED_ERROR' &&
-    //       getResponse
-    //         .message()
-    //         .includes('Request cancelled by a user-provided AbortSignal')
-    //     ) {
-    //       return true;
-    //     }
-    //     return false;
-    //   };
-    //   await testTrials(testGet());
-    // });
+    it('should cancel a get call', async () => {
+      const testGet = async () => {
+        const abortSignal = AbortSignal.timeout(1);
+        const getResponse = await cacheClientWithoutRetryStrategy.get(
+          integrationTestCacheName,
+          v4(),
+          {
+            abortSignal,
+          }
+        );
+        if (
+          getResponse.type === CacheGetResponse.Error &&
+          getResponse.errorCode() === 'CANCELLED_ERROR' &&
+          getResponse
+            .message()
+            .includes('Request cancelled by a user-provided AbortSignal')
+        ) {
+          return true;
+        }
+        return false;
+      };
+      await testTrials(testGet());
+    });
   });
 
   describe('cache client WITH default retry strategy', () => {
@@ -95,28 +95,28 @@ describe('AbortSignal', () => {
       await testTrials(testSet());
     });
 
-    // it('should cancel a get call', async () => {
-    //   const testGet = async () => {
-    //     const abortSignal = AbortSignal.timeout(1);
-    //     const getResponse = await cacheClient.get(
-    //       integrationTestCacheName,
-    //       v4(),
-    //       {
-    //         abortSignal,
-    //       }
-    //     );
-    //     if (
-    //       getResponse.type === CacheGetResponse.Error &&
-    //       getResponse.errorCode() === 'CANCELLED_ERROR' &&
-    //       getResponse
-    //         .message()
-    //         .includes('Request cancelled by a user-provided AbortSignal')
-    //     ) {
-    //       return true;
-    //     }
-    //     return false;
-    //   };
-    //   await testTrials(testGet());
-    // });
+    it('should cancel a get call', async () => {
+      const testGet = async () => {
+        const abortSignal = AbortSignal.timeout(1);
+        const getResponse = await cacheClient.get(
+          integrationTestCacheName,
+          v4(),
+          {
+            abortSignal,
+          }
+        );
+        if (
+          getResponse.type === CacheGetResponse.Error &&
+          getResponse.errorCode() === 'CANCELLED_ERROR' &&
+          getResponse
+            .message()
+            .includes('Request cancelled by a user-provided AbortSignal')
+        ) {
+          return true;
+        }
+        return false;
+      };
+      await testTrials(testGet());
+    });
   });
 });

--- a/packages/client-sdk-nodejs/test/integration/cache/large-messages.test.ts
+++ b/packages/client-sdk-nodejs/test/integration/cache/large-messages.test.ts
@@ -1,4 +1,7 @@
-import {expectWithMessage} from '@gomomento/common-integration-tests';
+import {
+  expectWithMessage,
+  itOnlyInCi,
+} from '@gomomento/common-integration-tests';
 import {SetupIntegrationTest} from '../integration-setup';
 import {CacheGet, CacheItemGetTtl, CacheSet} from '@gomomento/sdk-core';
 import {v4} from 'uuid';
@@ -7,7 +10,7 @@ import {log} from 'console';
 const {cacheClient, integrationTestCacheName} = SetupIntegrationTest();
 
 describe('CacheClient', () => {
-  it('should send and receive 5mb messages', async () => {
+  itOnlyInCi('should send and receive 5mb messages', async () => {
     const value = 'a'.repeat(5_000_000);
     const key = `js-5mb-key-${v4()}`;
     const ttlSeconds = 2000; // 2000 seconds == 30 minutes


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1257

Re-enables the flakey `get` AbortSignal tests and configures those tests to run in CI, but not in canaries, by adding the `testPathIgnorePatterns` filter to the `npm run integration-test-cache` command that the canaries use.

Using `ItOnlyInCi` did not impact the canaries, only affected whether the tests would run in GitHub Actions CI workflows. Upon auditing that usage, I also updated the large messages test. That test should be run only in CI, not locally where it will fail unless dev account has correct limits.
