### PR TITLE
chore: Skip legacy auth token tests if env var isn't set

### DIFF
--- a/packages/client-sdk-nodejs/test/integration/integration-setup.ts
+++ b/packages/client-sdk-nodejs/test/integration/integration-setup.ts
@@ -393,7 +393,7 @@ export function SetupLeaderboardIntegrationTest(): {
 
 export function SetupAuthClientIntegrationTest(): {
   mgaAccountSessionTokenAuthClient: AuthClient;
-  legacyTokenAuthClient: AuthClient;
+  legacyTokenAuthClient: AuthClient | undefined;
   mgaAccountSessionTokenCacheClient: CacheClient;
   mgaAccountSessionTokenTopicClient: TopicClient;
   authTokenAuthClientFactory: (authToken: string) => AuthClient;
@@ -426,11 +426,13 @@ export function SetupAuthClientIntegrationTest(): {
     mgaAccountSessionTokenAuthClient: new AuthClient({
       credentialProvider: mgaAccountSessionTokenCredsProvider(),
     }),
-    legacyTokenAuthClient: new AuthClient({
-      credentialProvider: CredentialProvider.fromEnvironmentVariable({
-        environmentVariableName: 'TEST_LEGACY_AUTH_TOKEN',
-      }),
-    }),
+    legacyTokenAuthClient: process.env.TEST_LEGACY_AUTH_TOKEN
+      ? new AuthClient({
+          credentialProvider: CredentialProvider.fromEnvironmentVariable({
+            environmentVariableName: 'TEST_LEGACY_AUTH_TOKEN',
+          }),
+        })
+      : undefined,
     mgaAccountSessionTokenCacheClient:
       momentoCacheClientForTestingWithMgaAccountSessionToken(),
     mgaAccountSessionTokenTopicClient:

--- a/packages/client-sdk-web/test/integration/integration-setup.ts
+++ b/packages/client-sdk-web/test/integration/integration-setup.ts
@@ -255,7 +255,7 @@ export function SetupLeaderboardIntegrationTest(): {
 
 export function SetupAuthClientIntegrationTest(): {
   mgaAccountSessionTokenAuthClient: AuthClient;
-  legacyTokenAuthClient: AuthClient;
+  legacyTokenAuthClient: AuthClient | undefined;
   mgaAccountSessionTokenCacheClient: CacheClient;
   mgaAccountSessionTokenTopicClient: TopicClient;
   authTokenAuthClientFactory: (authToken: string) => AuthClient;
@@ -288,11 +288,13 @@ export function SetupAuthClientIntegrationTest(): {
     mgaAccountSessionTokenAuthClient: new AuthClient({
       credentialProvider: mgaAccountSessionTokenCredsProvider(),
     }),
-    legacyTokenAuthClient: new AuthClient({
-      credentialProvider: CredentialProvider.fromEnvironmentVariable({
-        environmentVariableName: 'TEST_LEGACY_AUTH_TOKEN',
-      }),
-    }),
+    legacyTokenAuthClient: process.env.TEST_LEGACY_AUTH_TOKEN
+      ? new AuthClient({
+          credentialProvider: CredentialProvider.fromEnvironmentVariable({
+            environmentVariableName: 'TEST_LEGACY_AUTH_TOKEN',
+          }),
+        })
+      : undefined,
     mgaAccountSessionTokenCacheClient:
       momentoCacheClientForTestingWithMgaAccountSessionToken(),
     mgaAccountSessionTokenTopicClient:

--- a/packages/common-integration-tests/src/auth/auth-client.ts
+++ b/packages/common-integration-tests/src/auth/auth-client.ts
@@ -45,7 +45,7 @@ const SUPER_USER_PERMISSIONS: PermissionScope =
 
 export function runAuthClientTests(
   sessionTokenAuthClient: IAuthClient,
-  legacyTokenAuthClient: IAuthClient,
+  legacyTokenAuthClient: IAuthClient | undefined,
   sessionTokenCacheClient: ICacheClient,
   sessionTokenTopicClient: ITopicClient,
   authTokenAuthClientFactory: (authToken: string) => IAuthClient,
@@ -400,24 +400,32 @@ export function runAuthClientTests(
       }, `Unexpected response: ${generateResponse.toString()}`);
     });
 
-    it('should not support generating a superuser token when authenticated via a legacy token', async () => {
-      const generateResponse = await legacyTokenAuthClient.generateApiKey(
-        SUPER_USER_PERMISSIONS,
-        ExpiresIn.seconds(1)
-      );
-      expectWithMessage(() => {
-        expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
-      }, `Unexpected response: ${generateResponse.toString()}`);
-    });
+    // skip the legacy auth token tests if the env var isn't set
+    const describeFn = legacyTokenAuthClient ? describe : describe.skip;
+    describeFn('legacy token behavior', () => {
+      // Safe: this block only runs when describeFn is not `describe.skip`, which means legacyTokenAuthClient is defined.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const client = legacyTokenAuthClient!;
 
-    it('should not support generating an AllDataReadWrite token when authenticated via a legacy token', async () => {
-      const generateResponse = await legacyTokenAuthClient.generateApiKey(
-        AllDataReadWrite,
-        ExpiresIn.seconds(1)
-      );
-      expectWithMessage(() => {
-        expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
-      }, `Unexpected response: ${generateResponse.toString()}`);
+      it('should not support generating a superuser token when authenticated via a legacy token', async () => {
+        const generateResponse = await client.generateApiKey(
+          SUPER_USER_PERMISSIONS,
+          ExpiresIn.seconds(1)
+        );
+        expectWithMessage(() => {
+          expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
+        }, `Unexpected response: ${generateResponse.toString()}`);
+      });
+
+      it('should not support generating an AllDataReadWrite token when authenticated via a legacy token', async () => {
+        const generateResponse = await client.generateApiKey(
+          AllDataReadWrite,
+          ExpiresIn.seconds(1)
+        );
+        expectWithMessage(() => {
+          expect(generateResponse).toBeInstanceOf(GenerateApiKey.Error);
+        }, `Unexpected response: ${generateResponse.toString()}`);
+      });
     });
   });
 


### PR DESCRIPTION
It is not possible to generate new legacy auth tokens, so it can be hard to get these tests running for new environments. Instead, skip this set of tests if the environment variable isn't set.
